### PR TITLE
docker: externalize unbundleable deps, slim runtime image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "aztec-fpc",
-      "dependencies": {
-        "pino-pretty": "^13.1.3",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
         "@types/node": "^20.0.0",
@@ -20,10 +17,13 @@
       "dependencies": {
         "@aztec/accounts": "4.0.0-devnet.2-patch.1",
         "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
+        "@aztec/bb.js": "4.0.0-devnet.2-patch.1",
         "@aztec/pxe": "4.0.0-devnet.2-patch.1",
         "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
         "@aztec/wallets": "4.0.0-devnet.2-patch.1",
         "fastify": "^4.28.0",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "viem": "^2.18.0",
         "yaml": "^2.4.5",
         "zod": "^3.23.8",
@@ -34,9 +34,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
+        "@aztec/bb.js": "4.0.0-devnet.2-patch.1",
         "@aztec/ethereum": "4.0.0-devnet.2-patch.1",
         "@aztec/foundation": "4.0.0-devnet.2-patch.1",
         "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
+        "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "viem": "^2.18.0",
         "yaml": "^2.4.5",
@@ -957,7 +959,7 @@
 
     "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
 
-    "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "0.4.0", "atomic-sleep": "1.0.0", "on-exit-leak-free": "2.1.2", "pino-abstract-transport": "2.0.0", "pino-std-serializers": "7.1.0", "process-warning": "5.0.0", "quick-format-unescaped": "4.0.4", "real-require": "0.2.0", "safe-stable-stringify": "2.5.0", "sonic-boom": "4.2.1", "thread-stream": "3.1.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
@@ -1027,7 +1029,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1093,7 +1095,7 @@
 
     "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "5.0.0", "https-proxy-agent": "5.0.1", "node-fetch": "2.7.0", "stream-events": "1.0.5", "uuid": "9.0.1" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
 
-    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+    "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
     "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
@@ -1177,6 +1179,8 @@
 
     "@aztec/foundation/@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
 
+    "@aztec/foundation/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "0.4.0", "atomic-sleep": "1.0.0", "on-exit-leak-free": "2.1.2", "pino-abstract-transport": "2.0.0", "pino-std-serializers": "7.1.0", "process-warning": "5.0.0", "quick-format-unescaped": "4.0.4", "real-require": "0.2.0", "safe-stable-stringify": "2.5.0", "sonic-boom": "4.2.1", "thread-stream": "3.1.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
+
     "@aztec/pxe/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "optionalDependencies": { "typescript": "5.9.3" } }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
 
     "@aztec/stdlib/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "optionalDependencies": { "typescript": "5.9.3" } }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
@@ -1237,7 +1241,7 @@
 
     "fast-json-stringify/ajv-formats": ["ajv-formats@3.0.1", "", { "optionalDependencies": { "ajv": "8.18.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "fastify/secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
+    "fastify/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "0.4.0", "atomic-sleep": "1.0.0", "on-exit-leak-free": "2.1.2", "pino-abstract-transport": "2.0.0", "pino-std-serializers": "7.1.0", "process-warning": "5.0.0", "quick-format-unescaped": "4.0.4", "real-require": "0.2.0", "safe-stable-stringify": "2.5.0", "sonic-boom": "4.2.1", "thread-stream": "3.1.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -1259,9 +1263,9 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
-    "pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
-
     "pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pino-pretty/secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "raw-body/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.2", "toidentifier": "1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1294,6 +1298,12 @@
     "@aztec/foundation/@scure/bip39/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
     "@aztec/foundation/@scure/bip39/@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+
+    "@aztec/foundation/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "@aztec/foundation/pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "@aztec/foundation/pino/thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "@aztec/pxe/viem/abitype": ["abitype@1.1.0", "", { "optionalDependencies": { "typescript": "5.9.3", "zod": "3.25.76" } }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
@@ -1332,6 +1342,12 @@
     "command-line-usage/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "1.9.3" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "command-line-usage/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "fastify/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "4.2.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "fastify/pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "fastify/pino/thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "koa-compress/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "aztec-fpc",
   "version": "1.0.0",
-  "private": true,
+  "author": "",
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.4",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.4.0"
+  },
   "description": "",
-  "workspaces": [
-    "services/*"
-  ],
+  "keywords": [],
+  "license": "Apache-2.0",
+  "packageManager": "bun@1.3.9",
+  "private": true,
   "scripts": {
     "biome:check": "biome check --write",
     "biome:ci": "biome ci",
@@ -32,17 +39,7 @@
     "smoke:services": "bash scripts/services/fpc-services-smoke.sh",
     "test": "bun run test:contracts && bun run test:ts"
   },
-  "keywords": [],
-  "author": "",
-  "license": "Apache-2.0",
-  "packageManager": "bun@1.3.9",
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.4",
-    "@types/node": "^20.0.0",
-    "tsx": "^4.0.0",
-    "typescript": "^5.4.0"
-  },
-  "dependencies": {
-    "pino-pretty": "^13.1.3"
-  }
+  "workspaces": [
+    "services/*"
+  ]
 }

--- a/services/Dockerfile.common
+++ b/services/Dockerfile.common
@@ -31,8 +31,8 @@ COPY services/${SERVICE}/src/ services/${SERVICE}/src/
 
 RUN cd services/${SERVICE} && bun run build
 
-# ---------- prod-deps: production-only node_modules ----------
-FROM oven/bun:1.3.9-slim AS prod-deps
+# ---------- external-deps: only packages excluded from the bundle ----------
+FROM oven/bun:1.3.9-slim AS external-deps
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -40,14 +40,11 @@ RUN apt-get update && \
       make \
       g++ && \
     rm -rf /var/lib/apt/lists/*
-    
-WORKDIR /app
 
-COPY package.json bun.lock ./
-COPY services/attestation/package.json services/attestation/
-COPY services/topup/package.json services/topup/
+WORKDIR /deps
 
-RUN bun install --frozen-lockfile --production
+COPY services/external-deps.json package.json
+RUN bun install
 
 # ---------- runtime: final slim image ----------
 FROM oven/bun:1.3.9-slim AS runtime
@@ -59,9 +56,8 @@ RUN groupadd --system --gid 10001 app \
 
 WORKDIR /app
 
-COPY --from=prod-deps --chown=app:app /app/node_modules node_modules
-COPY --from=prod-deps --chown=app:app /app/services/${SERVICE}/node_modules services/${SERVICE}/node_modules
-COPY --from=build     --chown=app:app /app/services/${SERVICE}/dist services/${SERVICE}/dist
+COPY --from=external-deps --chown=app:app /deps/node_modules node_modules
+COPY --from=build         --chown=app:app /app/services/${SERVICE}/dist services/${SERVICE}/dist
 
 # Workspace package manifests (needed for Bun module resolution at runtime)
 COPY --chown=app:app package.json ./

--- a/services/EXTERNAL_DEPS.md
+++ b/services/EXTERNAL_DEPS.md
@@ -1,0 +1,14 @@
+# External Dependencies
+
+`external-deps.json` lists packages excluded from `bun build` via `--external` flags.
+
+These packages can't be bundled because they need runtime filesystem access:
+
+- **`@aztec/bb.js`** — loads `.wasm.gz` binaries and worker scripts via `__dirname`
+- **`pino`** — spawns worker threads (`thread-stream`) that load transport modules dynamically
+- **`pino-pretty`** — loaded by pino's worker thread via `require('pino-pretty')`
+
+The Dockerfile copies this file as `package.json` into the `external-deps` stage to install
+only these packages into the final image (instead of the full ~840 MB `node_modules`).
+
+When adding a new `--external` flag to a service build script, add the package here too.

--- a/services/attestation/package.json
+++ b/services/attestation/package.json
@@ -5,7 +5,7 @@
   "description": "Quote-signing attestation service for the MultiAssetFPC",
   "main": "dist/index.js",
   "scripts": {
-    "build": "bun build src/index.ts --outdir=dist --target=bun",
+    "build": "bun build src/index.ts --outdir=dist --target=bun --external @aztec/bb.js --external pino",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "start": "bun run dist/index.js",
@@ -14,10 +14,13 @@
   "dependencies": {
     "@aztec/accounts": "4.0.0-devnet.2-patch.1",
     "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
+    "@aztec/bb.js": "4.0.0-devnet.2-patch.1",
     "@aztec/pxe": "4.0.0-devnet.2-patch.1",
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
     "@aztec/wallets": "4.0.0-devnet.2-patch.1",
     "fastify": "^4.28.0",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "viem": "^2.18.0",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"

--- a/services/external-deps.json
+++ b/services/external-deps.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@aztec/bb.js": "4.0.0-devnet.2-patch.1",
+    "pino": "^9.0.0",
+    "pino-pretty": "^13.1.3"
+  }
+}

--- a/services/topup/package.json
+++ b/services/topup/package.json
@@ -5,7 +5,7 @@
   "description": "Background service that keeps the MultiAssetFPC funded with Fee Juice",
   "main": "dist/index.js",
   "scripts": {
-    "build": "bun build src/index.ts --outdir=dist --target=bun",
+    "build": "bun build src/index.ts --outdir=dist --target=bun --external @aztec/bb.js --external pino",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "start": "bun run dist/index.js",
@@ -13,9 +13,11 @@
   },
   "dependencies": {
     "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
+    "@aztec/bb.js": "4.0.0-devnet.2-patch.1",
     "@aztec/ethereum": "4.0.0-devnet.2-patch.1",
     "@aztec/foundation": "4.0.0-devnet.2-patch.1",
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
+    "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "viem": "^2.18.0",
     "yaml": "^2.4.5",


### PR DESCRIPTION
## Summary

- Fixes `bun build` `__dirname` collision that broke `@aztec/bb.js` (ENOENT on `barretenberg-threads.wasm.gz`) and pino (worker thread transport loading)
- Marks `@aztec/bb.js`, `pino`, and `pino-pretty` as `--external` in the build step — these packages need runtime filesystem access and can't be bundled
- Replaces the `prod-deps` Docker stage (full ~840 MB `node_modules`) with a minimal `external-deps` stage that installs only the external packages
- Adds `services/external-deps.json` as single source of truth for external deps, shared between build scripts and Dockerfile

## Background

Bun's bundler flattens per-module ESM `var __dirname` declarations into a single scope. The last one wins, causing all earlier modules to resolve filesystem paths incorrectly. CJS modules are unaffected (wrapped in `__commonJS` which creates function scope).

Packages excluded from the bundle:
| Package | Reason |
|---|---|
| `@aztec/bb.js` | Loads `.wasm.gz` binaries and worker scripts via `__dirname` |
| `pino` | Spawns worker threads (`thread-stream`) that `require()` transport modules |
| `pino-pretty` | Loaded dynamically by pino's worker thread |