### PR TITLE
docker: bundle with Bun, drop node_modules from final image

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,25 +252,75 @@ cp config.example.yaml config.yaml
 bun install && bun run build && bun run start
 ```
 
-### 12. Docker builds
+### 12. Docker
 
-Build both service images:
+#### Building images
+
+Both service images are built with [Docker Buildx Bake](https://docs.docker.com/build/bake/) via `docker-bake.hcl`. The bake file uses a two-stage build: `Dockerfile.common` produces a shared runtime base, then each service's Dockerfile adds its entrypoint and healthcheck.
+
+```bash
+# Build both images (attestation + topup)
+docker buildx bake
+
+# Build a single target
+docker buildx bake attestation
+docker buildx bake topup
+
+# Custom tag / registry
+TAG=v0.1.0 docker buildx bake
+REGISTRY=ghcr.io/ TAG=v0.1.0 docker buildx bake
+
+# Tag with current git SHA
+GIT_SHA=$(git rev-parse HEAD) docker buildx bake
+```
+
+Or via the workspace scripts:
 
 ```bash
 bun run docker:build
-```
-
-Or build individually:
-
-```bash
 bun run docker:build:attestation
 bun run docker:build:topup
 ```
 
-Images are tagged as `nethermind/aztec-fpc-{attestation,topup}:latest` by default. Override via environment variables:
+#### Running with Docker Compose
+
+The compose stack (`docker-compose.yaml`) includes:
+
+| Service | Description | Port |
+|---------|-------------|------|
+| `anvil` | Local L1 chain (Foundry) | 8545 |
+| `aztec-node` | Aztec sandbox node | 8080 |
+| `attestation` | FPC attestation service | 3000 |
+| `topup` | FPC Fee Juice top-up daemon | — |
+
+Each service reads a `config.yaml` mounted into the container. By default these are `config.example.yaml`:
+
+```
+services/attestation/config.yaml -> config.example.yaml
+services/topup/config.yaml       -> config.example.yaml
+```
+
+Start the stack:
 
 ```bash
-TAG=v1.0.0 bun run docker:build
+docker compose up
+```
+
+#### Environment variable overrides
+
+Environment variables take precedence over values in the config file:
+
+| Variable | Used by | Compose default |
+|----------|---------|-----------------|
+| `AZTEC_NODE_URL` | attestation, topup | `http://aztec-node:8080` |
+| `L1_RPC_URL` | topup | `http://anvil:8545` |
+| `OPERATOR_SECRET_KEY` | attestation | — |
+| `L1_OPERATOR_PRIVATE_KEY` | topup | — |
+
+Pass them via a `.env` file or inline:
+
+```bash
+OPERATOR_SECRET_KEY=0x... L1_OPERATOR_PRIVATE_KEY=0x... docker compose up
 ```
 
 ### 13. Verify

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,72 @@
+services:
+  anvil:
+    image: ghcr.io/foundry-rs/foundry:v1.4.1
+    entrypoint: ["anvil"]
+    command: ["--host", "0.0.0.0", "--silent"]
+    ports:
+      - "8545:8545"
+    healthcheck:
+      test: ["CMD", "cast", "bn", "--rpc-url", "http://localhost:8545"]
+      interval: 1s
+      timeout: 5s
+      retries: 24
+      start_period: 5s
+
+  aztec-node:
+    image: aztecprotocol/aztec:4.0.0-devnet.2-patch.1
+    command: ["start", "--local-network"]
+    ports:
+      - "8080:8080"
+    environment:
+      ARCHIVER_POLLING_INTERVAL_MS: 500
+      P2P_BLOCK_CHECK_INTERVAL_MS: 500
+      SEQ_TX_POLLING_INTERVAL_MS: 500
+      WS_BLOCK_CHECK_INTERVAL_MS: 500
+      ARCHIVER_VIEM_POLLING_INTERVAL_MS: 500
+      TEST_ACCOUNTS: "true"
+      LOG_LEVEL: "info;silent:sequencer;verbose:debug_log"
+      DEPLOY_AZTEC_CONTRACTS_SALT: 1
+      L1_CHAIN_ID: 31337
+      ETHEREUM_HOSTS: "http://anvil:8545"
+    depends_on:
+      anvil:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js", "get-node-info"]
+      interval: 1s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+
+  attestation:
+    image: nethermind/aztec-fpc-attestation
+    ports:
+      - "3000:3000"
+    configs:
+      - source: attestation-config
+        target: /app/config.yaml
+    environment:
+      AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
+      OPERATOR_SECRET_KEY: "${OPERATOR_SECRET_KEY:-}"
+    depends_on:
+      aztec-node:
+        condition: service_healthy
+
+  topup:
+    image: nethermind/aztec-fpc-topup
+    configs:
+      - source: topup-config
+        target: /app/config.yaml
+    environment:
+      AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
+      L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
+      L1_OPERATOR_PRIVATE_KEY: "${L1_OPERATOR_PRIVATE_KEY:-}"
+    depends_on:
+      aztec-node:
+        condition: service_healthy
+
+configs:
+  attestation-config:
+    file: ./services/attestation/config.yaml
+  topup-config:
+    file: ./services/topup/config.yaml

--- a/services/attestation/src/config.ts
+++ b/services/attestation/src/config.ts
@@ -62,6 +62,7 @@ export function loadConfig(path: string): Config {
 
   return {
     ...config,
+    aztec_node_url: process.env.AZTEC_NODE_URL ?? config.aztec_node_url,
     operator_secret_key: selectedSecret,
     operator_secret_key_source: envSecret ? "env" : "config",
     operator_secret_key_dual_source: Boolean(envSecret && fileSecret),

--- a/services/topup/src/config.ts
+++ b/services/topup/src/config.ts
@@ -84,6 +84,8 @@ export function loadConfig(path: string): Config {
 
   return {
     ...config,
+    aztec_node_url: process.env.AZTEC_NODE_URL ?? config.aztec_node_url,
+    l1_rpc_url: process.env.L1_RPC_URL ?? config.l1_rpc_url,
     l1_operator_private_key: selectedSecret,
     l1_operator_private_key_source: envSecret ? "env" : "config",
     l1_operator_private_key_dual_source: Boolean(envSecret && fileSecret),


### PR DESCRIPTION
Build services with `bun build` so the final image only has the bundled output and no node_modules. Renamed bundle script to build (replacing tsc).