### PR TITLE
contracts: codify zero-rate quote policy in fee entrypoint

### DIFF
--- a/contracts/fpc/src/main.nr
+++ b/contracts/fpc/src/main.nr
@@ -90,6 +90,7 @@ pub contract FPC {
         let operator = self.storage.operator.read();
         let accepted_asset = self.storage.accepted_asset.read();
         let sender = self.msg_sender();
+        assert(rate_num > (0 as u128), "rate_num must be > 0");
 
         // User-specific quote: binds to msg_sender so only this user can use it.
         // The operator signed acknowledging it will track private receipts

--- a/contracts/fpc/src/test/fee_entrypoint.nr
+++ b/contracts/fpc/src/test/fee_entrypoint.nr
@@ -65,6 +65,34 @@ unconstrained fn fee_entrypoint_happy_path_transfers_expected_charge() {
     assert_eq(operator_balance_after, operator_balance_before + charge);
 }
 
+#[test(should_fail_with = "rate_num must be > 0")]
+unconstrained fn fee_entrypoint_rejects_zero_rate_numerator() {
+    let (mut env, fpc_address, token_address, operator, user) = utils::setup();
+    let fpc = FPC::at(fpc_address);
+    let token = Token::at(token_address);
+
+    let rate_num = 0 as u128;
+    let rate_den = 1 as u128;
+    let authwit_nonce = 44;
+    let valid_until = env.last_block_timestamp() + 3600;
+    let charge = utils::expected_charge(env, rate_num, rate_den);
+    utils::add_quote_authwit(
+        env,
+        operator,
+        fpc_address,
+        token_address,
+        rate_num,
+        rate_den,
+        valid_until,
+        user,
+    );
+    let transfer_call = token.transfer_private_to_private(user, operator, charge, authwit_nonce);
+    add_private_authwit_from_call(env, user, fpc_address, transfer_call);
+
+    let _ =
+        env.call_private(user, fpc.fee_entrypoint(authwit_nonce, rate_num, rate_den, valid_until));
+}
+
 #[test(should_fail_with = "Unknown auth witness for message hash")]
 unconstrained fn fee_entrypoint_requires_fresh_transfer_authwit_each_call() {
     let (mut env, fpc_address, token_address, operator, user) = utils::setup();

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -97,21 +97,24 @@ Users see only `(final_rate_num, final_rate_den)` in their quote. The contract a
 charge = ceil(max_gas_cost_no_teardown × rate_num / rate_den)
 ```
 
+Policy: the standard `fee_entrypoint` requires `rate_num > 0`. Zero-rate quotes are rejected on-chain to avoid free-transaction quotes.
+
 ### 3.4 Payment Flow
 
 #### `fee_entrypoint(authwit_nonce, rate_num, rate_den, valid_until)`
 
 ```
-User private balance →[transfer_in_private]→ Operator private balance
+User private balance →[transfer_private_to_private]→ Operator private balance
 ```
 
 1. Reads `operator` and `accepted_asset` from storage
-2. Verifies the quote authwit is signed by `operator` and binds `user_address = msg_sender`
-3. Asserts `anchor_block_timestamp ≤ valid_until`
-4. Asserts `(valid_until - anchor_block_timestamp) ≤ 3600` seconds
-5. Computes `charge = ceil(max_gas_cost_no_teardown × rate_num / rate_den)`
-6. Calls `Token::at(accepted_asset).transfer_in_private(sender → operator, charge, nonce)`
-7. Calls `set_as_fee_payer()` + `end_setup()`
+2. Asserts `rate_num > 0`
+3. Verifies the quote authwit is signed by `operator` and binds `user_address = msg_sender`
+4. Asserts `anchor_block_timestamp ≤ valid_until`
+5. Asserts `(valid_until - anchor_block_timestamp) ≤ 3600` seconds
+6. Computes `charge = ceil(max_gas_cost_no_teardown × rate_num / rate_den)`
+7. Calls `Token::at(accepted_asset).transfer_private_to_private(sender → operator, charge, nonce)`
+8. Calls `set_as_fee_payer()` + `end_setup()`
 
 The token transfer is a private function call that executes in the setup phase, before `end_setup()`. It is irrevocably committed. If the user's app logic subsequently reverts, the fee has still been paid — this is unavoidable in the Aztec FPC model.
 


### PR DESCRIPTION
## Summary
- enforce explicit zero-rate rejection in `FPC.fee_entrypoint`
- add regression test for `rate_num = 0` rejection in fee entrypoint tests
- codify the policy in `docs/spec.md` so quote behavior is unambiguous

## Changes
- `contracts/fpc/src/main.nr`
  - add assertion rejecting zero numerator rates in the standard entrypoint
- `contracts/fpc/src/test/fee_entrypoint.nr`
  - add `fee_entrypoint_rejects_zero_rate_numerator`
- `docs/spec.md`
  - document policy and update payment-flow steps

## Validation
- `bun run test:contracts`

Closes #59
