### PR TITLE
ci: standardize actions/checkout to v6 across all workflows

### DIFF
--- a/.github/workflows/build-contract.yml
+++ b/.github/workflows/build-contract.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/docker-build-services.yml
+++ b/.github/workflows/docker-build-services.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/fpc-benchmark.yml
+++ b/.github/workflows/fpc-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive

--- a/.github/workflows/spec-credit-fpc-smoke.yml
+++ b/.github/workflows/spec-credit-fpc-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/spec-deploy-smoke.yml
+++ b/.github/workflows/spec-deploy-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/spec-fee-entrypoint-smoke.yml
+++ b/.github/workflows/spec-fee-entrypoint-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/spec-services-smoke.yml
+++ b/.github/workflows/spec-services-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v6 in 8 workflow files for consistency
- `docker-build-ci.yml` and `ts-packages.yml` were already on v6, no changes needed
- Vendored workflows under `vendor/` left untouched