### PR TITLE
refactor(deploy): rename image to aztec-fpc-contract-deployment and add to services bake group

### DIFF
--- a/.github/workflows/docker-build-services.yml
+++ b/.github/workflows/docker-build-services.yml
@@ -10,6 +10,8 @@ on:
       - "services/attestation/**"
       - "services/topup/**"
       - "services/Dockerfile.common"
+      - "scripts/contract/**"
+      - "contracts/**"
       - "package.json"
       - "bun.lock"
       - "tsconfig*.json"
@@ -67,6 +69,8 @@ jobs:
           echo "- nethermind/aztec-fpc-attestation:${GITHUB_SHA}" >> $GITHUB_STEP_SUMMARY
           echo "- nethermind/aztec-fpc-topup:${TAG}" >> $GITHUB_STEP_SUMMARY
           echo "- nethermind/aztec-fpc-topup:${GITHUB_SHA}" >> $GITHUB_STEP_SUMMARY
+          echo "- nethermind/aztec-fpc-contract-deployment:${TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "- nethermind/aztec-fpc-contract-deployment:${GITHUB_SHA}" >> $GITHUB_STEP_SUMMARY
           echo "### Platforms" >> $GITHUB_STEP_SUMMARY
           echo "- linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           echo "### Commit" >> $GITHUB_STEP_SUMMARY

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,7 +24,7 @@ group "default" {
 }
 
 group "services" {
-  targets = ["attestation", "topup"]
+  targets = ["attestation", "topup", "deploy"]
 }
 
 target "_labels" {
@@ -89,8 +89,8 @@ target "deploy" {
   platforms  = PLATFORMS
   target     = "deploy"
   tags = compact([
-    "${REGISTRY}nethermind/aztec-fpc-deploy:${TAG}${PLATFORM_SUFFIX}",
-    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-deploy:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
+    "${REGISTRY}nethermind/aztec-fpc-contract-deployment:${TAG}${PLATFORM_SUFFIX}",
+    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-contract-deployment:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
   ])
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       start_period: 30s
 
   deploy:
-    image: nethermind/aztec-fpc-deploy:local
+    image: nethermind/aztec-fpc-contract-deployment:local
     configs:
       - source: fpc-config
         target: /app/fpc-config.yaml


### PR DESCRIPTION
## Summary
- Rename deploy image tag from `aztec-fpc-deploy` to `aztec-fpc-contract-deployment` in bake, compose, and CI
- Add `deploy` target to the `services` bake group so it gets built/pushed by `docker-build-services.yml`
- Add `scripts/contract/**` and `contracts/**` path triggers to the CI workflow
- Add deploy image lines to the CI summary output