### PR TITLE
ci: Skip Aztec install when aztec-up use already reports correct version

### DIFF
--- a/.github/workflows/build-contract.yml
+++ b/.github/workflows/build-contract.yml
@@ -28,9 +28,11 @@ jobs:
         id: aztec-version
         run: echo "version=$(cat .aztecrc | tr -d '\n')" >> $GITHUB_OUTPUT
 
-      - name: Debug
+      - name: Add Aztec to PATH
         run: |
-          echo "HOME: $HOME"
+          echo "$HOME/.aztec/current/bin" >> $GITHUB_PATH
+          echo "$HOME/.aztec/current/node_modules/.bin" >> $GITHUB_PATH
+          echo "$HOME/.aztec/bin" >> $GITHUB_PATH
 
       - name: Cache Aztec toolchain
         uses: actions/cache@v5
@@ -42,16 +44,12 @@ jobs:
         env:
           VERSION: ${{ steps.aztec-version.outputs.version }}
         run: |
+          output=$(aztec-up use 2>&1) || true
+          if echo "$output" | grep -q "Using aztec version $VERSION"; then
+            echo "Already using Aztec version $VERSION, skipping install"
+            exit 0
+          fi
           bash -i <(curl -sL https://install.aztec.network/$VERSION)
-
-      - name: Add Aztec to PATH
-        run: |
-          echo "$HOME/.aztec/current/bin" >> $GITHUB_PATH
-          echo "$HOME/.aztec/current/node_modules/.bin" >> $GITHUB_PATH
-          echo "$HOME/.aztec/bin" >> $GITHUB_PATH
-
-      - name: Debug
-        run: which aztec
 
       - name: Format check
         run: nargo fmt --check


### PR DESCRIPTION
The Install Aztec step now runs aztec-up use first and checks whether the output contains Using aztec version $VERSION (from .aztecrc). If it does, the step skips the install and exits; otherwise it runs the existing install script. That way, when the cache already has the right Aztec version, the job avoids re-downloading and reinstalling and finishes faster.