### PR TITLE
feat(deploy): add FPC_VARIANT env var to select contract variant

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
       - ./configs:/app/configs
     environment:
       FPC_DEPLOY_ENV: "local"
+      FPC_VARIANT: "${FPC_VARIANT:-fpc}"
       AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
       L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
       FPC_LOCAL_DEPLOY_START_LOCAL_NETWORK: "0"
@@ -107,6 +108,7 @@ services:
     volumes:
       - ./configs:/app/configs:ro
     environment:
+      FPC_VARIANT: "${FPC_VARIANT:-fpc}"
       FPC_DEVNET_SMOKE_MANIFEST: "/app/configs/deploy-manifest.json"
       L1_RPC_URL: "http://anvil:8545"
       FPC_DEVNET_OPERATOR_SECRET_KEY: "${FPC_LOCAL_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"

--- a/fpc-config.yaml
+++ b/fpc-config.yaml
@@ -17,7 +17,7 @@ attestation:
 
 topup:
   threshold: "100000000000000000"
-  top_up_amount: "500000000000000000"
+  top_up_amount: "5000"
   bridge_state_path: ".topup-bridge-state.json"
   ops_port: 3001
   check_interval_ms: 60000

--- a/scripts/contract/deploy-fpc-devnet.sh
+++ b/scripts/contract/deploy-fpc-devnet.sh
@@ -25,7 +25,21 @@ resolve_default_fpc_artifact() {
   printf "%s\n" "$multi_asset_path"
 }
 
-FPC_ARTIFACT="$(resolve_default_fpc_artifact)"
+case "${FPC_VARIANT:-}" in
+  "")
+    FPC_ARTIFACT="$(resolve_default_fpc_artifact)"
+    ;;
+  fpc)
+    FPC_ARTIFACT="$REPO_ROOT/target/fpc-FPCMultiAsset.json"
+    ;;
+  credit)
+    FPC_ARTIFACT="$REPO_ROOT/target/credit_fpc-CreditFPC.json"
+    ;;
+  *)
+    echo "ERROR: FPC_VARIANT must be 'fpc' or 'credit' (got '${FPC_VARIANT}')" >&2
+    exit 1
+    ;;
+esac
 
 if [[ "$MODE" != "devnet" && "$MODE" != "local" ]]; then
   echo "ERROR: FPC_DEPLOY_ENV must be 'devnet' or 'local' (got '$MODE')" >&2
@@ -37,7 +51,9 @@ cd "${REPO_ROOT}"
 if [[ ! -f target/token_contract-Token.json || ! -f target/credit_fpc-CreditFPC.json || ( ! -f target/fpc-FPCMultiAsset.json && ! -f target/fpc-FPC.json ) ]]; then
   echo "Compiling Aztec workspace artifacts..."
   aztec compile --workspace --force
-  FPC_ARTIFACT="$(resolve_default_fpc_artifact)"
+  if [[ -z "${FPC_VARIANT:-}" ]]; then
+    FPC_ARTIFACT="$(resolve_default_fpc_artifact)"
+  fi
 fi
 
 if [[ "$MODE" == "local" ]]; then


### PR DESCRIPTION
## Summary
- Pass `FPC_VARIANT` env var through docker-compose to deploy and smoke services (defaults to `fpc`)
- Add `case` switch in deploy script to select `FPCMultiAsset` or `CreditFPC` artifact based on `FPC_VARIANT`
- Fix `top_up_amount` in `fpc-config.yaml` (was `500000000000000000`, now `5000`)