### PR TITLE
fix: correct PLATFORMS variable format for docker buildx bake

### DIFF
--- a/.github/workflows/docker-build-services.yml
+++ b/.github/workflows/docker-build-services.yml
@@ -56,7 +56,7 @@ jobs:
           REGISTRY: ${{ env.DOCKER_REGISTRY }}/
           TAG: ${{ env.TAG }}
           GIT_SHA: ${{ github.sha }}
-          PLATFORMS: '["linux/amd64", "linux/arm64"]'
+          PLATFORMS: 'linux/amd64,linux/arm64'
         run: docker buildx bake services --push
 
       - name: Summary

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,6 +12,7 @@ variable "GIT_SHA" {
 
 variable "PLATFORMS" {
   default = []
+  type = list(string)
 }
 
 variable "PLATFORM_SUFFIX" {


### PR DESCRIPTION
## Summary
- Change PLATFORMS from a JSON array string (`["linux/amd64", "linux/arm64"]`) to a comma-separated string (`linux/amd64,linux/arm64`) in the CI workflow
- Add explicit `type = list(string)` annotation to the PLATFORMS variable in `docker-bake.hcl`

## Test plan
- [ ] Verify CI docker build workflow runs successfully with the updated PLATFORMS format