### PR TITLE
feat(compose): add postdeploy service for post-deploy validation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,7 @@ services:
       FPC_LOCAL_DEPLOYER_PRIVATE_KEY: "${FPC_LOCAL_DEPLOYER_PRIVATE_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_LOCAL_OPERATOR_SECRET_KEY: "${FPC_LOCAL_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_MASTER_CONFIG: "/app/fpc-config.yaml"
+      FPC_LOCAL_OUT: "/app/configs/deploy-manifest.json"
       FPC_CONFIGS_OUT: "/app/configs"
     depends_on:
       aztec-node:
@@ -94,6 +95,22 @@ services:
       L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
       L1_OPERATOR_PRIVATE_KEY: "${L1_OPERATOR_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
       TOPUP_OPS_PORT: "${TOPUP_OPS_PORT:-3001}"
+    depends_on:
+      deploy:
+        condition: service_completed_successfully
+
+  postdeploy:
+    image: nethermind/aztec-fpc-smoke:local
+    profiles: ["postdeploy"]
+    command:
+      - "scripts/contract/devnet-postdeploy-smoke.ts"
+    volumes:
+      - ./configs:/app/configs:ro
+    environment:
+      FPC_DEVNET_SMOKE_MANIFEST: "/app/configs/deploy-manifest.json"
+      L1_RPC_URL: "http://anvil:8545"
+      FPC_DEVNET_OPERATOR_SECRET_KEY: "${FPC_LOCAL_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
+      L1_OPERATOR_PRIVATE_KEY: "${L1_OPERATOR_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
     depends_on:
       deploy:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary
- Set `FPC_LOCAL_OUT` on the `deploy` service so the manifest is written to the shared `./configs` volume
- Add `postdeploy` service behind `["postdeploy"]` profile that runs `devnet-postdeploy-smoke.ts`
- Service reads the deploy manifest from the shared volume, bridges FeeJuice, and executes an FPC-paid transaction