### PR TITLE
fix: bump pino in external-deps to ^10.3.1 to match services

### DIFF
--- a/services/external-deps.json
+++ b/services/external-deps.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@aztec/bb.js": "4.0.0-devnet.2-patch.2",
-    "pino": "^9.0.0",
+    "pino": "^10.3.1",
     "pino-pretty": "^13.1.3"
   }
 }


### PR DESCRIPTION
## Summary
- `external-deps.json` specified pino `^9.0.0` but both attestation and topup services depend on pino `^10.3.1`
- Since services mark pino as `--external` in their bun build, the Docker runtime stage installs from `external-deps.json`, causing a major version mismatch and potential runtime crash
- Bumped to `^10.3.1` to align with service dependencies; `pino-pretty ^13.1.3` is already compatible