### PR TITLE
fix: scope aztec test to fpc package

### DIFF
--- a/.github/workflows/build-contract.yml
+++ b/.github/workflows/build-contract.yml
@@ -60,4 +60,4 @@ jobs:
         run: aztec compile --workspace
 
       - name: Test contracts
-        run: aztec test
+        run: aztec test --package fpc

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,3 +1,2 @@
 [workspace]
 members = ["contracts/fpc","vendor/aztec-standards/src/token_contract"]
-default-member = "contracts/fpc"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ aztec compile
 
 ```bash
 nargo fmt
-aztec test
+aztec test --package fpc
 ```
 
 ### TypeScript quality checks


### PR DESCRIPTION
## Summary
- Scope `aztec test` to `--package fpc` in CI and docs so the vendored aztec-standards token contract isn't tested
- Remove the now-redundant `default-member` from `Nargo.toml`