### PR TITLE
refactor: extract managed-process utilities into shared module

### DIFF
--- a/scripts/common/managed-process.ts
+++ b/scripts/common/managed-process.ts
@@ -1,0 +1,190 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { type createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+
+export type ManagedProcess = {
+  name: string;
+  process: ChildProcessWithoutNullStreams;
+  getLogs: () => string;
+};
+
+const managedProcessRegistry = new Set<ManagedProcess>();
+let shutdownInProgress = false;
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function startManagedProcess(
+  name: string,
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+  },
+): ManagedProcess {
+  let logs = "";
+  const processHandle = spawn(command, args, {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  processHandle.stdout.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    logs += text;
+    process.stdout.write(`[${name}] ${text}`);
+  });
+  processHandle.stderr.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    logs += text;
+    process.stderr.write(`[${name}] ${text}`);
+  });
+
+  const managed: ManagedProcess = {
+    name,
+    process: processHandle,
+    getLogs: () => logs,
+  };
+  managedProcessRegistry.add(managed);
+  processHandle.on("exit", () => {
+    managedProcessRegistry.delete(managed);
+  });
+  return managed;
+}
+
+export async function stopManagedProcess(proc: ManagedProcess): Promise<void> {
+  if (proc.process.exitCode !== null) {
+    managedProcessRegistry.delete(proc);
+    return;
+  }
+
+  const pid = proc.process.pid;
+  let signaled = false;
+  if (typeof pid === "number" && pid > 0) {
+    try {
+      process.kill(-pid, "SIGTERM");
+      signaled = true;
+    } catch {
+      signaled = false;
+    }
+  }
+  if (!signaled) {
+    try {
+      proc.process.kill("SIGTERM");
+    } catch {
+      managedProcessRegistry.delete(proc);
+      return;
+    }
+  }
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (proc.process.exitCode !== null) {
+      managedProcessRegistry.delete(proc);
+      return;
+    }
+    await sleep(100);
+  }
+  if (typeof pid === "number" && pid > 0) {
+    try {
+      process.kill(-pid, "SIGKILL");
+      managedProcessRegistry.delete(proc);
+      return;
+    } catch {
+      // Fallback to direct child kill if process groups are unavailable.
+    }
+  }
+  try {
+    proc.process.kill("SIGKILL");
+  } catch {
+    // Process may have already exited between checks.
+  }
+  managedProcessRegistry.delete(proc);
+}
+
+export async function stopAllManagedProcesses(): Promise<void> {
+  for (const proc of Array.from(managedProcessRegistry).reverse()) {
+    await stopManagedProcess(proc);
+  }
+}
+
+export function installManagedProcessSignalHandlers(logPrefix: string): void {
+  const handleSignal = (signal: NodeJS.Signals) => {
+    if (shutdownInProgress) {
+      return;
+    }
+    shutdownInProgress = true;
+    void (async () => {
+      console.error(
+        `[${logPrefix}] Received ${signal}; stopping managed processes...`,
+      );
+      await stopAllManagedProcesses();
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    })();
+  };
+
+  process.once("SIGINT", () => handleSignal("SIGINT"));
+  process.once("SIGTERM", () => handleSignal("SIGTERM"));
+}
+
+export async function waitForNodeReady(
+  node: ReturnType<typeof createAztecNodeClient>,
+  timeoutMs: number,
+): Promise<void> {
+  await Promise.race([
+    waitForNode(node),
+    new Promise((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(`Timed out waiting for Aztec node after ${timeoutMs}ms`),
+          ),
+        timeoutMs,
+      ),
+    ),
+  ]);
+}
+
+export async function waitForHealth(
+  url: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep retrying during boot.
+    }
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for health endpoint: ${url}`);
+}
+
+export async function waitForLog(
+  proc: ManagedProcess,
+  expected: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (proc.getLogs().includes(expected)) {
+      return;
+    }
+    if (proc.process.exitCode !== null) {
+      throw new Error(
+        `Process ${proc.name} exited before logging "${expected}" (exit=${proc.process.exitCode})`,
+      );
+    }
+    await sleep(250);
+  }
+  throw new Error(
+    `Timed out waiting for ${proc.name} log "${expected}". Recent logs:\n${proc
+      .getLogs()
+      .slice(-4000)}`,
+  );
+}

--- a/scripts/services/credit-fpc-full-lifecycle-e2e.ts
+++ b/scripts/services/credit-fpc-full-lifecycle-e2e.ts
@@ -1,4 +1,3 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,7 +8,7 @@ import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Contract } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
-import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import {
   FeeJuiceContract,
   ProtocolContractAddress,
@@ -25,6 +24,17 @@ import { deriveSigningKey } from "@aztec/stdlib/keys";
 import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { ExecutionPayload } from "@aztec/stdlib/tx";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
+
+import {
+  installManagedProcessSignalHandlers,
+  type ManagedProcess,
+  sleep,
+  startManagedProcess,
+  stopManagedProcess,
+  waitForHealth,
+  waitForLog,
+  waitForNodeReady,
+} from "../common/managed-process.ts";
 
 type FullE2EMode = "credit";
 
@@ -76,12 +86,6 @@ type DeploymentRuntimeResult = {
   feePerDaGas: bigint;
   feePerL2Gas: bigint;
   maxGasCostNoTeardown: bigint;
-};
-
-type ManagedProcess = {
-  name: string;
-  process: ChildProcessWithoutNullStreams;
-  getLogs: () => string;
 };
 
 type TopupBridgeSubmission = {
@@ -151,9 +155,6 @@ const MAX_PORT = 65535;
 const CREDIT_EXPECTED_PAID_TX_COUNT = 2n;
 const QUOTE_DOMAIN_SEPARATOR = Fr.fromHexString("0x465043");
 const DIAGNOSTIC_TAIL_LINES = 200;
-const managedProcessRegistry = new Set<ManagedProcess>();
-let shutdownInProgress = false;
-
 function printHelp(): void {
   console.log(`Usage: bun run e2e:full-lifecycle:credit:local [--help]
 
@@ -304,10 +305,6 @@ function assertPrivateKeyHex(value: string, fieldName: string): void {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 function ceilDiv(numerator: bigint, denominator: bigint): bigint {
   return (numerator + denominator - 1n) / denominator;
 }
@@ -328,178 +325,6 @@ function loadArtifact(artifactPath: string): ContractArtifact {
     }
     throw error;
   }
-}
-
-async function waitForNodeReady(
-  node: ReturnType<typeof createAztecNodeClient>,
-  timeoutMs: number,
-): Promise<void> {
-  await Promise.race([
-    waitForNode(node),
-    new Promise((_, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            new Error(`Timed out waiting for Aztec node after ${timeoutMs}ms`),
-          ),
-        timeoutMs,
-      ),
-    ),
-  ]);
-}
-
-function startManagedProcess(
-  name: string,
-  command: string,
-  args: string[],
-  options: {
-    cwd: string;
-    env?: NodeJS.ProcessEnv;
-  },
-): ManagedProcess {
-  let logs = "";
-  const processHandle = spawn(command, args, {
-    cwd: options.cwd,
-    env: options.env ?? process.env,
-    detached: true,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  processHandle.stdout.on("data", (chunk: Buffer) => {
-    const text = chunk.toString();
-    logs += text;
-    process.stdout.write(`[${name}] ${text}`);
-  });
-  processHandle.stderr.on("data", (chunk: Buffer) => {
-    const text = chunk.toString();
-    logs += text;
-    process.stderr.write(`[${name}] ${text}`);
-  });
-
-  const managed: ManagedProcess = {
-    name,
-    process: processHandle,
-    getLogs: () => logs,
-  };
-  managedProcessRegistry.add(managed);
-  processHandle.on("exit", () => {
-    managedProcessRegistry.delete(managed);
-  });
-  return managed;
-}
-
-async function stopManagedProcess(proc: ManagedProcess): Promise<void> {
-  if (proc.process.exitCode !== null) {
-    managedProcessRegistry.delete(proc);
-    return;
-  }
-
-  const pid = proc.process.pid;
-  let signaled = false;
-  if (typeof pid === "number" && pid > 0) {
-    try {
-      process.kill(-pid, "SIGTERM");
-      signaled = true;
-    } catch {
-      signaled = false;
-    }
-  }
-  if (!signaled) {
-    try {
-      proc.process.kill("SIGTERM");
-    } catch {
-      managedProcessRegistry.delete(proc);
-      return;
-    }
-  }
-  const deadline = Date.now() + 5_000;
-  while (Date.now() < deadline) {
-    if (proc.process.exitCode !== null) {
-      managedProcessRegistry.delete(proc);
-      return;
-    }
-    await sleep(100);
-  }
-  if (typeof pid === "number" && pid > 0) {
-    try {
-      process.kill(-pid, "SIGKILL");
-      managedProcessRegistry.delete(proc);
-      return;
-    } catch {
-      // Fallback to direct child kill if process groups are unavailable.
-    }
-  }
-  try {
-    proc.process.kill("SIGKILL");
-  } catch {
-    // Process may have already exited between checks.
-  }
-  managedProcessRegistry.delete(proc);
-}
-
-async function stopAllManagedProcesses(): Promise<void> {
-  for (const proc of Array.from(managedProcessRegistry).reverse()) {
-    await stopManagedProcess(proc);
-  }
-}
-
-function installManagedProcessSignalHandlers(): void {
-  const handleSignal = (signal: NodeJS.Signals) => {
-    if (shutdownInProgress) {
-      return;
-    }
-    shutdownInProgress = true;
-    void (async () => {
-      console.error(
-        `[credit-full-lifecycle-e2e] Received ${signal}; stopping managed processes...`,
-      );
-      await stopAllManagedProcesses();
-      process.exit(signal === "SIGINT" ? 130 : 143);
-    })();
-  };
-
-  process.once("SIGINT", () => handleSignal("SIGINT"));
-  process.once("SIGTERM", () => handleSignal("SIGTERM"));
-}
-
-async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    try {
-      const response = await fetch(url);
-      if (response.ok) {
-        return;
-      }
-    } catch {
-      // Keep retrying while the service boots.
-    }
-    await sleep(500);
-  }
-  throw new Error(`Timed out waiting for health endpoint: ${url}`);
-}
-
-async function waitForLog(
-  proc: ManagedProcess,
-  expected: string,
-  timeoutMs: number,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    if (proc.getLogs().includes(expected)) {
-      return;
-    }
-    if (proc.process.exitCode !== null) {
-      throw new Error(
-        `Process ${proc.name} exited before logging "${expected}" (exit=${proc.process.exitCode})`,
-      );
-    }
-    await sleep(250);
-  }
-  throw new Error(
-    `Timed out waiting for ${proc.name} log "${expected}". Recent logs:\n${proc
-      .getLogs()
-      .slice(-4000)}`,
-  );
 }
 
 function parseTopupBridgeSubmissions(logs: string): TopupBridgeSubmission[] {
@@ -2636,7 +2461,7 @@ function writeStep8Summary(summaryPath: string, runDir: string): void {
 }
 
 async function main(): Promise<void> {
-  installManagedProcessSignalHandlers();
+  installManagedProcessSignalHandlers("credit-full-lifecycle-e2e");
   if (process.argv.includes("--help") || process.argv.includes("-h")) {
     printHelp();
     return;


### PR DESCRIPTION
## Summary
- Extract ~170 lines of identical process lifecycle code from 3 service scripts into `scripts/common/managed-process.ts`
- Shared module exports: `ManagedProcess` type, `sleep`, `startManagedProcess`, `stopManagedProcess`, `stopAllManagedProcesses`, `installManagedProcessSignalHandlers`, `waitForNodeReady`, `waitForHealth`, `waitForLog`
- Parameterize `installManagedProcessSignalHandlers` with a `logPrefix` string (the only difference across files)
- Remove `node:child_process` and `waitForNode` imports from consumer files (now encapsulated in shared module)
- Net reduction of ~334 lines (563 deleted, 229 added)