### PR TITLE
ci: add TS packages workflow

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -1,0 +1,35 @@
+name: TS packages
+
+on:
+  push:
+    branches: [main]
+    tags: ["**"]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  check-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Biome CI
+        run: bun run biome:ci
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun run test:ts

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "services/*"
   ],
   "scripts": {
+    "biome:check": "biome check --write",
+    "biome:ci": "biome ci",
     "build": "bun run --workspaces --if-present build",
     "format": "biome format --write .",
     "lint": "biome lint .",

--- a/services/attestation/src/index.ts
+++ b/services/attestation/src/index.ts
@@ -10,17 +10,17 @@
  *   node dist/index.js [--config path/to/config.yaml]
  */
 
-import { createAztecNodeClient } from "@aztec/aztec.js/node";
-import { Fr } from "@aztec/aztec.js/fields";
 import {
   getSchnorrAccountContractAddress,
   SchnorrAccountContract,
 } from "@aztec/accounts/schnorr";
+import { Fr } from "@aztec/aztec.js/fields";
+import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { CompleteAddress } from "@aztec/stdlib/contract";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
-import { createQuoteAuthwitSigner } from "./signer.js";
 import { loadConfig } from "./config.js";
 import { buildServer } from "./server.js";
+import { createQuoteAuthwitSigner } from "./signer.js";
 
 const configPath =
   process.argv.find((_, i, a) => a[i - 1] === "--config") ?? "config.yaml";

--- a/services/attestation/src/server.ts
+++ b/services/attestation/src/server.ts
@@ -1,8 +1,8 @@
-import Fastify from "fastify";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import type { QuoteAuthwitSigner } from "./signer.js";
+import Fastify from "fastify";
 import type { Config } from "./config.js";
 import { computeFinalRate } from "./config.js";
+import type { QuoteAuthwitSigner } from "./signer.js";
 import { signQuote } from "./signer.js";
 
 function badRequest(message: string) {

--- a/services/attestation/src/signer.ts
+++ b/services/attestation/src/signer.ts
@@ -18,12 +18,12 @@
  */
 
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
+import { computeAuthWitMessageHash } from "@aztec/aztec.js/authorization";
 import { Fr } from "@aztec/aztec.js/fields";
 import {
-  computeInnerAuthWitHash,
   type AuthWitness,
+  computeInnerAuthWitHash,
 } from "@aztec/stdlib/auth-witness";
-import { computeAuthWitMessageHash } from "@aztec/aztec.js/authorization";
 
 /** Matches ChainInfo from @aztec/entrypoints/interfaces */
 export interface ChainInfo {

--- a/services/attestation/test/fee-entrypoint-devnet-smoke.ts
+++ b/services/attestation/test/fee-entrypoint-devnet-smoke.ts
@@ -2,17 +2,17 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 
 import { getInitialTestAccountsData } from "@aztec/accounts/testing";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
 import type { ContractArtifact } from "@aztec/aztec.js/abi";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
+import { Contract } from "@aztec/aztec.js/contracts";
+import { Fr } from "@aztec/aztec.js/fields";
+import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import {
   FeeJuiceContract,
   ProtocolContractAddress,
 } from "@aztec/aztec.js/protocol";
-import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
-import { Contract } from "@aztec/aztec.js/contracts";
-import { Fr } from "@aztec/aztec.js/fields";
-import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
 import {
   loadContractArtifact,
@@ -26,9 +26,9 @@ import {
   createPublicClient,
   createWalletClient,
   decodeEventLog,
+  type Hex,
   http,
   parseAbi,
-  type Hex,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 

--- a/services/attestation/test/server.test.ts
+++ b/services/attestation/test/server.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import type { Config } from "../src/config.js";
 import { buildServer } from "../src/server.js";
-import { computeQuoteInnerHash } from "../src/signer.js";
 import type { QuoteAuthwitSigner } from "../src/signer.js";
+import { computeQuoteInnerHash } from "../src/signer.js";
 
 const VALID_USER =
   "0x089323ce9a610e9f013b661ce80dde444b554e9f6ed9f5167adb234668f0af72";

--- a/services/attestation/test/signer.test.ts
+++ b/services/attestation/test/signer.test.ts
@@ -6,9 +6,9 @@ import { computeInnerAuthWitHash } from "@aztec/stdlib/auth-witness";
 import {
   computeQuoteInnerHash,
   createQuoteAuthwitSigner,
-  signQuote,
   type MessageHashAuthwitSigner,
   type QuoteParams,
+  signQuote,
 } from "../src/signer.js";
 
 const FPC = AztecAddress.fromString(

--- a/services/topup/src/bridge.ts
+++ b/services/topup/src/bridge.ts
@@ -4,15 +4,15 @@
 
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import {
+  type Chain,
   createPublicClient,
   createWalletClient,
   defineChain,
   getAddress,
+  type Hex,
   http,
   isAddress,
   parseAbi,
-  type Chain,
-  type Hex,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import * as viemChains from "viem/chains";

--- a/services/topup/src/index.ts
+++ b/services/topup/src/index.ts
@@ -12,9 +12,9 @@
 
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
-import { loadConfig } from "./config.js";
 import { bridgeFeeJuice } from "./bridge.js";
 import { createTopupChecker } from "./checker.js";
+import { loadConfig } from "./config.js";
 import { waitForFeeJuiceBridgeConfirmation } from "./confirm.js";
 import { createFeeJuiceBalanceReader } from "./monitor.js";
 


### PR DESCRIPTION
## Summary

- **Add CI workflow for TypeScript packages** (`ts-packages.yml`) that runs biome ci, typecheck, build, and tests in fail-fast order
- **Add `biome:check` and `biome:ci` root scripts** for local dev and CI respectively
- **Fix import ordering** across service files to pass `biome ci`