### PR TITLE
docker: add bake file and multi-stage Dockerfiles for services

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,58 @@
+variable "REGISTRY" {
+  default = ""
+}
+
+variable "TAG" {
+  default = "latest"
+}
+
+variable "GIT_SHA" {
+  default = ""
+}
+
+group "default" {
+  targets = ["attestation", "topup"]
+}
+
+target "_labels" {
+  labels = {
+    "org.opencontainers.image.source"   = "https://github.com/nethermind/aztec-fpc"
+    "org.opencontainers.image.revision" = "${GIT_SHA}"
+  }
+}
+
+target "attestation-base" {
+  context    = "."
+  dockerfile = "services/Dockerfile.common"
+  target     = "runtime"
+  args       = { SERVICE = "attestation" }
+}
+
+target "topup-base" {
+  context    = "."
+  dockerfile = "services/Dockerfile.common"
+  target     = "runtime"
+  args       = { SERVICE = "topup" }
+}
+
+target "attestation" {
+  inherits   = ["_labels"]
+  context    = "."
+  dockerfile = "services/attestation/Dockerfile"
+  contexts   = { common = "target:attestation-base" }
+  tags = compact([
+    "${REGISTRY}nethermind/aztec-fpc-attestation:${TAG}",
+    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-attestation:${GIT_SHA}" : "",
+  ])
+}
+
+target "topup" {
+  inherits   = ["_labels"]
+  context    = "."
+  dockerfile = "services/topup/Dockerfile"
+  contexts   = { common = "target:topup-base" }
+  tags = compact([
+    "${REGISTRY}nethermind/aztec-fpc-topup:${TAG}",
+    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-topup:${GIT_SHA}" : "",
+  ])
+}

--- a/services/Dockerfile.common
+++ b/services/Dockerfile.common
@@ -1,0 +1,59 @@
+ARG SERVICE
+
+# ---------- deps: install all dependencies (dev + prod) ----------
+FROM oven/bun:1.3.9-slim AS deps
+
+WORKDIR /app
+
+# Bun workspace resolution requires every member's package.json present
+# before `bun install` will accept the lockfile.
+COPY package.json bun.lock ./
+COPY services/attestation/package.json services/attestation/
+COPY services/topup/package.json services/topup/
+
+RUN bun install --frozen-lockfile
+
+# ---------- build: compile TypeScript ----------
+FROM deps AS build
+
+ARG SERVICE
+
+COPY tsconfig.base.json ./
+COPY services/${SERVICE}/tsconfig.json services/${SERVICE}/
+COPY services/${SERVICE}/src/ services/${SERVICE}/src/
+
+RUN cd services/${SERVICE} && bun run build
+
+# ---------- prod-deps: production-only node_modules ----------
+FROM oven/bun:1.3.9-slim AS prod-deps
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+COPY services/attestation/package.json services/attestation/
+COPY services/topup/package.json services/topup/
+
+RUN bun install --frozen-lockfile --production
+
+# ---------- runtime: final slim image ----------
+FROM oven/bun:1.3.9-slim AS runtime
+
+ARG SERVICE
+
+RUN groupadd --system --gid 10001 app \
+    && useradd --system --uid 10001 --gid app --no-create-home app
+
+WORKDIR /app
+
+COPY --from=prod-deps --chown=app:app /app/node_modules node_modules
+COPY --from=prod-deps --chown=app:app /app/services/${SERVICE}/node_modules services/${SERVICE}/node_modules
+COPY --from=build     --chown=app:app /app/services/${SERVICE}/dist services/${SERVICE}/dist
+
+# Workspace package manifests (needed for Bun module resolution at runtime)
+COPY --chown=app:app package.json ./
+COPY --chown=app:app services/${SERVICE}/package.json services/${SERVICE}/
+
+# Reference config — real config must be bind-mounted at runtime
+COPY --chown=app:app services/${SERVICE}/config.example.yaml services/${SERVICE}/
+
+USER app

--- a/services/attestation/Dockerfile
+++ b/services/attestation/Dockerfile
@@ -1,0 +1,8 @@
+FROM common
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD bun -e "await fetch('http://127.0.0.1:3000/health').then(r => { if (!r.ok) throw 1 })"
+
+ENTRYPOINT ["bun", "run", "services/attestation/dist/index.js"]

--- a/services/topup/Dockerfile
+++ b/services/topup/Dockerfile
@@ -1,0 +1,3 @@
+FROM common
+
+ENTRYPOINT ["bun", "run", "services/topup/dist/index.js"]


### PR DESCRIPTION
## Summary
- Add `docker-bake.hcl` with `attestation` and `topup` build targets, OCI labels, and configurable `REGISTRY`/`TAG`/`GIT_SHA` variables
- Add shared multi-stage `services/Dockerfile.common` (deps → build → prod-deps → runtime) based on `oven/bun:1.3.9-slim` with a non-root user
- Add per-service Dockerfiles: `attestation` (with healthcheck on `:3000/health`) and `topup`

## Test plan
- [ ] `docker buildx bake` builds both images successfully
- [ ] Attestation container starts and responds on `/health`
- [ ] Topup container starts and runs the entrypoint