### PR TITLE
ci: run lightweight health check on PRs

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -6,8 +6,8 @@ on:
       - main
     tags:
       - "**"
-  # pull_request:
-  #   types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
@@ -31,9 +31,14 @@ jobs:
       - name: Build all images
         run: docker buildx bake --load
 
+      - name: Start services
+        if: github.event_name == 'pull_request'
+        run: docker compose up --wait
+
       - name: Smoke tests
+        if: github.event_name != 'pull_request'
         run: docker compose --profile smoke up --attach smoke --exit-code-from smoke
 
       - name: Tear down
         if: always()
-        run: docker compose --profile smoke down -v --remove-orphans
+        run: docker compose down -v --remove-orphans


### PR DESCRIPTION
## Summary
- Enable the `pull_request` trigger on the Docker build CI workflow
- On PRs, run `docker compose up --wait` to verify services start successfully
- Reserve the full smoke test suite for pushes to main, tags, and manual dispatches

## Test plan
- [ ] Open a PR and verify `docker compose up --wait` runs instead of the smoke suite
- [ ] Push to main and verify the full smoke tests still run