### PR TITLE
docker: add smoke test image and bake targets

### DIFF
--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -1,0 +1,24 @@
+FROM common
+
+# ── TypeScript config ──
+COPY tsconfig.base.json ./
+COPY services/attestation/tsconfig.json services/attestation/
+COPY services/topup/tsconfig.json services/topup/
+
+# ── Service source & build ──
+COPY services/attestation/src/ services/attestation/src/
+COPY services/topup/src/ services/topup/src/
+RUN cd services/attestation && bun run build
+RUN cd services/topup && bun run build
+
+# ── Test files ──
+COPY services/attestation/test/ services/attestation/test/
+
+# ── Config examples (used by services smoke to generate runtime configs) ──
+COPY services/attestation/config.example.yaml services/attestation/
+COPY services/topup/config.example.yaml services/topup/
+
+# ── Smoke & deploy scripts ──
+COPY scripts/ scripts/
+
+ENTRYPOINT ["bunx", "tsx"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,6 +22,10 @@ group "default" {
   targets = ["attestation", "topup", "contract-compile", "contract-deploy"]
 }
 
+group "smoke" {
+  targets = ["smoke-test"]
+}
+
 group "contract" {
   targets = ["contract-compile", "contract-deploy"]
 }
@@ -98,5 +102,23 @@ target "contract-deploy" {
   tags = compact([
     "${REGISTRY}nethermind/aztec-fpc-contract-deploy:${TAG}${PLATFORM_SUFFIX}",
     GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-contract-deploy:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
+  ])
+}
+
+target "smoke-base" {
+  context    = "."
+  dockerfile = "scripts/contract/Dockerfile.deploy"
+  target     = "runtime"
+}
+
+target "smoke-test" {
+  inherits   = ["_labels"]
+  context    = "."
+  dockerfile = "Dockerfile.smoke"
+  contexts   = { common = "target:smoke-base" }
+  platforms  = PLATFORMS
+  tags = compact([
+    "${REGISTRY}nethermind/aztec-fpc-smoke:${TAG}${PLATFORM_SUFFIX}",
+    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-smoke:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
   ])
 }


### PR DESCRIPTION
## Summary
- Add `Dockerfile.smoke` extending the deploy `runtime` stage with service builds, test files, config examples, and smoke scripts
- Add `smoke-base` and `smoke-test` bake targets in `docker-bake.hcl` for building the image via `docker buildx bake smoke`

## Test plan
- [ ] `docker buildx bake --print smoke` validates the bake config
- [ ] `docker buildx bake smoke` builds the image successfully
- [ ] Image contains compiled contract artifacts, built services, and smoke scripts