### PR TITLE
refactor: merge FPC/CreditFPC into single configurable FPC contract

### DIFF
--- a/scripts/contract/deploy-fpc-devnet.sh
+++ b/scripts/contract/deploy-fpc-devnet.sh
@@ -36,9 +36,11 @@ if [[ -z "${OPERATOR_SECRET_KEY}" && -z "${OPERATOR_SECRET_KEY_REF}" ]]; then
   echo "WARN: No operator key provided. Using deployer key as operator key for devnet." >&2
 fi
 
+FPC_ARTIFACT="${FPC_DEVNET_FPC_ARTIFACT:-target/fpc-FPC.json}"
+
 cd "${REPO_ROOT}"
 
-if [[ ! -f target/token_contract-Token.json || ! -f target/fpc-FPC.json || ! -f target/credit_fpc-CreditFPC.json ]]; then
+if [[ ! -f target/token_contract-Token.json || ! -f "${FPC_ARTIFACT}" ]]; then
   echo "Compiling Aztec workspace artifacts..."
   aztec compile --workspace --force
 fi
@@ -48,6 +50,7 @@ cmd=(
   --node-url "${NODE_URL}"
   --sponsored-fpc-address "${SPONSORED_FPC_ADDRESS}"
   --deployer-alias "${DEPLOYER_ALIAS}"
+  --fpc-artifact "${FPC_ARTIFACT}"
   --out "${OUT_PATH}"
 )
 

--- a/scripts/contract/deploy-fpc-devnet.ts
+++ b/scripts/contract/deploy-fpc-devnet.ts
@@ -16,6 +16,7 @@ type CliArgs = {
   operatorSecretKey: string | null;
   operatorSecretKeyRef: string | null;
   acceptedAsset: string | null;
+  fpcArtifact: string;
   out: string;
   preflightOnly: boolean;
 };
@@ -121,10 +122,9 @@ const WALLET_SPONSORED_FPC_ALIAS = "sponsoredfpc";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const DEFAULT_FPC_ARTIFACT = path.join(REPO_ROOT, "target", "fpc-FPC.json");
 const REQUIRED_ARTIFACTS = {
   token: path.join(REPO_ROOT, "target", "token_contract-Token.json"),
-  fpc: path.join(REPO_ROOT, "target", "fpc-FPC.json"),
-  creditFpc: path.join(REPO_ROOT, "target", "credit_fpc-CreditFPC.json"),
 } as const;
 
 class CliError extends Error {
@@ -147,13 +147,15 @@ function usage(): string {
     "    [--l1-rpc-url <url>] \\",
     "    [--validate-topup-path] \\",
     "    [--accepted-asset <aztec_address>] \\",
+    "    [--fpc-artifact <path>] \\",
     "    [--preflight-only]",
     "",
     "Notes:",
     "  - --l1-rpc-url is optional for deployment-only preflight.",
     "  - --validate-topup-path requires --l1-rpc-url and enforces L1 chain-id matching.",
     "  - In preflight mode, the script may register missing wallet aliases but sends no contract deploy txs.",
-    "  - Without --preflight-only, the script deploys Token (unless --accepted-asset is provided), FPC, and CreditFPC and writes a validated manifest.",
+    "  - --fpc-artifact selects the compiled FPC artifact to deploy (default: target/fpc-FPC.json).",
+    "  - Without --preflight-only, the script deploys Token (unless --accepted-asset is provided) and the FPC contract, then writes a validated manifest.",
   ].join("\n");
 }
 
@@ -248,6 +250,8 @@ function parseCliArgs(argv: string[]): CliParseResult {
     process.env.FPC_DEVNET_OPERATOR_SECRET_KEY_REF ?? null;
   let acceptedAsset: string | null =
     process.env.FPC_DEVNET_ACCEPTED_ASSET ?? null;
+  let fpcArtifact: string =
+    process.env.FPC_DEVNET_FPC_ARTIFACT ?? DEFAULT_FPC_ARTIFACT;
   let out: string | null = process.env.FPC_DEVNET_OUT ?? null;
   let preflightOnly = false;
 
@@ -291,6 +295,10 @@ function parseCliArgs(argv: string[]): CliParseResult {
         break;
       case "--accepted-asset":
         acceptedAsset = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--fpc-artifact":
+        fpcArtifact = nextArg(argv, i, arg);
         i += 1;
         break;
       case "--out":
@@ -366,6 +374,7 @@ function parseCliArgs(argv: string[]): CliParseResult {
       acceptedAsset: acceptedAsset
         ? parseAztecAddress(acceptedAsset, "--accepted-asset")
         : null,
+      fpcArtifact: path.resolve(fpcArtifact),
       out,
       preflightOnly,
     },
@@ -1332,16 +1341,13 @@ async function assertL1RpcReachable(l1RpcUrl: string): Promise<number> {
   }
 }
 
-function assertRequiredArtifactsExist(): void {
+function assertRequiredArtifactsExist(fpcArtifact: string): void {
   const missing: string[] = [];
   if (!existsSync(REQUIRED_ARTIFACTS.token)) {
     missing.push(REQUIRED_ARTIFACTS.token);
   }
-  if (!existsSync(REQUIRED_ARTIFACTS.fpc)) {
-    missing.push(REQUIRED_ARTIFACTS.fpc);
-  }
-  if (!existsSync(REQUIRED_ARTIFACTS.creditFpc)) {
-    missing.push(REQUIRED_ARTIFACTS.creditFpc);
+  if (!existsSync(fpcArtifact)) {
+    missing.push(fpcArtifact);
   }
   if (missing.length > 0) {
     const formatted = missing.map((entry) => `  - ${entry}`).join("\n");
@@ -1374,7 +1380,7 @@ async function main(): Promise<void> {
     `[deploy-fpc-devnet] output_manifest_path=${path.resolve(args.out)}`,
   );
 
-  assertRequiredArtifactsExist();
+  assertRequiredArtifactsExist(args.fpcArtifact);
   console.log("[deploy-fpc-devnet] artifact preflight passed");
 
   const nodeState = await assertAztecNodePreflight(args.nodeUrl);
@@ -1478,7 +1484,7 @@ async function main(): Promise<void> {
     nodeUrl: args.nodeUrl,
     fromAlias: deployer.walletAlias,
     sponsoredFpcAddress: args.sponsoredFpcAddress,
-    artifactPath: REQUIRED_ARTIFACTS.fpc,
+    artifactPath: args.fpcArtifact,
     alias: `devnet-fpc-${aliasSuffix}`,
     constructorArgs: [
       operatorIdentity.address,
@@ -1490,25 +1496,6 @@ async function main(): Promise<void> {
   });
   console.log(
     `[deploy-fpc-devnet] fpc deployed. address=${fpcDeploy.address} tx_hash=${fpcDeploy.txHash}`,
-  );
-
-  console.log("[deploy-fpc-devnet] deploying CreditFPC contract");
-  const creditFpcDeploy = await deployContractWithAztecWallet({
-    nodeUrl: args.nodeUrl,
-    fromAlias: deployer.walletAlias,
-    sponsoredFpcAddress: args.sponsoredFpcAddress,
-    artifactPath: REQUIRED_ARTIFACTS.creditFpc,
-    alias: `devnet-credit-fpc-${aliasSuffix}`,
-    constructorArgs: [
-      operatorIdentity.address,
-      operatorIdentity.pubkeyX,
-      operatorIdentity.pubkeyY,
-      acceptedAssetAddress,
-    ],
-    context: "CreditFPC",
-  });
-  console.log(
-    `[deploy-fpc-devnet] credit_fpc deployed. address=${creditFpcDeploy.address} tx_hash=${creditFpcDeploy.txHash}`,
   );
 
   const manifest = writeDevnetDeployManifest(args.out, {
@@ -1553,7 +1540,6 @@ async function main(): Promise<void> {
     contracts: {
       accepted_asset: acceptedAssetAddress,
       fpc: fpcDeploy.address,
-      credit_fpc: creditFpcDeploy.address,
     },
     operator: {
       address: operatorIdentity.address,
@@ -1563,7 +1549,6 @@ async function main(): Promise<void> {
     tx_hashes: {
       accepted_asset_deploy: acceptedAssetDeployTxHash,
       fpc_deploy: fpcDeploy.txHash,
-      credit_fpc_deploy: creditFpcDeploy.txHash,
     },
     payment_mode: paymentMode,
   });
@@ -1572,7 +1557,7 @@ async function main(): Promise<void> {
     `[deploy-fpc-devnet] deployment completed. wrote manifest to ${path.resolve(args.out)}`,
   );
   console.log(
-    `[deploy-fpc-devnet] output contracts: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} credit_fpc=${manifest.contracts.credit_fpc}`,
+    `[deploy-fpc-devnet] output contracts: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc}`,
   );
 }
 

--- a/scripts/contract/devnet-manifest.ts
+++ b/scripts/contract/devnet-manifest.ts
@@ -55,7 +55,6 @@ export type DevnetDeployManifest = {
   contracts: {
     accepted_asset: string;
     fpc: string;
-    credit_fpc: string;
   };
   operator: {
     address: string;
@@ -65,7 +64,6 @@ export type DevnetDeployManifest = {
   tx_hashes: {
     accepted_asset_deploy: string | null;
     fpc_deploy: string | null;
-    credit_fpc_deploy: string | null;
   };
   payment_mode?: string;
 };
@@ -76,7 +74,6 @@ export type LegacyDeployOutputCompat = {
   operator_address: string;
   accepted_asset: string;
   fpc_address: string;
-  credit_fpc_address: string;
   node_contracts: {
     fee_juice_portal_address: string;
     fee_juice_address: string;
@@ -87,10 +84,6 @@ export type LegacyDeployOutputCompat = {
       source: "deployed" | "provided" | "reused";
     };
     fpc: {
-      address: string;
-      source: "deployed" | "reused";
-    };
-    credit_fpc: {
       address: string;
       source: "deployed" | "reused";
     };
@@ -494,10 +487,6 @@ function parseManifest(input: unknown): DevnetDeployManifest {
       requireString(contractsRaw, "fpc", "manifest.contracts"),
       "manifest.contracts.fpc",
     ),
-    credit_fpc: parseAztecAddress(
-      requireString(contractsRaw, "credit_fpc", "manifest.contracts"),
-      "manifest.contracts.credit_fpc",
-    ),
   };
 
   const operatorRaw = requireObject(input, "operator", "manifest");
@@ -525,10 +514,6 @@ function parseManifest(input: unknown): DevnetDeployManifest {
     fpc_deploy: parseTxHashOrNull(
       txHashesRaw.fpc_deploy,
       "manifest.tx_hashes.fpc_deploy",
-    ),
-    credit_fpc_deploy: parseTxHashOrNull(
-      txHashesRaw.credit_fpc_deploy,
-      "manifest.tx_hashes.credit_fpc_deploy",
     ),
   };
 
@@ -589,7 +574,6 @@ export function withLegacyDeployCompat(
     operator_address: manifest.operator.address,
     accepted_asset: manifest.contracts.accepted_asset,
     fpc_address: manifest.contracts.fpc,
-    credit_fpc_address: manifest.contracts.credit_fpc,
     node_contracts: {
       fee_juice_portal_address:
         manifest.aztec_required_addresses.l1_contract_addresses
@@ -605,10 +589,6 @@ export function withLegacyDeployCompat(
       fpc: {
         address: manifest.contracts.fpc,
         source: inferContractDeploySource(manifest.tx_hashes.fpc_deploy),
-      },
-      credit_fpc: {
-        address: manifest.contracts.credit_fpc,
-        source: inferContractDeploySource(manifest.tx_hashes.credit_fpc_deploy),
       },
     },
   };
@@ -685,8 +665,6 @@ function buildSelfCheckFixture(): DevnetDeployManifest {
       accepted_asset:
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       fpc: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-      credit_fpc:
-        "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
     },
     operator: {
       address:
@@ -699,8 +677,6 @@ function buildSelfCheckFixture(): DevnetDeployManifest {
         "0x1111111111111111111111111111111111111111111111111111111111111111",
       fpc_deploy:
         "0x2222222222222222222222222222222222222222222222222222222222222222",
-      credit_fpc_deploy:
-        "0x3333333333333333333333333333333333333333333333333333333333333333",
     },
     payment_mode: "fpc-sponsored",
   };

--- a/scripts/contract/devnet-postdeploy-smoke.ts
+++ b/scripts/contract/devnet-postdeploy-smoke.ts
@@ -9,6 +9,7 @@ import {
 
 type CliArgs = {
   manifestPath: string;
+  fpcArtifact: string;
   l1RpcUrl: string;
   operatorSecretKey: string | null;
   l1OperatorPrivateKey: string | null;
@@ -180,6 +181,7 @@ const DEFAULT_MANIFEST_PATH = path.join(
   "deployments",
   "devnet-manifest-v2.json",
 );
+const DEFAULT_FPC_ARTIFACT = path.join(REPO_ROOT, "target", "fpc-FPC.json");
 const DEFAULT_LOCAL_L1_PRIVATE_KEY =
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const HEX_32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
@@ -192,6 +194,7 @@ function usage(): string {
     "Usage:",
     "  bunx tsx scripts/contract/devnet-postdeploy-smoke.ts \\",
     "    [--manifest <path.json>] \\",
+    "    [--fpc-artifact <path.json>] \\",
     "    [--l1-rpc-url <http(s)-url>] \\",
     "    [--operator-secret-key <hex32>] \\",
     "    [--l1-operator-private-key <hex32>] \\",
@@ -214,6 +217,7 @@ function usage(): string {
     "",
     "Defaults:",
     `  --manifest ${DEFAULT_MANIFEST_PATH}`,
+    `  --fpc-artifact ${DEFAULT_FPC_ARTIFACT}`,
     "  --node-ready-timeout-ms 45000",
     "  --bridge-wait-timeout-ms 240000",
     "  --bridge-poll-ms 2000",
@@ -231,6 +235,7 @@ function usage(): string {
     "",
     "Environment fallbacks:",
     "  FPC_DEVNET_SMOKE_MANIFEST",
+    "  FPC_DEVNET_SMOKE_FPC_ARTIFACT",
     "  FPC_DEVNET_L1_RPC_URL (or L1_RPC_URL)",
     "  FPC_DEVNET_OPERATOR_SECRET_KEY",
     "  L1_OPERATOR_PRIVATE_KEY",
@@ -309,6 +314,8 @@ function parseHex32(value: string, fieldName: string): string {
 function parseCliArgs(argv: string[]): CliParseResult {
   let manifestPath =
     readEnvString("FPC_DEVNET_SMOKE_MANIFEST") ?? DEFAULT_MANIFEST_PATH;
+  let fpcArtifact =
+    readEnvString("FPC_DEVNET_SMOKE_FPC_ARTIFACT") ?? DEFAULT_FPC_ARTIFACT;
   let l1RpcUrlRaw =
     readEnvString("FPC_DEVNET_L1_RPC_URL") ??
     readEnvString("L1_RPC_URL") ??
@@ -382,6 +389,10 @@ function parseCliArgs(argv: string[]): CliParseResult {
     switch (arg) {
       case "--manifest":
         manifestPath = path.resolve(nextArg(argv, i, arg));
+        i += 1;
+        break;
+      case "--fpc-artifact":
+        fpcArtifact = path.resolve(nextArg(argv, i, arg));
         i += 1;
         break;
       case "--l1-rpc-url":
@@ -485,6 +496,7 @@ function parseCliArgs(argv: string[]): CliParseResult {
     kind: "args",
     args: {
       manifestPath: path.resolve(manifestPath),
+      fpcArtifact: path.resolve(fpcArtifact),
       l1RpcUrl: parseHttpUrl(l1RpcUrlRaw, "l1-rpc-url"),
       operatorSecretKey: operatorSecretKey
         ? parseHex32(operatorSecretKey, "operator-secret-key")
@@ -692,6 +704,35 @@ function loadArtifact(deps: AztecDeps, artifactPath: string): unknown {
     }
     throw error;
   }
+}
+
+function readContractNameFromArtifact(artifactPath: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(artifactPath, "utf8");
+  } catch {
+    throw new CliError(`Failed to read artifact at ${artifactPath}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliError(`Artifact at ${artifactPath} is not valid JSON`);
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new CliError(`Artifact at ${artifactPath} is not a JSON object`);
+  }
+
+  const name = (parsed as Record<string, unknown>).name;
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw new CliError(
+      `Artifact at ${artifactPath} does not contain a non-empty "name" field`,
+    );
+  }
+
+  return name;
 }
 
 function fieldStringToBigInt(value: string, fieldName: string): bigint {
@@ -1051,14 +1092,8 @@ async function runSmoke(args: CliArgs): Promise<void> {
     deps,
     path.join(REPO_ROOT, "target", "token_contract-Token.json"),
   );
-  const fpcArtifact = loadArtifact(
-    deps,
-    path.join(REPO_ROOT, "target", "fpc-FPC.json"),
-  );
-  const creditFpcArtifact = loadArtifact(
-    deps,
-    path.join(REPO_ROOT, "target", "credit_fpc-CreditFPC.json"),
-  );
+  const fpcArtifact = loadArtifact(deps, args.fpcArtifact);
+  const contractName = readContractNameFromArtifact(args.fpcArtifact);
 
   const token = deps.Contract.at(
     deps.AztecAddress.fromString(manifest.contracts.accepted_asset),
@@ -1070,11 +1105,6 @@ async function runSmoke(args: CliArgs): Promise<void> {
     fpcArtifact,
     wallet,
   );
-  const creditFpc = deps.Contract.at(
-    deps.AztecAddress.fromString(manifest.contracts.credit_fpc),
-    creditFpcArtifact,
-    wallet,
-  );
 
   const minFees = await node.getCurrentMinFees();
   const feePerDaGas = minFees.feePerDaGas as bigint;
@@ -1083,23 +1113,17 @@ async function runSmoke(args: CliArgs): Promise<void> {
     BigInt(args.daGasLimit) * feePerDaGas +
     BigInt(args.l2GasLimit) * feePerL2Gas;
 
-  const fpcMinTopup =
-    maxGasCostNoTeardown * args.topupSafetyMultiplier + 1_000_000n;
-  const creditMinTopup =
-    maxGasCostNoTeardown * args.topupSafetyMultiplier * 2n + 1_000_000n;
-  const fpcTopupAmount = args.fpcTopupWeiOverride ?? fpcMinTopup;
-  const creditTopupAmount = args.creditTopupWeiOverride ?? creditMinTopup;
-  if (args.fpcTopupWeiOverride && args.fpcTopupWeiOverride < fpcMinTopup) {
+  const txCount = contractName === "CreditFPC" ? 2n : 1n;
+  const minTopup =
+    maxGasCostNoTeardown * args.topupSafetyMultiplier * txCount + 1_000_000n;
+  const topupOverride =
+    contractName === "CreditFPC"
+      ? args.creditTopupWeiOverride
+      : args.fpcTopupWeiOverride;
+  const topupAmount = topupOverride ?? minTopup;
+  if (topupOverride && topupOverride < minTopup) {
     throw new CliError(
-      `fpc-topup-wei override is below minimum ${fpcMinTopup.toString()}`,
-    );
-  }
-  if (
-    args.creditTopupWeiOverride &&
-    args.creditTopupWeiOverride < creditMinTopup
-  ) {
-    throw new CliError(
-      `credit-topup-wei override is below minimum ${creditMinTopup.toString()}`,
+      `topup-wei override is below minimum ${minTopup.toString()}`,
     );
   }
 
@@ -1107,13 +1131,11 @@ async function runSmoke(args: CliArgs): Promise<void> {
     `[devnet-postdeploy-smoke] manifest=${args.manifestPath} node_url=${manifest.network.node_url}`,
   );
   console.log(
-    `[devnet-postdeploy-smoke] contracts accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} credit_fpc=${manifest.contracts.credit_fpc}`,
+    `[devnet-postdeploy-smoke] contracts accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} fpc_contract_name=${contractName}`,
   );
-  console.log(
-    `[devnet-postdeploy-smoke] topup targets fpc=${fpcTopupAmount} credit_fpc=${creditTopupAmount}`,
-  );
+  console.log(`[devnet-postdeploy-smoke] topup target=${topupAmount}`);
 
-  const fpcFeeJuiceBalance = await topUpFeePayer({
+  const feeJuiceBalance = await topUpFeePayer({
     deps,
     args,
     node,
@@ -1123,277 +1145,251 @@ async function runSmoke(args: CliArgs): Promise<void> {
     l1PublicClient,
     l1WalletClient,
     feePayerAddress: fpc.address,
-    amount: fpcTopupAmount,
-    label: "fpc",
+    amount: topupAmount,
+    label: contractName,
   });
   console.log(
-    `[devnet-postdeploy-smoke] fpc_fee_juice_balance=${fpcFeeJuiceBalance}`,
-  );
-
-  const creditFeeJuiceBalance = await topUpFeePayer({
-    deps,
-    args,
-    node,
-    wallet,
-    operatorAddress,
-    token,
-    l1PublicClient,
-    l1WalletClient,
-    feePayerAddress: creditFpc.address,
-    amount: creditTopupAmount,
-    label: "credit_fpc",
-  });
-  console.log(
-    `[devnet-postdeploy-smoke] credit_fpc_fee_juice_balance=${creditFeeJuiceBalance}`,
+    `[devnet-postdeploy-smoke] fpc_fee_juice_balance=${feeJuiceBalance}`,
   );
 
   const QUOTE_DOMAIN_SEPARATOR = deps.Fr.fromHexString("0x465043");
 
-  const fpcExpectedCharge = ceilDiv(
-    maxGasCostNoTeardown * args.fpcRateNum,
-    args.fpcRateDen,
-  );
-  const fpcFjAmount = maxGasCostNoTeardown;
-  const fpcAaAmount = fpcExpectedCharge;
-  await token.methods
-    .mint_to_private(operatorAddress, fpcExpectedCharge + 1_000_000n)
-    .send({ from: operatorAddress, wait: { timeout: 180 } });
-  await token.methods
-    .mint_to_public(operatorAddress, 2n)
-    .send({ from: operatorAddress, wait: { timeout: 180 } });
+  if (contractName === "FPC") {
+    const fpcExpectedCharge = ceilDiv(
+      maxGasCostNoTeardown * args.fpcRateNum,
+      args.fpcRateDen,
+    );
+    const fpcFjAmount = maxGasCostNoTeardown;
+    const fpcAaAmount = fpcExpectedCharge;
+    await token.methods
+      .mint_to_private(operatorAddress, fpcExpectedCharge + 1_000_000n)
+      .send({ from: operatorAddress, wait: { timeout: 180 } });
+    await token.methods
+      .mint_to_public(operatorAddress, 2n)
+      .send({ from: operatorAddress, wait: { timeout: 180 } });
 
-  const latestFpcBlock = await node.getBlock("latest");
-  if (!latestFpcBlock) {
-    throw new Error("Could not read latest block while creating FPC quote");
-  }
-  const fpcValidUntil = latestFpcBlock.timestamp + args.quoteTtlSeconds;
-  const fpcQuoteHash = await deps.computeInnerAuthWitHash([
-    QUOTE_DOMAIN_SEPARATOR,
-    fpc.address.toField(),
-    token.address.toField(),
-    new deps.Fr(fpcFjAmount),
-    new deps.Fr(fpcAaAmount),
-    new deps.Fr(fpcValidUntil),
-    operatorAddress.toField(),
-  ]);
-  const fpcQuoteSig = await schnorr.constructSignature(
-    fpcQuoteHash.toBuffer(),
-    operatorSigningKey,
-  );
-  const fpcQuoteSigBytes = Array.from(fpcQuoteSig.toBuffer());
-  const fpcAuthwitNonce = deps.Fr.random();
-  const fpcTransferCall = token.methods.transfer_private_to_private(
-    operatorAddress,
-    operatorAddress,
-    fpcAaAmount,
-    fpcAuthwitNonce,
-  );
-  const fpcTransferAuthwit = await wallet.createAuthWit(operatorAddress, {
-    caller: fpc.address,
-    action: fpcTransferCall,
-  });
-  const fpcFeeEntrypointCall = await fpc.methods
-    .fee_entrypoint(
-      fpcAuthwitNonce,
-      fpcFjAmount,
+    const latestBlock = await node.getBlock("latest");
+    if (!latestBlock) {
+      throw new Error("Could not read latest block while creating FPC quote");
+    }
+    const fpcValidUntil = latestBlock.timestamp + args.quoteTtlSeconds;
+    const fpcQuoteHash = await deps.computeInnerAuthWitHash([
+      QUOTE_DOMAIN_SEPARATOR,
+      fpc.address.toField(),
+      token.address.toField(),
+      new deps.Fr(fpcFjAmount),
+      new deps.Fr(fpcAaAmount),
+      new deps.Fr(fpcValidUntil),
+      operatorAddress.toField(),
+    ]);
+    const fpcQuoteSig = await schnorr.constructSignature(
+      fpcQuoteHash.toBuffer(),
+      operatorSigningKey,
+    );
+    const fpcQuoteSigBytes = Array.from(fpcQuoteSig.toBuffer());
+    const fpcAuthwitNonce = deps.Fr.random();
+    const fpcTransferCall = token.methods.transfer_private_to_private(
+      operatorAddress,
+      operatorAddress,
       fpcAaAmount,
-      fpcValidUntil,
-      fpcQuoteSigBytes,
-    )
-    .getFunctionCall();
-  const fpcPaymentMethod = {
-    getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
-    getExecutionPayload: async () =>
-      new deps.ExecutionPayload(
-        [fpcFeeEntrypointCall],
-        [fpcTransferAuthwit],
-        [],
-        [],
-        fpc.address,
-      ),
-    getFeePayer: async () => fpc.address,
-    getGasSettings: () => undefined,
-  };
-  const fpcReceipt = await token.methods
-    .transfer_public_to_public(
-      operatorAddress,
-      operatorAddress,
-      1n,
-      deps.Fr.random(),
-    )
-    .send({
-      from: operatorAddress,
-      fee: {
-        paymentMethod: fpcPaymentMethod,
-        gasSettings: {
-          gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
-          maxFeesPerGas: { feePerDaGas, feePerL2Gas },
-        },
-      },
-      wait: { timeout: 180 },
-    });
-  console.log(
-    `[devnet-postdeploy-smoke] fpc_fee_path_tx_fee_juice=${fpcReceipt.transactionFee} expected_charge=${fpcExpectedCharge}`,
-  );
-
-  const creditMintAmount =
-    maxGasCostNoTeardown * args.creditMintMultiplier + args.creditMintBuffer;
-  const creditExpectedCharge = ceilDiv(
-    creditMintAmount * args.creditRateNum,
-    args.creditRateDen,
-  );
-  const creditFjAmount = creditMintAmount;
-  const creditAaAmount = creditExpectedCharge;
-  await token.methods
-    .mint_to_private(operatorAddress, creditExpectedCharge + 1_000_000n)
-    .send({ from: operatorAddress, wait: { timeout: 180 } });
-  await token.methods
-    .mint_to_public(operatorAddress, 2n)
-    .send({ from: operatorAddress, wait: { timeout: 180 } });
-
-  const latestCreditBlock = await node.getBlock("latest");
-  if (!latestCreditBlock) {
-    throw new Error(
-      "Could not read latest block while creating CreditFPC quote",
+      fpcAuthwitNonce,
     );
-  }
-  const creditValidUntil = latestCreditBlock.timestamp + args.quoteTtlSeconds;
-  const creditQuoteHash = await deps.computeInnerAuthWitHash([
-    QUOTE_DOMAIN_SEPARATOR,
-    creditFpc.address.toField(),
-    token.address.toField(),
-    new deps.Fr(creditFjAmount),
-    new deps.Fr(creditAaAmount),
-    new deps.Fr(creditValidUntil),
-    operatorAddress.toField(),
-  ]);
-  const creditQuoteSig = await schnorr.constructSignature(
-    creditQuoteHash.toBuffer(),
-    operatorSigningKey,
-  );
-  const creditQuoteSigBytes = Array.from(creditQuoteSig.toBuffer());
-  const creditAuthwitNonce = deps.Fr.random();
-  const creditTransferCall = token.methods.transfer_private_to_private(
-    operatorAddress,
-    operatorAddress,
-    creditAaAmount,
-    creditAuthwitNonce,
-  );
-  const creditTransferAuthwit = await wallet.createAuthWit(operatorAddress, {
-    caller: creditFpc.address,
-    action: creditTransferCall,
-  });
-  const payAndMintCall = await creditFpc.methods
-    .pay_and_mint(
-      creditAuthwitNonce,
-      creditFjAmount,
+    const fpcTransferAuthwit = await wallet.createAuthWit(operatorAddress, {
+      caller: fpc.address,
+      action: fpcTransferCall,
+    });
+    const fpcFeeEntrypointCall = await fpc.methods
+      .fee_entrypoint(
+        fpcAuthwitNonce,
+        fpcFjAmount,
+        fpcAaAmount,
+        fpcValidUntil,
+        fpcQuoteSigBytes,
+      )
+      .getFunctionCall();
+    const fpcPaymentMethod = {
+      getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
+      getExecutionPayload: async () =>
+        new deps.ExecutionPayload(
+          [fpcFeeEntrypointCall],
+          [fpcTransferAuthwit],
+          [],
+          [],
+          fpc.address,
+        ),
+      getFeePayer: async () => fpc.address,
+      getGasSettings: () => undefined,
+    };
+    const fpcReceipt = await token.methods
+      .transfer_public_to_public(
+        operatorAddress,
+        operatorAddress,
+        1n,
+        deps.Fr.random(),
+      )
+      .send({
+        from: operatorAddress,
+        fee: {
+          paymentMethod: fpcPaymentMethod,
+          gasSettings: {
+            gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
+            maxFeesPerGas: { feePerDaGas, feePerL2Gas },
+          },
+        },
+        wait: { timeout: 180 },
+      });
+    console.log(
+      `[devnet-postdeploy-smoke] fpc_fee_path_tx_fee_juice=${fpcReceipt.transactionFee} expected_charge=${fpcExpectedCharge}`,
+    );
+    console.log(`[devnet-postdeploy-smoke] PASS variant=FPC successful_txs=1`);
+  } else if (contractName === "CreditFPC") {
+    const creditMintAmount =
+      maxGasCostNoTeardown * args.creditMintMultiplier + args.creditMintBuffer;
+    const creditExpectedCharge = ceilDiv(
+      creditMintAmount * args.creditRateNum,
+      args.creditRateDen,
+    );
+    const creditFjAmount = creditMintAmount;
+    const creditAaAmount = creditExpectedCharge;
+    await token.methods
+      .mint_to_private(operatorAddress, creditExpectedCharge + 1_000_000n)
+      .send({ from: operatorAddress, wait: { timeout: 180 } });
+    await token.methods
+      .mint_to_public(operatorAddress, 2n)
+      .send({ from: operatorAddress, wait: { timeout: 180 } });
+
+    const latestBlock = await node.getBlock("latest");
+    if (!latestBlock) {
+      throw new Error(
+        "Could not read latest block while creating CreditFPC quote",
+      );
+    }
+    const creditValidUntil = latestBlock.timestamp + args.quoteTtlSeconds;
+    const creditQuoteHash = await deps.computeInnerAuthWitHash([
+      QUOTE_DOMAIN_SEPARATOR,
+      fpc.address.toField(),
+      token.address.toField(),
+      new deps.Fr(creditFjAmount),
+      new deps.Fr(creditAaAmount),
+      new deps.Fr(creditValidUntil),
+      operatorAddress.toField(),
+    ]);
+    const creditQuoteSig = await schnorr.constructSignature(
+      creditQuoteHash.toBuffer(),
+      operatorSigningKey,
+    );
+    const creditQuoteSigBytes = Array.from(creditQuoteSig.toBuffer());
+    const creditAuthwitNonce = deps.Fr.random();
+    const creditTransferCall = token.methods.transfer_private_to_private(
+      operatorAddress,
+      operatorAddress,
       creditAaAmount,
-      creditValidUntil,
-      creditQuoteSigBytes,
-    )
-    .getFunctionCall();
-  const creditPayAndMintMethod = {
-    getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
-    getExecutionPayload: async () =>
-      new deps.ExecutionPayload(
-        [payAndMintCall],
-        [creditTransferAuthwit],
-        [],
-        [],
-        creditFpc.address,
-      ),
-    getFeePayer: async () => creditFpc.address,
-    getGasSettings: () => undefined,
-  };
-  const payAndMintReceipt = await token.methods
-    .transfer_public_to_public(
-      operatorAddress,
-      operatorAddress,
-      1n,
-      deps.Fr.random(),
-    )
-    .send({
-      from: operatorAddress,
-      fee: {
-        paymentMethod: creditPayAndMintMethod,
-        gasSettings: {
-          gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
-          maxFeesPerGas: { feePerDaGas, feePerL2Gas },
-        },
-      },
-      wait: { timeout: 180 },
-    });
-  console.log(
-    `[devnet-postdeploy-smoke] credit_pay_and_mint_tx_fee_juice=${payAndMintReceipt.transactionFee}`,
-  );
-
-  const creditBefore = BigInt(
-    (
-      await creditFpc.methods
-        .balance_of(operatorAddress)
-        .simulate({ from: operatorAddress })
-    ).toString(),
-  );
-  const payWithCreditCall = await creditFpc.methods
-    .pay_with_credit()
-    .getFunctionCall();
-  const creditPayWithCreditMethod = {
-    getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
-    getExecutionPayload: async () =>
-      new deps.ExecutionPayload(
-        [payWithCreditCall],
-        [],
-        [],
-        [],
-        creditFpc.address,
-      ),
-    getFeePayer: async () => creditFpc.address,
-    getGasSettings: () => undefined,
-  };
-  const payWithCreditReceipt = await token.methods
-    .transfer_public_to_public(
-      operatorAddress,
-      operatorAddress,
-      1n,
-      deps.Fr.random(),
-    )
-    .send({
-      from: operatorAddress,
-      fee: {
-        paymentMethod: creditPayWithCreditMethod,
-        gasSettings: {
-          gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
-          maxFeesPerGas: { feePerDaGas, feePerL2Gas },
-        },
-      },
-      wait: { timeout: 180 },
-    });
-  console.log(
-    `[devnet-postdeploy-smoke] credit_pay_with_credit_tx_fee_juice=${payWithCreditReceipt.transactionFee}`,
-  );
-  const creditAfter = BigInt(
-    (
-      await creditFpc.methods
-        .balance_of(operatorAddress)
-        .simulate({ from: operatorAddress })
-    ).toString(),
-  );
-  if (creditAfter >= creditBefore) {
-    throw new Error(
-      `Credit balance did not decrease after pay_with_credit. before=${creditBefore} after=${creditAfter}`,
+      creditAuthwitNonce,
     );
-  }
-
-  const fpcSuccessfulTxCount = 1;
-  const creditSuccessfulTxCount = 2;
-  if (fpcSuccessfulTxCount < 1 || creditSuccessfulTxCount < 1) {
-    throw new Error(
-      `Invalid smoke tx counts fpc=${fpcSuccessfulTxCount} credit=${creditSuccessfulTxCount}`,
+    const creditTransferAuthwit = await wallet.createAuthWit(operatorAddress, {
+      caller: fpc.address,
+      action: creditTransferCall,
+    });
+    const payAndMintCall = await fpc.methods
+      .pay_and_mint(
+        creditAuthwitNonce,
+        creditFjAmount,
+        creditAaAmount,
+        creditValidUntil,
+        creditQuoteSigBytes,
+      )
+      .getFunctionCall();
+    const creditPayAndMintMethod = {
+      getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
+      getExecutionPayload: async () =>
+        new deps.ExecutionPayload(
+          [payAndMintCall],
+          [creditTransferAuthwit],
+          [],
+          [],
+          fpc.address,
+        ),
+      getFeePayer: async () => fpc.address,
+      getGasSettings: () => undefined,
+    };
+    const payAndMintReceipt = await token.methods
+      .transfer_public_to_public(
+        operatorAddress,
+        operatorAddress,
+        1n,
+        deps.Fr.random(),
+      )
+      .send({
+        from: operatorAddress,
+        fee: {
+          paymentMethod: creditPayAndMintMethod,
+          gasSettings: {
+            gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
+            maxFeesPerGas: { feePerDaGas, feePerL2Gas },
+          },
+        },
+        wait: { timeout: 180 },
+      });
+    console.log(
+      `[devnet-postdeploy-smoke] credit_pay_and_mint_tx_fee_juice=${payAndMintReceipt.transactionFee}`,
     );
+
+    const creditBefore = BigInt(
+      (
+        await fpc.methods
+          .balance_of(operatorAddress)
+          .simulate({ from: operatorAddress })
+      ).toString(),
+    );
+    const payWithCreditCall = await fpc.methods
+      .pay_with_credit()
+      .getFunctionCall();
+    const creditPayWithCreditMethod = {
+      getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
+      getExecutionPayload: async () =>
+        new deps.ExecutionPayload([payWithCreditCall], [], [], [], fpc.address),
+      getFeePayer: async () => fpc.address,
+      getGasSettings: () => undefined,
+    };
+    const payWithCreditReceipt = await token.methods
+      .transfer_public_to_public(
+        operatorAddress,
+        operatorAddress,
+        1n,
+        deps.Fr.random(),
+      )
+      .send({
+        from: operatorAddress,
+        fee: {
+          paymentMethod: creditPayWithCreditMethod,
+          gasSettings: {
+            gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
+            maxFeesPerGas: { feePerDaGas, feePerL2Gas },
+          },
+        },
+        wait: { timeout: 180 },
+      });
+    console.log(
+      `[devnet-postdeploy-smoke] credit_pay_with_credit_tx_fee_juice=${payWithCreditReceipt.transactionFee}`,
+    );
+    const creditAfter = BigInt(
+      (
+        await fpc.methods
+          .balance_of(operatorAddress)
+          .simulate({ from: operatorAddress })
+      ).toString(),
+    );
+    if (creditAfter >= creditBefore) {
+      throw new Error(
+        `Credit balance did not decrease after pay_with_credit. before=${creditBefore} after=${creditAfter}`,
+      );
+    }
+    console.log(
+      `[devnet-postdeploy-smoke] PASS variant=CreditFPC successful_txs=2`,
+    );
+  } else {
+    throw new CliError(`Unsupported FPC contract variant: ${contractName}`);
   }
-  console.log(
-    `[devnet-postdeploy-smoke] PASS fpc_successful_txs=${fpcSuccessfulTxCount} credit_successful_txs=${creditSuccessfulTxCount}`,
-  );
 }
 
 async function main(argv: string[]): Promise<void> {

--- a/scripts/contract/verify-fpc-devnet-deployment.ts
+++ b/scripts/contract/verify-fpc-devnet-deployment.ts
@@ -73,7 +73,7 @@ function usage(): string {
     "  FPC_DEVNET_VERIFY_NODE_READY_TIMEOUT_MS (default: 45000)",
     "",
     "Checks performed:",
-    "  1) Contract existence on node for accepted_asset, fpc, credit_fpc",
+    "  1) Contract existence on node for accepted_asset, fpc",
     "  2) FPC immutable initialization hash verification",
     "  3) Contract instance readiness (published + non-zero initialization hash)",
     "  4) Contract class readiness (class publicly registered)",
@@ -370,10 +370,6 @@ async function verifyAttempt(params: {
       key: "fpc",
       address: manifest.contracts.fpc,
     },
-    {
-      key: "credit_fpc",
-      address: manifest.contracts.credit_fpc,
-    },
   ] as const;
 
   const parsedAddresses = new Map<string, unknown>();
@@ -478,7 +474,7 @@ async function main(): Promise<void> {
   );
   const manifest = readManifestFromDisk(args.manifestPath);
   console.log(
-    `[verify-fpc-devnet] loaded manifest for node=${manifest.network.node_url} fpc=${manifest.contracts.fpc} credit_fpc=${manifest.contracts.credit_fpc}`,
+    `[verify-fpc-devnet] loaded manifest for node=${manifest.network.node_url} fpc=${manifest.contracts.fpc}`,
   );
 
   const deps = await loadAztecDeps();
@@ -529,7 +525,7 @@ async function main(): Promise<void> {
         `[verify-fpc-devnet] verification passed on attempt ${attempt}/${args.maxAttempts}`,
       );
       console.log(
-        `[verify-fpc-devnet] contracts ready: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} credit_fpc=${manifest.contracts.credit_fpc}`,
+        `[verify-fpc-devnet] contracts ready: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc}`,
       );
       return;
     }

--- a/scripts/services/render-config-from-manifest.ts
+++ b/scripts/services/render-config-from-manifest.ts
@@ -776,7 +776,7 @@ function main(argv: string[]): void {
     `[render-config-from-manifest] wrote topup config: ${args.topupOutPath}`,
   );
   console.log(
-    `[render-config-from-manifest] contracts: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} credit_fpc=${manifest.contracts.credit_fpc}`,
+    `[render-config-from-manifest] contracts: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc}`,
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove separate `credit_fpc` address and `credit_fpc_deploy` tx hash from manifest; deploy pipeline now handles a single FPC contract via `contracts.fpc`
- Remove `fpc_contract_name` from manifest — the smoke test derives the variant directly from the artifact
- Add `--fpc-artifact` CLI flag to both `deploy-fpc-devnet.ts` and `devnet-postdeploy-smoke.ts` (default: `target/fpc-FPC.json`)
- Smoke test reads the artifact's `name` field to determine which FPC variant to exercise: `FPC` (fee_entrypoint flow) or `CreditFPC` (pay_and_mint + pay_with_credit flow)
- Collapse dual topup and dual contract instantiation into single FPC path
- Update shell wrapper, verification script, and config renderer to remove CreditFPC references

## Test plan
- [x] `bun run build` passes
- [x] `bunx tsx scripts/contract/devnet-manifest.ts --self-check` passes without `fpc_contract_name`
- [x] `bunx tsx scripts/contract/devnet-postdeploy-smoke.ts --help` shows `--fpc-artifact` in usage
- [ ] End-to-end devnet deploy + smoke test with FPC artifact
- [ ] End-to-end devnet deploy + smoke test with CreditFPC artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)