### PR TITLE
Replace manual bridge with L1FeeJuicePortalManager

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
+        "@aztec/ethereum": "4.0.0-devnet.2-patch.1",
         "@aztec/foundation": "4.0.0-devnet.2-patch.1",
         "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
         "viem": "^2.18.0",

--- a/services/topup/config.yaml
+++ b/services/topup/config.yaml
@@ -10,13 +10,9 @@ aztec_node_url: "http://localhost:8080"
 # ─── L1 configuration ─────────────────────────────────────────────────────────
 l1_rpc_url: "http://localhost:8545"
 
-# The Fee Juice portal contract address on L1 (bridges ETH → Fee Juice on L2)
-# Find this from your Aztec deployment's l1ContractAddresses.feeJuicePortalAddress
-fee_juice_portal_address: "0x0000000000000000000000000000000000000001"
-
 # TODO: In production, inject the private key from a secrets manager or HSM.
 #       Never store plaintext keys in config files committed to version control.
-l1_operator_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+l1_operator_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 # ─── Top-up thresholds ────────────────────────────────────────────────────────
 # Bridge when FPC Fee Juice balance drops below this (in wei / smallest unit)
@@ -25,7 +21,7 @@ threshold: "1000000000000000000000000"
 
 # Amount to bridge each time the threshold is hit (in wei)
 # Example: 10e18 = 10 FeeJuice units
-top_up_amount: "10000000000000000000"
+top_up_amount: "100"
 
 # How often to check the balance (milliseconds). 60000 = every minute.
 check_interval_ms: 60000

--- a/services/topup/package.json
+++ b/services/topup/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
+    "@aztec/ethereum": "4.0.0-devnet.2-patch.1",
     "@aztec/foundation": "4.0.0-devnet.2-patch.1",
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
     "viem": "^2.18.0",

--- a/services/topup/src/bridge.ts
+++ b/services/topup/src/bridge.ts
@@ -1,90 +1,49 @@
 /**
  * L1 → L2 Fee Juice bridge.
  *
- * Fee Juice is bridged by calling depositToAztecPublic on the L1 FeeJuicePortal
- * contract. The portal locks ETH on L1 and sends a message to L2; the Aztec
- * sequencer mints the equivalent Fee Juice to the recipient address on L2.
- *
- * Bridge latency: typically 1-3 L1 blocks (12-36 seconds on mainnet) plus one
- * Aztec L2 block for the L1→L2 message to be processed. Configure your
- * threshold high enough to absorb this delay.
- *
- * ABI: FeeJuicePortal.depositToAztecPublic(bytes32 to, uint256 amount, bytes32 secretHash)
- *   to         — L2 recipient address (the FPC address, left-padded to 32 bytes)
- *   amount     — wei amount of ETH to bridge as Fee Juice
- *   secretHash — keccak256 of a secret; used to claim the message on L2.
- *                For automated top-up, the secret can be Fr.ZERO and the claim
- *                is handled automatically by the L2 protocol.
+ * Uses the canonical L1FeeJuicePortalManager from @aztec/aztec.js which
+ * handles ERC20 approval, deposit, event extraction, and claim secret
+ * generation. Portal/token/handler addresses are fetched from the Aztec node.
  */
 
 import {
-  createPublicClient,
-  createWalletClient,
-  http,
-  type Hex,
-  parseAbi,
-} from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+  L1FeeJuicePortalManager,
+  type L2AmountClaim,
+} from "@aztec/aztec.js/ethereum";
+import type { AztecNode } from "@aztec/aztec.js/node";
+import type { AztecAddress } from "@aztec/aztec.js/addresses";
+import { createEthereumChain } from "@aztec/ethereum/chain";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
+import { createLogger } from "@aztec/foundation/log";
 
-// Minimal ABI — only the deposit function we need.
-// Full ABI available in @aztec/l1-artifacts if the package is present.
-const FEE_JUICE_PORTAL_ABI = parseAbi([
-  "function depositToAztecPublic(bytes32 to, uint256 amount, bytes32 secretHash) payable returns (bytes32)",
-]);
+export type { L2AmountClaim };
 
-export interface BridgeResult {
-  l1TxHash: Hex;
-  amount: bigint;
-}
+const logger = createLogger("topup:bridge");
 
 /**
- * Bridge `amount` wei of ETH from L1 to the FPC's L2 Fee Juice balance.
+ * Bridge `amount` of Fee Juice from L1 to the given L2 address.
  *
- * @param l1RpcUrl       - L1 Ethereum RPC endpoint
- * @param privateKey     - L1 operator private key (hex, TODO: use KMS in production)
- * @param portalAddress  - Deployed FeeJuicePortal contract address on L1
- * @param fpcL2Address   - The FPC's L2 address (recipient of Fee Juice on L2)
- * @param amount         - Amount in wei to bridge
+ * @param node          - Aztec node client (used to fetch L1 contract addresses and chain id)
+ * @param l1RpcUrl      - L1 Ethereum RPC endpoint
+ * @param privateKey    - L1 operator private key (hex, TODO: use KMS in production)
+ * @param fpcL2Address  - The FPC's L2 address (recipient of Fee Juice on L2)
+ * @param amount        - Amount to bridge (in token smallest unit)
  */
 export async function bridgeFeeJuice(
+  node: AztecNode,
   l1RpcUrl: string,
-  privateKey: Hex,
-  portalAddress: Hex,
-  fpcL2Address: string,
+  privateKey: string,
+  fpcL2Address: AztecAddress,
   amount: bigint,
-): Promise<BridgeResult> {
-  const account = privateKeyToAccount(privateKey);
+): Promise<L2AmountClaim> {
+  const { l1ChainId } = await node.getNodeInfo();
+  const chain = createEthereumChain([l1RpcUrl], l1ChainId);
+  const client = createExtendedL1Client(
+    chain.rpcUrls,
+    privateKey,
+    chain.chainInfo,
+  );
 
-  const publicClient = createPublicClient({
-    transport: http(l1RpcUrl),
-  });
-
-  const walletClient = createWalletClient({
-    account,
-    transport: http(l1RpcUrl),
-  });
-
-  // Convert L2 address to bytes32 (left-padded)
-  const recipientBytes32 =
-    `0x${fpcL2Address.replace("0x", "").padStart(64, "0")}` as Hex;
-
-  // secretHash = 0x0 lets the L2 protocol auto-claim the message
-  const secretHash = `0x${"00".repeat(32)}` as Hex;
-
-  const hash = await walletClient.writeContract({
-    chain: undefined,
-    address: portalAddress,
-    abi: FEE_JUICE_PORTAL_ABI,
-    functionName: "depositToAztecPublic",
-    args: [recipientBytes32, amount, secretHash],
-    value: amount, // ETH sent along with the call
-  });
-
-  // Wait for L1 confirmation
-  const receipt = await publicClient.waitForTransactionReceipt({ hash });
-  if (receipt.status !== "success") {
-    throw new Error(`L1 bridge transaction reverted: ${hash}`);
-  }
-
-  return { l1TxHash: hash, amount };
+  const portal = await L1FeeJuicePortalManager.new(node, client, logger);
+  return portal.bridgeTokensPublic(fpcL2Address, amount);
 }

--- a/services/topup/src/config.ts
+++ b/services/topup/src/config.ts
@@ -6,7 +6,6 @@ const ConfigSchema = z.object({
   fpc_address: z.string(),
   aztec_node_url: z.string().url(),
   l1_rpc_url: z.string().url(),
-  fee_juice_portal_address: z.string(),
   /** TODO: replace with KMS/HSM lookup in production. */
   l1_operator_private_key: z.string(),
   /** Bridge when FPC balance drops below this (bigint string, wei units). */

--- a/services/topup/src/index.ts
+++ b/services/topup/src/index.ts
@@ -12,7 +12,6 @@
 
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
-import type { Hex } from "viem";
 import { loadConfig } from "./config.js";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
 import { bridgeFeeJuice } from "./bridge.js";
@@ -62,17 +61,16 @@ async function main() {
     bridgeInFlight = true;
 
     try {
-      const result = await bridgeFeeJuice(
+      const claim = await bridgeFeeJuice(
+        pxe,
         config.l1_rpc_url,
-        config.l1_operator_private_key as Hex,
-        config.fee_juice_portal_address as Hex,
-        config.fpc_address,
+        config.l1_operator_private_key,
+        fpcAddress,
         topUpAmount,
       );
 
-      console.log(`Bridge submitted. L1 tx: ${result.l1TxHash}`);
       console.log(
-        `Bridged ${result.amount} wei. Waiting for L2 confirmation...`,
+        `Bridge complete. claimAmount=${claim.claimAmount}, messageHash=${claim.messageHash}, messageLeafIndex=${claim.messageLeafIndex}`,
       );
 
       // Wait for the L2 message to be processed. L1→L2 message processing


### PR DESCRIPTION
## Summary

- **Fix incorrect bridge logic**: The manual `writeContract` bridge sent native ETH (`value: amount`) but the FeeJuicePortal actually uses `safeTransferFrom` on an ERC20 token. It also hardcoded a minimal ABI, manually padded addresses, and skipped ERC20 approval.
- **Use canonical `L1FeeJuicePortalManager.bridgeTokensPublic`** from `@aztec/aztec.js/ethereum`, which correctly handles ERC20 approval, deposit, event extraction, and claim secret generation.
- **Remove `fee_juice_portal_address` from config**: Portal/token/handler addresses are now fetched automatically from the Aztec node via `getNodeInfo()`.

## Changes

| File | Change |
|------|--------|
| `services/topup/package.json` | Add `@aztec/ethereum` dependency |
| `services/topup/src/bridge.ts` | Full rewrite using `L1FeeJuicePortalManager` |
| `services/topup/src/config.ts` | Remove `fee_juice_portal_address` field |
| `services/topup/src/index.ts` | Update caller to new signature and richer return type |
| `services/topup/config.yaml` | Remove portal address config |
| `bun.lock` | Updated lockfile |

## Test plan

- [ ] `cd services/topup && bun install` resolves cleanly
- [ ] `bun run typecheck` passes with no errors
- [ ] Smoke test against local devnet: bridge triggers ERC20 approval + deposit (not raw ETH transfer)