### PR TITLE
docs: attribute CreditFPC derivation from defi-wonderland/aztec-fee-p…

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,14 @@
+# Attribution
+
+This project includes code derived from third-party sources.
+
+## defi-wonderland/aztec-fee-payment
+
+- **Repository**: https://github.com/defi-wonderland/aztec-fee-payment
+- **License**: MIT
+- **File**: `contracts/credit_fpc/src/main.nr`
+- **Original**: `src/nr/metered_contract/src/main.nr`
+- **Description**: The CreditFPC contract's private fee-credit model (balance tracking,
+  gas-cost deduction, and teardown refund) was originally derived from Wonderland's
+  `metered_contract`. It has since been adapted to use operator Schnorr-signed quotes,
+  nullifier-based replay protection, and a packed single-slot config.

--- a/contracts/credit_fpc/src/main.nr
+++ b/contracts/credit_fpc/src/main.nr
@@ -1,3 +1,14 @@
+/// Originally derived from defi-wonderland/aztec-fee-payment:
+/// https://github.com/defi-wonderland/aztec-fee-payment/blob/dev/src/nr/metered_contract/src/main.nr
+/// Licensed under MIT.
+///
+/// Key changes from upstream:
+/// - Replaced authwit-delegated owner verification with operator Schnorr-signed quotes
+/// - Added quote replay protection via nullifiers
+/// - Replaced pay_fee / pay_fee_exact with pay_and_mint / pay_with_credit
+/// - Packed config into single PublicImmutable slot (1 Merkle proof vs 4)
+/// - Added exchange-rate conversion via fee_math
+
 mod fee_math;
 mod test;
 


### PR DESCRIPTION
…ayment

Add file-level attribution header to credit_fpc/src/main.nr and a root ATTRIBUTION.md documenting that the contract's private fee-credit model was originally derived from Wonderland's metered_contract.