### PR TITLE
ci: add GitHub Actions workflow to build and test contract

### DIFF
--- a/.github/workflows/build-contract.yml
+++ b/.github/workflows/build-contract.yml
@@ -1,0 +1,36 @@
+name: Build contract
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Aztec version
+        id: aztec-version
+        run: echo "version=$(cat .aztecrc | tr -d '\n')" >> $GITHUB_OUTPUT
+
+      - name: Install Aztec
+        env:
+          VERSION: ${{ steps.aztec-version.outputs.version }}
+        run: |
+          bash -i <(curl -sL https://install.aztec.network/$VERSION)
+
+      - name: Add Aztec to PATH
+        run: |
+          echo "$HOME/.aztec/current/bin" >> $GITHUB_PATH
+          echo "$HOME/.aztec/current/node_modules/.bin" >> $GITHUB_PATH
+          echo "$HOME/.aztec/bin" >> $GITHUB_PATH
+
+      - name: Format check
+        run: nargo fmt --check
+
+      - name: Build
+        run: aztec compile
+
+      - name: Test
+        run: aztec test


### PR DESCRIPTION
Adds a workflow that:
- Reads Aztec version from .aztecrc
- Installs Aztec tooling from install.aztec.network
- Adds .aztec paths to PATH
- Runs nargo fmt --check, aztec compile, aztec test
- Triggers on push and pull_request