### PR TITLE
docker: bundle with Bun, drop node_modules from final image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
         "@aztec/wallets": "4.0.0-devnet.2-patch.1",
         "fastify": "^4.28.0",
+        "pino-pretty": "^13.1.3",
         "viem": "^2.18.0",
         "yaml": "^2.4.5",
         "zod": "^3.23.8",
@@ -955,7 +956,7 @@
 
     "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "0.4.0", "atomic-sleep": "1.0.0", "on-exit-leak-free": "2.1.2", "pino-abstract-transport": "2.0.0", "pino-std-serializers": "7.1.0", "process-warning": "5.0.0", "quick-format-unescaped": "4.0.4", "real-require": "0.2.0", "safe-stable-stringify": "2.5.0", "sonic-boom": "4.2.1", "thread-stream": "3.1.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
-    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "2.0.20", "dateformat": "4.6.3", "fast-copy": "4.0.2", "fast-safe-stringify": "2.1.1", "help-me": "5.0.0", "joycon": "3.1.1", "minimist": "1.2.8", "on-exit-leak-free": "2.1.2", "pino-abstract-transport": "3.0.0", "pump": "3.0.3", "secure-json-parse": "4.1.0", "sonic-boom": "4.2.1", "strip-json-comments": "5.0.3" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
@@ -1253,9 +1254,9 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
-    "pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+    "pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
-    "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+    "pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "pino-pretty/secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 

--- a/scripts/services/fpc-services-smoke.ts
+++ b/scripts/services/fpc-services-smoke.ts
@@ -687,8 +687,9 @@ async function main() {
 
     const attestation = startManagedProcess(
       "attestation",
-      "node",
+      "bun",
       [
+        "run",
         path.join(repoRoot, "services", "attestation", "dist", "index.js"),
         "--config",
         attestationConfigPath,
@@ -726,8 +727,9 @@ async function main() {
 
     const topup = startManagedProcess(
       "topup",
-      "node",
+      "bun",
       [
+        "run",
         path.join(repoRoot, "services", "topup", "dist", "index.js"),
         "--config",
         topupConfigPath,

--- a/services/Dockerfile.common
+++ b/services/Dockerfile.common
@@ -13,7 +13,7 @@ COPY services/topup/package.json services/topup/
 
 RUN bun install --frozen-lockfile
 
-# ---------- build: compile TypeScript ----------
+# ---------- build: compile with Bun (single file, no node_modules at runtime) ----------
 FROM deps AS build
 
 ARG SERVICE
@@ -21,19 +21,9 @@ ARG SERVICE
 COPY tsconfig.base.json ./
 COPY services/${SERVICE}/tsconfig.json services/${SERVICE}/
 COPY services/${SERVICE}/src/ services/${SERVICE}/src/
+COPY services/${SERVICE}/package.json services/${SERVICE}/
 
 RUN cd services/${SERVICE} && bun run build
-
-# ---------- prod-deps: production-only node_modules ----------
-FROM oven/bun:1.3.9-slim AS prod-deps
-
-WORKDIR /app
-
-COPY package.json bun.lock ./
-COPY services/attestation/package.json services/attestation/
-COPY services/topup/package.json services/topup/
-
-RUN bun install --frozen-lockfile --production
 
 # ---------- runtime: final slim image ----------
 FROM oven/bun:1.3.9-slim AS runtime
@@ -45,13 +35,7 @@ RUN groupadd --system --gid 10001 app \
 
 WORKDIR /app
 
-COPY --from=prod-deps --chown=app:app /app/node_modules node_modules
-COPY --from=prod-deps --chown=app:app /app/services/${SERVICE}/node_modules services/${SERVICE}/node_modules
-COPY --from=build     --chown=app:app /app/services/${SERVICE}/dist services/${SERVICE}/dist
-
-# Workspace package manifests (needed for Bun module resolution at runtime)
-COPY --chown=app:app package.json ./
-COPY --chown=app:app services/${SERVICE}/package.json services/${SERVICE}/
+COPY --from=build --chown=app:app /app/services/${SERVICE}/dist services/${SERVICE}/dist
 
 # Reference config — real config must be bind-mounted at runtime
 COPY --chown=app:app services/${SERVICE}/config.example.yaml services/${SERVICE}/

--- a/services/attestation/package.json
+++ b/services/attestation/package.json
@@ -5,7 +5,7 @@
   "description": "Quote-signing attestation service for the MultiAssetFPC",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "bun build src/index.ts --outdir=dist --target=bun",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "start": "bun run dist/index.js",
@@ -18,6 +18,7 @@
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
     "@aztec/wallets": "4.0.0-devnet.2-patch.1",
     "fastify": "^4.28.0",
+    "pino-pretty": "^13.1.3",
     "viem": "^2.18.0",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"

--- a/services/topup/package.json
+++ b/services/topup/package.json
@@ -5,7 +5,7 @@
   "description": "Background service that keeps the MultiAssetFPC funded with Fee Juice",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "bun build src/index.ts --outdir=dist --target=bun",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "start": "bun run dist/index.js",


### PR DESCRIPTION
Build services with bun build so the final image only has the bundled output and no node_modules. Renamed bundle script to build (replacing tsc).