### PR TITLE
tooling/deploy: add shell wrapper and root local deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,28 @@ Useful overrides:
 - `FPC_SERVICES_SMOKE_ATTESTATION_PORT` (default `3300`)
 - `FPC_SERVICES_SMOKE_RELAY_ADVANCE_BLOCKS` (default: `2`; sends mock L2 txs after bridge submit so local relay can finalize)
 
-### 7. Deploy the contract
+### 7. Deploy the contract (recommended)
+
+Use the local deploy wrapper:
+
+```bash
+bun run deploy:fpc:local
+```
+
+Useful overrides:
+
+- `AZTEC_NODE_URL` (default `http://127.0.0.1:8080`)
+- `L1_RPC_URL` (default `http://127.0.0.1:8545`)
+- `FPC_LOCAL_OPERATOR` (default local `test0` Aztec address)
+- `FPC_LOCAL_OUT` (default `./tmp/deploy-fpc-local.json`)
+
+Pass through extra deploy args when needed (for example reuse mode):
+
+```bash
+bun run deploy:fpc:local -- --reuse
+```
+
+### 8. Deploy the contract manually (alternative)
 
 ```bash
 # operator = your Aztec account (receives fees, signs quotes)
@@ -183,7 +204,7 @@ aztec deploy \
 
 Record the deployed address.
 
-### 8. Configure and start the attestation service
+### 9. Configure and start the attestation service
 
 ```bash
 cd services/attestation
@@ -193,7 +214,7 @@ cp config.example.yaml config.yaml
 bun install && bun run build && bun run start
 ```
 
-### 9. Configure and start the top-up service
+### 10. Configure and start the top-up service
 
 ```bash
 cd services/topup
@@ -205,7 +226,7 @@ cp config.example.yaml config.yaml
 bun install && bun run build && bun run start
 ```
 
-### 10. Verify
+### 11. Verify
 
 ```bash
 curl http://localhost:3000/health

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "topup:build": "bun run --filter @aztec-fpc/topup build",
     "topup:dev": "bun run --filter @aztec-fpc/topup dev",
     "topup:start": "bun run --filter @aztec-fpc/topup start",
-    "deploy:fpc:local": "bunx tsx scripts/contract/deploy-fpc-local.ts --operator 0x00000000000000000000000000000000000000000000000000000000000000aa --out ./tmp/deploy-fpc-local.preflight.json",
+    "deploy:fpc:local": "bash scripts/contract/deploy-fpc-local.sh",
     "smoke:services": "bash scripts/services/fpc-services-smoke.sh",
     "test": "bun run test:contracts && bun run test:ts"
   },

--- a/scripts/contract/deploy-fpc-local.sh
+++ b/scripts/contract/deploy-fpc-local.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+
+AZTEC_NODE_URL="${AZTEC_NODE_URL:-http://127.0.0.1:8080}"
+L1_RPC_URL="${L1_RPC_URL:-http://127.0.0.1:8545}"
+# Default local-network operator (test0 account).
+FPC_LOCAL_OPERATOR="${FPC_LOCAL_OPERATOR:-0x089323ce9a610e9f013b661ce80dde444b554e9f6ed9f5167adb234668f0af72}"
+FPC_LOCAL_OUT="${FPC_LOCAL_OUT:-./tmp/deploy-fpc-local.json}"
+
+cd "${REPO_ROOT}"
+
+bunx tsx scripts/contract/deploy-fpc-local.ts \
+  --aztec-node-url "${AZTEC_NODE_URL}" \
+  --l1-rpc-url "${L1_RPC_URL}" \
+  --operator "${FPC_LOCAL_OPERATOR}" \
+  --out "${FPC_LOCAL_OUT}" \
+  "$@"


### PR DESCRIPTION
## Summary
- add `scripts/contract/deploy-fpc-local.sh` wrapper for local deploy execution
- set wrapper defaults for local devnet endpoints:
  - `AZTEC_NODE_URL=http://127.0.0.1:8080`
  - `L1_RPC_URL=http://127.0.0.1:8545`
- wire root command `deploy:fpc:local` in `package.json` to use the wrapper
- update `README.md` deployment section with wrapper-first instructions and overrides

## Validation
- `bun run deploy:fpc:local`
- confirm output file exists at `./tmp/deploy-fpc-local.json`

Closes #55
Issue: https://github.com/NethermindEth/aztec-fpc/issues/55
