### PR TITLE
ci: add docker build and smoke test workflow

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -1,0 +1,39 @@
+name: Docker build CI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "**"
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  docker-build-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build all images
+        run: docker buildx bake --load
+
+      - name: Smoke tests
+        run: docker compose --profile smoke up --attach smoke --exit-code-from smoke
+
+      - name: Tear down
+        if: always()
+        run: docker compose --profile smoke down -v --remove-orphans

--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -8,8 +8,6 @@ COPY services/topup/tsconfig.json services/topup/
 # ── Service source & build ──
 COPY services/attestation/src/ services/attestation/src/
 COPY services/topup/src/ services/topup/src/
-RUN cd services/attestation && bun run build
-RUN cd services/topup && bun run build
 
 # ── Test files ──
 COPY services/attestation/test/ services/attestation/test/
@@ -18,7 +16,13 @@ COPY services/attestation/test/ services/attestation/test/
 COPY services/attestation/config.example.yaml services/attestation/
 COPY services/topup/config.example.yaml services/topup/
 
+# ── Compiled contract artifacts ──
+COPY --from=deploy /app/target/ target/
+
 # ── Smoke & deploy scripts ──
 COPY scripts/ scripts/
 
-ENTRYPOINT ["bunx", "tsx"]
+# ── Build services ──
+RUN bun run build
+
+ENTRYPOINT ["bun", "run", "--sequential"]

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,18 @@
         "typescript": "^5.4.0",
       },
     },
+    "scripts": {
+      "name": "@aztec-fpc/scripts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aztec/accounts": "4.0.0-devnet.2-patch.2",
+        "@aztec/aztec.js": "4.0.0-devnet.2-patch.2",
+        "@aztec/foundation": "4.0.0-devnet.2-patch.2",
+        "@aztec/stdlib": "4.0.0-devnet.2-patch.2",
+        "@aztec/wallets": "4.0.0-devnet.2-patch.2",
+        "viem": "^2.18.0",
+      },
+    },
     "services/attestation": {
       "name": "@aztec-fpc/attestation",
       "version": "0.1.0",
@@ -131,6 +143,8 @@
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
 
     "@aztec-fpc/attestation": ["@aztec-fpc/attestation@workspace:services/attestation"],
+
+    "@aztec-fpc/scripts": ["@aztec-fpc/scripts@workspace:scripts"],
 
     "@aztec-fpc/topup": ["@aztec-fpc/topup@workspace:services/topup"],
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -73,10 +73,18 @@ target "topup" {
   ])
 }
 
+target "deps" {
+  context    = "."
+  dockerfile = "services/Dockerfile.common"
+  target     = "deps"
+  platforms  = PLATFORMS
+}
+
 target "deploy" {
   inherits   = ["_labels"]
   context    = "."
   dockerfile = "scripts/contract/Dockerfile.deploy"
+  contexts   = { deps = "target:deps" }
   platforms  = PLATFORMS
   target     = "deploy"
   tags = compact([
@@ -85,17 +93,14 @@ target "deploy" {
   ])
 }
 
-target "smoke-base" {
-  context    = "."
-  dockerfile = "scripts/contract/Dockerfile.deploy"
-  target     = "runtime"
-}
-
 target "smoke" {
   inherits   = ["_labels"]
   context    = "."
   dockerfile = "Dockerfile.smoke"
-  contexts   = { common = "target:smoke-base" }
+  contexts   = {
+    common = "target:deps"
+    deploy = "target:deploy"
+  }
   platforms  = PLATFORMS
   tags = compact([
     "${REGISTRY}nethermind/aztec-fpc-smoke:${TAG}${PLATFORM_SUFFIX}",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,57 +92,21 @@ services:
       deploy:
         condition: service_completed_successfully
 
-  smoke-fee-entrypoint:
+  smoke:
     image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke-fee-entrypoint"]
-    command: ["services/attestation/test/fee-entrypoint-devnet-smoke.ts"]
+    profiles: ["smoke"]
+    command:
+      - "scripts/services/fpc-services-smoke.ts"
+      - "services/attestation/test/fee-entrypoint-devnet-smoke.ts"
+      - "services/attestation/test/credit-fpc-devnet-smoke.ts"
     environment:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_SMOKE_L1_RPC_URL: "http://anvil:8545"
-    depends_on:
-      aztec-node:
-        condition: service_healthy
-
-  smoke-credit-fpc:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke-credit-fpc"]
-    command: ["services/attestation/test/credit-fpc-devnet-smoke.ts"]
-    environment:
-      AZTEC_NODE_URL: "http://aztec-node:8080"
       CREDIT_FPC_SMOKE_L1_RPC_URL: "http://anvil:8545"
-    depends_on:
-      aztec-node:
-        condition: service_healthy
-
-  smoke-deploy:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke-deploy"]
-    entrypoint: ["bash", "-c"]
-    command:
-      - |
-        FPC_LOCAL_OUT=/tmp/deploy-out.json \
-          scripts/contract/deploy-fpc-local.sh && \
-        FPC_DEPLOY_SMOKE_DEPLOY_OUTPUT=/tmp/deploy-out.json \
-          bunx tsx scripts/contract/deploy-fpc-local-smoke.ts
-    environment:
-      AZTEC_NODE_URL: "http://aztec-node:8080"
-      L1_RPC_URL: "http://anvil:8545"
-      FPC_DEPLOY_SMOKE_L1_RPC_URL: "http://anvil:8545"
-      FPC_DEPLOY_SMOKE_START_LOCAL_NETWORK: "0"
-    depends_on:
-      aztec-node:
-        condition: service_healthy
-
-  smoke-services:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke-services"]
-    command: ["scripts/services/fpc-services-smoke.ts"]
-    environment:
-      AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_SERVICES_SMOKE_L1_RPC_URL: "http://anvil:8545"
     depends_on:
-      aztec-node:
-        condition: service_healthy
+      deploy:
+        condition: service_completed_successfully
 
 configs:
   fpc-config:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test": "bun run test:contracts && bun run test:ts"
   },
   "workspaces": [
+    "scripts",
     "services/*"
   ]
 }

--- a/scripts/contract/Dockerfile.deploy
+++ b/scripts/contract/Dockerfile.deploy
@@ -39,11 +39,13 @@ COPY --from=oven/bun:1.3.9-slim /usr/local/bin/bunx /usr/local/bin/bunx
 
 WORKDIR /app
 
-# ── Install JS dependencies (layer-cached until package.json/bun.lock change) ──
+# ── JS dependencies (reused from deps stage via bake context) ──
 COPY package.json bun.lock ./
+COPY scripts/package.json scripts/
 COPY services/attestation/package.json services/attestation/
 COPY services/topup/package.json services/topup/
-RUN bun install --frozen-lockfile
+COPY --from=deps /app/node_modules node_modules/
+COPY --from=deps /app/scripts/node_modules scripts/node_modules/
 
 # ── Pull compiled contract artifacts from compile stage ──
 COPY --from=compile /app/target/ target/

--- a/scripts/contract/deploy-fpc-local-smoke.sh
+++ b/scripts/contract/deploy-fpc-local-smoke.sh
@@ -174,10 +174,9 @@ if [[ ! -f "$DEPLOY_OUTPUT" ]]; then
 fi
 
 echo "[deploy-smoke] Running relay-aware first-use smoke checks (FPC + CreditFPC)"
-NODE_PATH="$REPO_ROOT/services/attestation/node_modules${NODE_PATH:+:$NODE_PATH}" \
 AZTEC_NODE_URL="$AZTEC_NODE_URL" \
 FPC_DEPLOY_SMOKE_L1_RPC_URL="$L1_RPC_URL" \
 FPC_DEPLOY_SMOKE_DEPLOY_OUTPUT="$DEPLOY_OUTPUT" \
-  bunx tsx "$REPO_ROOT/scripts/contract/deploy-fpc-local-smoke.ts"
+  bun run "$REPO_ROOT/scripts/contract/deploy-fpc-local-smoke.ts"
 
 echo "[deploy-smoke] PASS: full local deploy smoke flow succeeded"

--- a/scripts/contract/deploy-fpc-local.sh
+++ b/scripts/contract/deploy-fpc-local.sh
@@ -13,7 +13,7 @@ FPC_LOCAL_OUT="${FPC_LOCAL_OUT:-./tmp/deploy-fpc-local.json}"
 cd "${REPO_ROOT}"
 
 # Deploys token (if needed), FPC, and CreditFPC to local devnet.
-bunx tsx scripts/contract/deploy-fpc-local.ts \
+bun run scripts/contract/deploy-fpc-local.ts \
   --aztec-node-url "${AZTEC_NODE_URL}" \
   --l1-rpc-url "${L1_RPC_URL}" \
   --operator "${FPC_LOCAL_OPERATOR}" \

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@aztec-fpc/scripts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@aztec/accounts": "4.0.0-devnet.2-patch.2",
+    "@aztec/aztec.js": "4.0.0-devnet.2-patch.2",
+    "@aztec/foundation": "4.0.0-devnet.2-patch.2",
+    "@aztec/stdlib": "4.0.0-devnet.2-patch.2",
+    "@aztec/wallets": "4.0.0-devnet.2-patch.2",
+    "viem": "^2.18.0"
+  }
+}

--- a/scripts/services/fpc-full-lifecycle-e2e.sh
+++ b/scripts/services/fpc-full-lifecycle-e2e.sh
@@ -198,8 +198,4 @@ echo "[full-lifecycle-e2e] Building topup service"
 bun run --filter @aztec-fpc/topup build
 
 echo "[full-lifecycle-e2e] Running full lifecycle E2E runner"
-(
-  cd "$REPO_ROOT/services/attestation"
-  NODE_PATH="$REPO_ROOT/services/attestation/node_modules${NODE_PATH:+:$NODE_PATH}" \
-    bunx tsx "$REPO_ROOT/scripts/services/fpc-full-lifecycle-e2e.ts" "$@"
-)
+bun run "$REPO_ROOT/scripts/services/fpc-full-lifecycle-e2e.ts" "$@"

--- a/scripts/services/fpc-services-smoke.sh
+++ b/scripts/services/fpc-services-smoke.sh
@@ -169,8 +169,4 @@ echo "[services-smoke] Building topup service"
 bun run --filter @aztec-fpc/topup build
 
 echo "[services-smoke] Running services end-to-end smoke"
-(
-  cd "$REPO_ROOT/services/attestation"
-  NODE_PATH="$REPO_ROOT/services/attestation/node_modules${NODE_PATH:+:$NODE_PATH}" \
-    bunx tsx "$REPO_ROOT/scripts/services/fpc-services-smoke.ts"
-)
+bun run "$REPO_ROOT/scripts/services/fpc-services-smoke.ts"

--- a/services/Dockerfile.common
+++ b/services/Dockerfile.common
@@ -15,6 +15,7 @@ WORKDIR /app
 # Bun workspace resolution requires every member's package.json present
 # before `bun install` will accept the lockfile.
 COPY package.json bun.lock ./
+COPY scripts/package.json scripts/
 COPY services/attestation/package.json services/attestation/
 COPY services/topup/package.json services/topup/
 


### PR DESCRIPTION
## Summary
- Add `docker-build-ci` workflow that builds all images via `docker buildx bake --load`, starts the compose stack with `--wait`, runs all four smoke-test profiles sequentially, then tears down

## Test plan
- [ ] Verify `docker buildx bake --load` builds all images locally
- [ ] Verify `docker compose up -d --wait` starts the full stack
- [ ] Verify all smoke tests pass in the containerized environment