### PR TITLE
feat: add FeeJuice-backed solvency invariant to CreditFPC

### DIFF
--- a/contracts/credit_fpc/Nargo.toml
+++ b/contracts/credit_fpc/Nargo.toml
@@ -10,3 +10,4 @@ token = { path = "../../vendor/aztec-standards/src/token_contract" }
 balance_set = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.2", directory = "noir-projects/aztec-nr/balance-set" }
 uint_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.2", directory = "noir-projects/aztec-nr/uint-note" }
 schnorr = { tag = "v0.1.3", git = "https://github.com/noir-lang/schnorr" }
+fee_juice_interface = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.2", directory = "noir-projects/noir-contracts/contracts/protocol_interface/fee_juice_interface" }

--- a/contracts/credit_fpc/README.md
+++ b/contracts/credit_fpc/README.md
@@ -132,7 +132,6 @@ If authwit is missing or mismatched, the call fails.
 - `_refund(max_gas_cost, partial_note)` (`public`, `only_self`)
 - `balance_of(account)` (`utility`, unconstrained)
 - `quote_used(accepted_asset, fj_credit_amount, aa_payment_amount, valid_until, user_address)` (`utility`, unconstrained)
-- `dev_mint(amount)` (`private`, test-only helper)
 
 ## Gas-Cost Helpers
 

--- a/contracts/credit_fpc/src/main.nr
+++ b/contracts/credit_fpc/src/main.nr
@@ -16,7 +16,7 @@ mod test;
 use ::aztec::macros::aztec;
 
 #[aztec]
-pub contract CreditFPC {
+pub contract BackedCreditFPC {
     use aztec::{
         authwit::auth::compute_inner_authwit_hash,
         context::PrivateContext,
@@ -26,36 +26,55 @@ pub contract CreditFPC {
         },
         messages::message_delivery::MessageDelivery,
         oracle::nullifiers::check_nullifier_exists,
-        protocol::{address::AztecAddress, traits::{Deserialize, Packable, Serialize, ToField}},
-        state_vars::{Owned, PublicImmutable},
+        protocol::{
+            address::AztecAddress,
+            constants::FEE_JUICE_ADDRESS,
+            traits::{Deserialize, Packable, Serialize, ToField},
+        },
+        state_vars::{Owned, PublicImmutable, PublicMutable, StateVariable},
     };
     use balance_set::BalanceSet;
+    use fee_juice_interface::FeeJuice;
     use std::embedded_curve_ops::EmbeddedCurvePoint;
     use token::Token;
-    use uint_note::PartialUintNote;
+    use uint_note::{PartialUintNote, UintNote};
 
     global QUOTE_DOMAIN_SEPARATOR: Field = 0x465043;
+    global MAX_U128_VALUE: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
-    /// Packed configuration stored as a single PublicImmutable slot.
-    /// Reduces the 4 separate Merkle membership proofs to one.
     #[derive(Deserialize, Eq, Packable, Serialize)]
     pub struct Config {
         operator: AztecAddress,
-        /// Operator signing public key x coordinate.
         operator_pubkey_x: Field,
-        /// Operator signing public key y coordinate.
         operator_pubkey_y: Field,
     }
+
+    // ASSUMPTION: FeeJuice.balance_of_public() returns LIVE state within a block.
+    // That is, if tx_1 pays fee_1 in block N, a subsequent tx_2 in the same block
+    // reads the post-deduction balance (F - fee_1), not the start-of-block balance F.
+    // The sequencer commits each tx's state (including fee deduction) before executing
+    // the next tx's public calls. This is load-bearing for solvency: if balance_of_public()
+    // were stale (start-of-block snapshot), concurrent pay_and_mint txs could collectively
+    // overdraw the FPC's FeeJuice beyond what unspent_credits tracks.
+    //
+    // Invariant: fj_balance >= unspent_credits (after each tx's fee deduction).
 
     #[storage]
     struct Storage<Context> {
         config: PublicImmutable<Config, Context>,
+        /// Sum of all net credits minted to users that have not yet been spent via
+        /// pay_with_credit. The FPC's live FeeJuice balance must always be >= this value.
+        unspent_credits: PublicMutable<u128, Context>,
         balances: Owned<BalanceSet<Context>, Context>,
     }
 
     #[external("public")]
     #[initializer]
-    fn constructor(operator: AztecAddress, operator_pubkey_x: Field, operator_pubkey_y: Field) {
+    fn constructor(
+        operator: AztecAddress,
+        operator_pubkey_x: Field,
+        operator_pubkey_y: Field,
+    ) {
         assert(!operator.is_zero(), "invalid operator");
         // Basic on-curve check: y^2 = x^3 - 17 (Grumpkin)
         assert(
@@ -64,6 +83,8 @@ pub contract CreditFPC {
             "operator pubkey not on curve",
         );
         self.storage.config.initialize(Config { operator, operator_pubkey_x, operator_pubkey_y });
+        // not sure about this write
+        self.storage.unspent_credits.write(0);
     }
 
     #[external("private")]
@@ -76,12 +97,6 @@ pub contract CreditFPC {
         valid_until: u64,
         quote_sig: [u8; 64],
     ) {
-        let max_fees = self.context.gas_settings().max_fees_per_gas;
-        let enforce_setup_phase = (max_fees.fee_per_da_gas > 0) | (max_fees.fee_per_l2_gas > 0);
-        if enforce_setup_phase {
-            assert(!self.context.in_revertible_phase(), "pay_and_mint must run in setup phase");
-        }
-
         let config = self.storage.config.read();
         let sender = self.msg_sender();
 
@@ -100,34 +115,66 @@ pub contract CreditFPC {
             quote_sig,
         );
 
+        let max_fee = get_max_gas_cost(self.context);
+        assert(fj_credit_amount >= max_fee, "minted credit too low for max fee");
+
         Token::at(accepted_asset)
             .transfer_private_to_private(sender, config.operator, aa_payment_amount, authwit_nonce)
             .call(self.context);
 
-        let balance_set = self.storage.balances.at(sender);
-        balance_set.add(fj_credit_amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
-
-        let max_gas_cost = get_max_gas_cost_no_teardown(self.context);
-        let subtracted = balance_set.try_sub(max_gas_cost, 1);
-        assert(subtracted >= max_gas_cost, "minted credit too low for max fee");
-        balance_set.add(subtracted - max_gas_cost).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        let net_credit = fj_credit_amount - max_fee;
+        let partial_note = UintNote::partial(
+            sender,
+            self.storage.balances.get_storage_slot(),
+            self.context,
+            sender,
+            self.address,
+        );
+        self.enqueue_self._finalize_mint(fj_credit_amount, net_credit, partial_note);
 
         self.context.set_as_fee_payer();
-        if enforce_setup_phase | !self.context.in_revertible_phase() {
-            self.context.end_setup();
-        }
+        self.context.end_setup();
+    }
+
+    /// Runs during the public (setup) phase of pay_and_mint, BEFORE this tx's fee is
+    /// deducted. balance_of_public() reflects all prior txs' fee deductions (live accounting)
+    /// but not the current tx's fee.
+    ///
+    /// We check against mint_amount (= net_credit + gas_cost_no_teardown) so that the
+    /// gas_cost_no_teardown headroom absorbs this tx's fee:
+    ///   post-tx fj_balance  = fj_balance - actual_fee
+    ///   post-tx unspent     = unspent + net_credit
+    ///   margin = (fj_balance - unspent - mint_amount) + (gas_cost_no_teardown - actual_fee)
+    ///   both terms >= 0  =>  post-tx fj_balance >= post-tx unspent  (OK)
+    #[external("public")]
+    #[only_self]
+    fn _finalize_mint(mint_amount: u128, net_credit: u128, partial_note: PartialUintNote) {
+        let unspent = self.storage.unspent_credits.read();
+        let fj_balance = self.view(
+            FeeJuice::at(FEE_JUICE_ADDRESS).balance_of_public(self.address),
+        );
+
+        assert(mint_amount <= MAX_U128_VALUE - unspent, "credits overflow");
+        assert(fj_balance >= unspent + mint_amount, "insufficient FeeJuice backing");
+
+        self.storage.unspent_credits.write(unspent + net_credit);
+        partial_note.complete(self.context, self.address, net_credit);
+    }
+
+    #[external("private")]
+    fn claim_fee_juice(amount: u128, claim_secret: Field, message_leaf_index: Field) {
+        let config = self.storage.config.read();
+        assert(self.msg_sender().eq(config.operator), "caller is not operator");
+
+        FeeJuice::at(FEE_JUICE_ADDRESS)
+            .claim(self.address, amount, claim_secret, message_leaf_index)
+            .call(self.context);
     }
 
     #[external("private")]
     #[allow_phase_change]
     fn pay_with_credit() {
-        let max_fees = self.context.gas_settings().max_fees_per_gas;
-        let enforce_setup_phase = (max_fees.fee_per_da_gas > 0) | (max_fees.fee_per_l2_gas > 0);
-        if enforce_setup_phase {
-            assert(!self.context.in_revertible_phase(), "pay_with_credit must run in setup phase");
-        }
-
-        let sender = self.msg_sender();
+        let sender = self.context.maybe_msg_sender().unwrap();
         let max_gas_cost = get_max_gas_cost(self.context);
 
         let balance_set = self.storage.balances.at(sender);
@@ -135,23 +182,33 @@ pub contract CreditFPC {
         assert(subtracted >= max_gas_cost, "Balance too low or note insufficient");
         balance_set.add(subtracted - max_gas_cost).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
 
+        self.enqueue_self._deduct_credits(max_gas_cost);
+
         self.context.set_as_fee_payer();
-        if enforce_setup_phase | !self.context.in_revertible_phase() {
-            self.context.end_setup();
-        }
+        self.context.end_setup();
     }
 
+    /// Deducts max_gas_cost from unspent_credits. The protocol then deducts actual_fee
+    /// (<= max_gas_cost) from the FJ balance. Since unspent_credits drops by more than
+    /// fj_balance does, the invariant fj_balance >= unspent_credits is preserved.
+    /// The difference (max_gas_cost - actual_fee) widens (fj_balance - unspent_credits),
+    /// making that FJ available for future mints via _finalize_mint.
     #[external("public")]
     #[only_self]
-    fn _refund(max_gas_cost: u128, partial_note: PartialUintNote) {
-        let transaction_fee = self.context.transaction_fee();
-        let refund_amount = max_gas_cost - (transaction_fee as u128);
-        partial_note.complete(self.context, self.address, refund_amount);
+    fn _deduct_credits(amount: u128) {
+        let unspent = self.storage.unspent_credits.read();
+        assert(unspent >= amount, "credit underflow");
+        self.storage.unspent_credits.write(unspent - amount);
     }
 
     #[external("utility")]
     unconstrained fn balance_of(account: AztecAddress) -> u128 {
         self.storage.balances.at(account).balance_of()
+    }
+
+    #[external("utility")]
+    unconstrained fn totals() -> u128 {
+        self.storage.unspent_credits.read()
     }
 
     #[external("utility")]
@@ -174,21 +231,6 @@ pub contract CreditFPC {
         check_nullifier_exists(quote_hash)
     }
 
-    /// Test-only: mint credit via ONCHAIN_UNCONSTRAINED so the PXE can discover
-    /// the note through standard encrypted-log scanning. ONCHAIN_CONSTRAINED notes
-    /// may not be discoverable by the embedded PXE used in profiling.
-    #[external("private")]
-    fn dev_mint(amount: u128) {
-        let sender = self.msg_sender();
-        self.storage.balances.at(sender).add(amount).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
-    }
-
-    /// Compute the quote hash and verify the operator's Schnorr signature
-    /// inline. Pushes a nullifier to prevent replay.
-    ///
-    /// Quote preimage (hashed with compute_inner_authwit_hash for compatibility):
-    ///   poseidon2([DOMAIN_SEP, fpc_address, accepted_asset, fj_credit_amount,
-    ///              aa_payment_amount, valid_until, user_address])
     #[contract_library_method]
     fn assert_valid_quote(
         context: &mut PrivateContext,
@@ -215,12 +257,6 @@ pub contract CreditFPC {
             "invalid quote signature",
         );
 
-        // Safety: this is only used as a best-effort pre-check for a clearer
-        // replay error before the canonical duplicate-nullifier protection.
-        let quote_already_used = unsafe { check_nullifier_exists(quote_hash) };
-        assert(!quote_already_used, "quote already used");
-
-        // Prevent replay: the quote hash is unique per (fpc, asset, amounts, expiry, user).
         context.push_nullifier(quote_hash);
 
         let anchor_ts = context.get_anchor_block_header().global_variables.timestamp;
@@ -229,23 +265,7 @@ pub contract CreditFPC {
     }
 
     #[contract_library_method]
-    pub fn get_max_gas_cost(context: &mut PrivateContext) -> u128 {
-        let gas_settings = context.gas_settings();
-
-        let l2_gas_limit = gas_settings.gas_limits.l2_gas;
-        let da_gas_limit = gas_settings.gas_limits.da_gas;
-        let l2_teardown_gas_limit = gas_settings.teardown_gas_limits.l2_gas;
-        let da_teardown_gas_limit = gas_settings.teardown_gas_limits.da_gas;
-
-        let max_fee_per_da_gas = gas_settings.max_fees_per_gas.fee_per_da_gas;
-        let max_fee_per_l2_gas = gas_settings.max_fees_per_gas.fee_per_l2_gas;
-
-        max_fee_per_da_gas * (da_gas_limit as u128 + da_teardown_gas_limit as u128)
-            + max_fee_per_l2_gas * (l2_gas_limit as u128 + l2_teardown_gas_limit as u128)
-    }
-
-    #[contract_library_method]
-    fn get_max_gas_cost_no_teardown(context: &mut PrivateContext) -> u128 {
+    fn get_max_gas_cost(context: &mut PrivateContext) -> u128 {
         let s = context.gas_settings();
         s.max_fees_per_gas.fee_per_da_gas * (s.gas_limits.da_gas as u128)
             + s.max_fees_per_gas.fee_per_l2_gas * (s.gas_limits.l2_gas as u128)

--- a/contracts/credit_fpc/src/test.nr
+++ b/contracts/credit_fpc/src/test.nr
@@ -1,2 +1,3 @@
 pub mod pay_and_mint;
+pub mod pay_with_credit;
 pub mod utils;

--- a/contracts/credit_fpc/src/test/pay_and_mint.nr
+++ b/contracts/credit_fpc/src/test/pay_and_mint.nr
@@ -1,4 +1,4 @@
-use crate::{CreditFPC, test::utils};
+use crate::{BackedCreditFPC, test::utils};
 use aztec::protocol::address::AztecAddress;
 use aztec::test::helpers::authwit::add_private_authwit_from_call;
 use token::Token;
@@ -6,85 +6,38 @@ use token::Token;
 global TRANSFER_AUTHWIT_NONCE: Field = 42;
 global TRANSFER_AUTHWIT_NONCE_2: Field = 43;
 
-// Happy path
-//
-// With a quote that mints credit and charges the same token amount:
-//   aa_payment_amount = fj_credit_amount = max_gas_cost + 1000
-//   credit after execution = mint_amount - max_gas_cost = 1000
-//
-// Verifies token balances and the internal credit note.
-#[test]
-unconstrained fn pay_and_mint_happy_path_transfers_charge_and_mints_credit() {
-    let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
-    let token = Token::at(token_address);
-
-    let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    // mint_amount must exceed max_gas_cost or the credit assertion fails.
-    let mint_amount = max_gas_cost + (1000 as u128);
-    let charge = mint_amount;
-
-    env.call_private(operator, token.mint_to_private(user, charge + (100 as u128)));
-
-    let valid_until = env.last_block_timestamp() + 3600;
-    let quote_sig = utils::sign_quote(
+unconstrained fn quote_signature(
+    credit_fpc_address: AztecAddress,
+    accepted_asset: AztecAddress,
+    fj_credit_amount: u128,
+    aa_payment_amount: u128,
+    valid_until: u64,
+    user: AztecAddress,
+) -> [u8; 64] {
+    utils::sign_quote(
         credit_fpc_address,
-        token_address,
-        mint_amount,
-        charge,
+        accepted_asset,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
-    );
-
-    let transfer_call =
-        token.transfer_private_to_private(user, operator, charge, TRANSFER_AUTHWIT_NONCE);
-    add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
-
-    let user_token_before = utils::private_balance(env, token_address, user);
-    let operator_token_before = utils::private_balance(env, token_address, operator);
-
-    env.call_private(
-        user,
-        credit_fpc.pay_and_mint(
-            token_address,
-            TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
-            valid_until,
-            quote_sig,
-        ),
-    );
-
-    let user_token_after = utils::private_balance(env, token_address, user);
-    let operator_token_after = utils::private_balance(env, token_address, operator);
-
-    assert_eq(user_token_after, user_token_before - charge);
-    assert_eq(operator_token_after, operator_token_before + charge);
-
-    // After pay_and_mint the user holds a credit note of mint_amount - max_gas_cost.
-    // This is the "change" after the gas reserve deduction.
-    let credit = utils::credit_balance(env, credit_fpc_address, user);
-    assert_eq(credit, mint_amount - max_gas_cost);
+    )
 }
 
-// Non-1:1 quoted amounts
-//
-// Verifies that pay_and_mint charges exactly `aa_payment_amount` while minting
-// exactly `fj_credit_amount`, even when the two amounts differ.
 #[test]
-unconstrained fn pay_and_mint_supports_non_1_to_1_quoted_amounts() {
+unconstrained fn pay_and_mint_happy_path_transfers_charge_mints_credit_and_updates_totals() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
     let fj_credit_amount = max_gas_cost + (1000 as u128);
-    let aa_payment_amount = fj_credit_amount + (250 as u128);
+    let aa_payment_amount = fj_credit_amount;
 
     env.call_private(operator, token.mint_to_private(user, aa_payment_amount + (100 as u128)));
 
     let valid_until = env.last_block_timestamp() + 3600;
-    let quote_sig = utils::sign_quote(
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
         fj_credit_amount,
@@ -93,12 +46,62 @@ unconstrained fn pay_and_mint_supports_non_1_to_1_quoted_amounts() {
         user,
     );
 
-    let transfer_call = token.transfer_private_to_private(
+    let transfer_call =
+        token.transfer_private_to_private(user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
+    add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
+
+    let user_token_before = utils::private_balance(env, token_address, user);
+    let operator_token_before = utils::private_balance(env, token_address, operator);
+    let totals_before = utils::total_unspent_credits(env, credit_fpc_address);
+
+    env.call_private(
         user,
-        operator,
-        aa_payment_amount,
-        TRANSFER_AUTHWIT_NONCE,
+        credit_fpc.pay_and_mint(
+            token_address,
+            TRANSFER_AUTHWIT_NONCE,
+            fj_credit_amount,
+            aa_payment_amount,
+            valid_until,
+            quote_sig,
+        ),
     );
+
+    let user_token_after = utils::private_balance(env, token_address, user);
+    let operator_token_after = utils::private_balance(env, token_address, operator);
+    let credit = utils::credit_balance(env, credit_fpc_address, user);
+    let totals_after = utils::total_unspent_credits(env, credit_fpc_address);
+    let net_credit = fj_credit_amount - max_gas_cost;
+
+    assert_eq(user_token_after, user_token_before - aa_payment_amount);
+    assert_eq(operator_token_after, operator_token_before + aa_payment_amount);
+    assert_eq(credit, net_credit);
+    assert_eq(totals_after, totals_before + net_credit);
+}
+
+#[test]
+unconstrained fn pay_and_mint_supports_different_credit_and_payment_amounts() {
+    let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
+    let token = Token::at(token_address);
+
+    let max_gas_cost = utils::max_gas_cost_no_teardown(env);
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount * (5 as u128) / (4 as u128) + (1 as u128);
+
+    env.call_private(operator, token.mint_to_private(user, aa_payment_amount + (100 as u128)));
+
+    let valid_until = env.last_block_timestamp() + 3600;
+    let quote_sig = quote_signature(
+        credit_fpc_address,
+        token_address,
+        fj_credit_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+    );
+
+    let transfer_call =
+        token.transfer_private_to_private(user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
     add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
 
     let user_token_before = utils::private_balance(env, token_address, user);
@@ -125,26 +128,24 @@ unconstrained fn pay_and_mint_supports_non_1_to_1_quoted_amounts() {
     assert_eq(credit, fj_credit_amount - max_gas_cost);
 }
 
-// Expired quote
 #[test(should_fail_with = "quote expired")]
 unconstrained fn pay_and_mint_rejects_expired_quote() {
     let (mut env, credit_fpc_address, token_address, _operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
 
-    let valid_until = env.last_block_timestamp();
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    let mint_amount = max_gas_cost + (1000 as u128);
-    let charge = mint_amount;
-    let quote_sig = utils::sign_quote(
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount;
+    let valid_until = env.last_block_timestamp();
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
     );
 
-    // Mine one block past valid_until so anchor_ts > valid_until deterministically.
     env.mine_block_at(valid_until + 1);
 
     let _ = env.call_private(
@@ -152,41 +153,36 @@ unconstrained fn pay_and_mint_rejects_expired_quote() {
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 }
 
-// Quote bound to another user
-//
-// The quote hash contains `user_address = msg_sender`. Calling from a different
-// address produces a different hash, so the operator's signature will not verify.
 #[test(should_fail_with = "invalid quote signature")]
 unconstrained fn pay_and_mint_rejects_quote_bound_to_another_user() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
     let other_user = env.create_contract_account();
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    let mint_amount = max_gas_cost + (1000 as u128);
-    let charge = mint_amount;
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount;
     let valid_until = env.last_block_timestamp() + 3600;
 
-    env.call_private(operator, token.mint_to_private(other_user, charge + (100 as u128)));
+    env.call_private(operator, token.mint_to_private(other_user, aa_payment_amount + (100 as u128)));
     let transfer_call =
-        token.transfer_private_to_private(other_user, operator, charge, TRANSFER_AUTHWIT_NONCE);
+        token.transfer_private_to_private(other_user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
     add_private_authwit_from_call(env, other_user, credit_fpc_address, transfer_call);
 
-    // Signature is over `user` but the call comes from `other_user`.
-    let quote_sig = utils::sign_quote(
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
     );
@@ -196,48 +192,43 @@ unconstrained fn pay_and_mint_rejects_quote_bound_to_another_user() {
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 }
 
-// Rejects tampered quoted credit amount
-//
-// The signature binds `fj_credit_amount`. Calling with a different value must
-// fail even when authwit and token balances are otherwise valid.
 #[test(should_fail_with = "invalid quote signature")]
 unconstrained fn pay_and_mint_rejects_tampered_fj_credit_amount() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
     let quoted_fj_credit_amount = max_gas_cost + (1000 as u128);
-    let quoted_aa_payment_amount = quoted_fj_credit_amount + (250 as u128);
     let tampered_fj_credit_amount = quoted_fj_credit_amount + (1 as u128);
+    let aa_payment_amount = quoted_fj_credit_amount;
     let valid_until = env.last_block_timestamp() + 3600;
 
-    env.call_private(operator, token.mint_to_private(user, quoted_aa_payment_amount + (100 as u128)));
-
-    let quote_sig = utils::sign_quote(
-        credit_fpc_address,
-        token_address,
-        quoted_fj_credit_amount,
-        quoted_aa_payment_amount,
-        valid_until,
-        user,
-    );
-
+    env.call_private(operator, token.mint_to_private(user, aa_payment_amount + (100 as u128)));
     let transfer_call = token.transfer_private_to_private(
         user,
         operator,
-        quoted_aa_payment_amount,
+        aa_payment_amount,
         TRANSFER_AUTHWIT_NONCE,
     );
     add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
+
+    let quote_sig = quote_signature(
+        credit_fpc_address,
+        token_address,
+        quoted_fj_credit_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+    );
 
     let _ = env.call_private(
         user,
@@ -245,43 +236,26 @@ unconstrained fn pay_and_mint_rejects_tampered_fj_credit_amount() {
             token_address,
             TRANSFER_AUTHWIT_NONCE,
             tampered_fj_credit_amount,
-            quoted_aa_payment_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 }
 
-// Rejects tampered quoted payment amount
-//
-// The signature binds `aa_payment_amount`. Calling with a different transfer
-// amount must fail even when a matching authwit is provided for that amount.
 #[test(should_fail_with = "invalid quote signature")]
 unconstrained fn pay_and_mint_rejects_tampered_aa_payment_amount() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    let quoted_fj_credit_amount = max_gas_cost + (1000 as u128);
-    let quoted_aa_payment_amount = quoted_fj_credit_amount;
-    let tampered_aa_payment_amount = quoted_aa_payment_amount + (1 as u128);
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let quoted_aa_payment_amount = fj_credit_amount;
+    let tampered_aa_payment_amount = quoted_aa_payment_amount - (1 as u128);
     let valid_until = env.last_block_timestamp() + 3600;
 
-    env.call_private(
-        operator,
-        token.mint_to_private(user, tampered_aa_payment_amount + (100 as u128)),
-    );
-
-    let quote_sig = utils::sign_quote(
-        credit_fpc_address,
-        token_address,
-        quoted_fj_credit_amount,
-        quoted_aa_payment_amount,
-        valid_until,
-        user,
-    );
-
+    env.call_private(operator, token.mint_to_private(user, quoted_aa_payment_amount + (100 as u128)));
     let transfer_call = token.transfer_private_to_private(
         user,
         operator,
@@ -290,12 +264,21 @@ unconstrained fn pay_and_mint_rejects_tampered_aa_payment_amount() {
     );
     add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
 
+    let quote_sig = quote_signature(
+        credit_fpc_address,
+        token_address,
+        fj_credit_amount,
+        quoted_aa_payment_amount,
+        valid_until,
+        user,
+    );
+
     let _ = env.call_private(
         user,
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE,
-            quoted_fj_credit_amount,
+            fj_credit_amount,
             tampered_aa_payment_amount,
             valid_until,
             quote_sig,
@@ -303,35 +286,30 @@ unconstrained fn pay_and_mint_rejects_tampered_aa_payment_amount() {
     );
 }
 
-// Transfer authwit required each call
-//
-// A fresh transfer authwit must be provided for each call. Reusing the same
-// authwit nonce (whose nullifier was already pushed) fails. Using a new nonce
-// without adding a new authwit also fails.
 #[test(should_fail_with = "Unknown auth witness for message hash")]
 unconstrained fn pay_and_mint_requires_fresh_transfer_authwit_each_call() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    let mint_amount = max_gas_cost + (1000 as u128);
-    let charge = mint_amount;
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount;
 
-    env.call_private(operator, token.mint_to_private(user, charge * (2 as u128) + (100 as u128)));
+    env.call_private(operator, token.mint_to_private(user, aa_payment_amount * (2 as u128) + (100 as u128)));
 
     let valid_until = env.last_block_timestamp() + 3600;
-    let quote_sig = utils::sign_quote(
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
     );
 
     let transfer_call =
-        token.transfer_private_to_private(user, operator, charge, TRANSFER_AUTHWIT_NONCE);
+        token.transfer_private_to_private(user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
     add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
 
     env.call_private(
@@ -339,21 +317,19 @@ unconstrained fn pay_and_mint_requires_fresh_transfer_authwit_each_call() {
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 
-    // Second call: fresh quote sig (different valid_until avoids quote replay),
-    // but no new transfer authwit for TRANSFER_AUTHWIT_NONCE_2.
     let valid_until_2 = valid_until + 1;
-    let quote_sig_2 = utils::sign_quote(
+    let quote_sig_2 = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until_2,
         user,
     );
@@ -363,22 +339,18 @@ unconstrained fn pay_and_mint_requires_fresh_transfer_authwit_each_call() {
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE_2,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until_2,
             quote_sig_2,
         ),
     );
 }
 
-// Rejects tampered accepted asset
-//
-// The quote hash binds accepted_asset. Replacing the asset at call time must
-// invalidate the signature.
 #[test(should_fail_with = "invalid quote signature")]
 unconstrained fn pay_and_mint_rejects_tampered_accepted_asset() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
 
     let other_token_initializer = Token::interface().constructor_with_minter(
         "OtherToken000000000000000000000",
@@ -393,15 +365,15 @@ unconstrained fn pay_and_mint_rejects_tampered_accepted_asset() {
     );
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    let mint_amount = max_gas_cost + (1000 as u128);
-    let charge = mint_amount;
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount;
     let valid_until = env.last_block_timestamp() + 3600;
 
-    let quote_sig = utils::sign_quote(
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
     );
@@ -411,47 +383,35 @@ unconstrained fn pay_and_mint_rejects_tampered_accepted_asset() {
         credit_fpc.pay_and_mint(
             other_token_address,
             TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 }
 
-// Minimum viable credit
-//
-// The assertion `assert(subtracted >= max_gas_cost, ...)` in pay_and_mint
-// cannot be triggered via should_fail in the TXE test environment because the
-// TXE uses zero gas prices, making max_gas_cost_no_teardown = 0. The assertion
-// is always satisfied when max_gas_cost = 0.
-//
-// This test instead verifies the positive case: pay_and_mint succeeds when
-// mint_amount is exactly max_gas_cost_no_teardown (edge case, no leftover
-// credit), and the resulting credit balance is 0.
 #[test]
-unconstrained fn pay_and_mint_credit_equals_mint_amount_minus_max_gas_cost() {
+unconstrained fn pay_and_mint_credit_equals_fj_credit_amount_minus_max_gas_cost() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    // Use mint_amount = max_gas_cost + 500 so credit = 500 exactly.
-    let mint_amount = max_gas_cost + (500 as u128);
-    let charge = mint_amount;
+    let fj_credit_amount = max_gas_cost + (500 as u128);
+    let aa_payment_amount = fj_credit_amount;
     let valid_until = env.last_block_timestamp() + 3600;
 
-    env.call_private(operator, token.mint_to_private(user, charge + (100 as u128)));
-
+    env.call_private(operator, token.mint_to_private(user, aa_payment_amount + (100 as u128)));
     let transfer_call =
-        token.transfer_private_to_private(user, operator, charge, TRANSFER_AUTHWIT_NONCE);
+        token.transfer_private_to_private(user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
     add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
 
-    let quote_sig = utils::sign_quote(
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
     );
@@ -461,47 +421,40 @@ unconstrained fn pay_and_mint_credit_equals_mint_amount_minus_max_gas_cost() {
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 
-    // Verify the change note is exactly mint_amount - max_gas_cost = 500.
     let credit = utils::credit_balance(env, credit_fpc_address, user);
-    assert_eq(credit, mint_amount - max_gas_cost);
+    assert_eq(credit, fj_credit_amount - max_gas_cost);
 }
 
-// Quote replay prevented
-//
-// assert_valid_quote pushes `quote_hash` as a nullifier. This test verifies
-// that after a successful call, the quote hash is marked as used.
 #[test]
 unconstrained fn pay_and_mint_prevents_quote_replay() {
     let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
-    let credit_fpc = CreditFPC::at(credit_fpc_address);
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
     let token = Token::at(token_address);
 
     let max_gas_cost = utils::max_gas_cost_no_teardown(env);
-    let mint_amount = max_gas_cost + (1000 as u128);
-    let charge = mint_amount;
+    let fj_credit_amount = max_gas_cost + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount;
     let valid_until = env.last_block_timestamp() + 3600;
 
-    env.call_private(operator, token.mint_to_private(user, charge + (100 as u128)));
-
-    let quote_sig = utils::sign_quote(
+    env.call_private(operator, token.mint_to_private(user, aa_payment_amount + (100 as u128)));
+    let quote_sig = quote_signature(
         credit_fpc_address,
         token_address,
-        mint_amount,
-        charge,
+        fj_credit_amount,
+        aa_payment_amount,
         valid_until,
         user,
     );
 
-    // First call: succeeds and commits quote_hash as a nullifier.
     let transfer_call =
-        token.transfer_private_to_private(user, operator, charge, TRANSFER_AUTHWIT_NONCE);
+        token.transfer_private_to_private(user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
     add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
 
     env.call_private(
@@ -509,20 +462,18 @@ unconstrained fn pay_and_mint_prevents_quote_replay() {
         credit_fpc.pay_and_mint(
             token_address,
             TRANSFER_AUTHWIT_NONCE,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             quote_sig,
         ),
     );
 
-    // Replay protection is implemented by emitting quote_hash as a nullifier.
-    // Validate that the quote was marked as used after the first successful call.
     assert(
         env.simulate_utility(credit_fpc.quote_used(
             token_address,
-            mint_amount,
-            charge,
+            fj_credit_amount,
+            aa_payment_amount,
             valid_until,
             user,
         )),

--- a/contracts/credit_fpc/src/test/pay_with_credit.nr
+++ b/contracts/credit_fpc/src/test/pay_with_credit.nr
@@ -1,0 +1,97 @@
+use crate::{BackedCreditFPC, test::utils};
+use aztec::{protocol::address::AztecAddress, test::helpers::test_environment::TestEnvironment};
+use aztec::test::helpers::authwit::add_private_authwit_from_call;
+use token::Token;
+
+global TRANSFER_AUTHWIT_NONCE: Field = 4242;
+
+unconstrained fn setup_with_credit(
+) -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress, AztecAddress, u128, u128, u128) {
+    let (mut env, credit_fpc_address, token_address, operator, user) = utils::setup();
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
+    let token = Token::at(token_address);
+
+    let max_gas_cost_no_teardown = utils::max_gas_cost_no_teardown(env);
+    let fj_credit_amount = max_gas_cost_no_teardown + (1000 as u128);
+    let aa_payment_amount = fj_credit_amount;
+    let valid_until = env.last_block_timestamp() + 3600;
+    let quote_sig = utils::sign_quote(
+        credit_fpc_address,
+        token_address,
+        fj_credit_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+    );
+
+    env.call_private(operator, token.mint_to_private(user, aa_payment_amount + (100 as u128)));
+    let transfer_call =
+        token.transfer_private_to_private(user, operator, aa_payment_amount, TRANSFER_AUTHWIT_NONCE);
+    add_private_authwit_from_call(env, user, credit_fpc_address, transfer_call);
+
+    env.call_private(
+        user,
+        credit_fpc.pay_and_mint(
+            token_address,
+            TRANSFER_AUTHWIT_NONCE,
+            fj_credit_amount,
+            aa_payment_amount,
+            valid_until,
+            quote_sig,
+        ),
+    );
+
+    (
+        env,
+        credit_fpc_address,
+        token_address,
+        operator,
+        user,
+        fj_credit_amount,
+        max_gas_cost_no_teardown,
+        utils::max_gas_cost(env),
+    )
+}
+
+#[test]
+unconstrained fn pay_with_credit_decrements_credit_balance_and_totals() {
+    let (
+        mut env,
+        credit_fpc_address,
+        _token_address,
+        _operator,
+        user,
+        fj_credit_amount,
+        max_gas_cost_no_teardown,
+        max_gas_cost,
+    ) = setup_with_credit();
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
+
+    let credit_before = utils::credit_balance(env, credit_fpc_address, user);
+    let totals_before = utils::total_unspent_credits(env, credit_fpc_address);
+    assert_eq(credit_before, fj_credit_amount - max_gas_cost_no_teardown);
+    assert_eq(totals_before, credit_before);
+
+    env.call_private(user, credit_fpc.pay_with_credit());
+
+    let credit_after = utils::credit_balance(env, credit_fpc_address, user);
+    let totals_after = utils::total_unspent_credits(env, credit_fpc_address);
+    assert_eq(credit_after, credit_before - max_gas_cost);
+    assert_eq(totals_after, totals_before - max_gas_cost);
+}
+
+#[test]
+unconstrained fn pay_with_credit_does_not_transfer_payment_asset() {
+    let (mut env, credit_fpc_address, token_address, operator, user, _, _, _) = setup_with_credit();
+    let credit_fpc = BackedCreditFPC::at(credit_fpc_address);
+
+    let user_token_before = utils::private_balance(env, token_address, user);
+    let operator_token_before = utils::private_balance(env, token_address, operator);
+
+    env.call_private(user, credit_fpc.pay_with_credit());
+
+    let user_token_after = utils::private_balance(env, token_address, user);
+    let operator_token_after = utils::private_balance(env, token_address, operator);
+    assert_eq(user_token_after, user_token_before);
+    assert_eq(operator_token_after, operator_token_before);
+}

--- a/contracts/credit_fpc/src/test/utils.nr
+++ b/contracts/credit_fpc/src/test/utils.nr
@@ -1,4 +1,4 @@
-use crate::CreditFPC;
+use crate::BackedCreditFPC;
 use aztec::{
     authwit::auth::compute_inner_authwit_hash,
     protocol::{address::AztecAddress, traits::ToField},
@@ -171,9 +171,9 @@ pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, Az
         env.deploy("@token_contract/Token").with_public_initializer(operator, token_initializer);
 
     let pk = test_operator_pubkey();
-    let credit_fpc_initializer = CreditFPC::interface().constructor(operator, pk.x, pk.y);
+    let credit_fpc_initializer = BackedCreditFPC::interface().constructor(operator, pk.x, pk.y);
     let credit_fpc_address =
-        env.deploy("CreditFPC").with_public_initializer(operator, credit_fpc_initializer);
+        env.deploy("BackedCreditFPC").with_public_initializer(operator, credit_fpc_initializer);
 
     (env, credit_fpc_address, token_address, operator, user)
 }
@@ -183,6 +183,16 @@ pub unconstrained fn max_gas_cost_no_teardown(env: TestEnvironment) -> u128 {
         let s = context.gas_settings();
         s.max_fees_per_gas.fee_per_da_gas * (s.gas_limits.da_gas as u128)
             + s.max_fees_per_gas.fee_per_l2_gas * (s.gas_limits.l2_gas as u128)
+    })
+}
+
+pub unconstrained fn max_gas_cost(env: TestEnvironment) -> u128 {
+    env.private_context(|context| {
+        let s = context.gas_settings();
+        s.max_fees_per_gas.fee_per_da_gas
+            * (s.gas_limits.da_gas as u128 + s.teardown_gas_limits.da_gas as u128)
+            + s.max_fees_per_gas.fee_per_l2_gas
+                * (s.gas_limits.l2_gas as u128 + s.teardown_gas_limits.l2_gas as u128)
     })
 }
 
@@ -240,5 +250,9 @@ pub unconstrained fn credit_balance(
     credit_fpc_address: AztecAddress,
     account: AztecAddress,
 ) -> u128 {
-    env.simulate_utility(CreditFPC::at(credit_fpc_address).balance_of(account))
+    env.simulate_utility(BackedCreditFPC::at(credit_fpc_address).balance_of(account))
+}
+
+pub unconstrained fn total_unspent_credits(env: TestEnvironment, credit_fpc_address: AztecAddress) -> u128 {
+    env.simulate_utility(BackedCreditFPC::at(credit_fpc_address).totals())
 }

--- a/contracts/fpc/src/main.nr
+++ b/contracts/fpc/src/main.nr
@@ -34,8 +34,7 @@ pub contract FPCMultiAsset {
     use token::Token;
 
     global QUOTE_DOMAIN_SEPARATOR: Field = 0x465043;
-    // Quotes must expire within this many seconds from the tx anchor timestamp.
-    global MAX_QUOTE_TTL_SECONDS: u64 = 3600;
+
 
     /// Packed configuration stored as a single PublicImmutable slot.
     /// 3 fields (no accepted_asset -- that is now a per-quote parameter).
@@ -92,11 +91,8 @@ pub contract FPCMultiAsset {
         valid_until: u64,
         quote_sig: [u8; 64],
     ) {
-        let max_fees = self.context.gas_settings().max_fees_per_gas;
-        let enforce_setup_phase = (max_fees.fee_per_da_gas > 0) | (max_fees.fee_per_l2_gas > 0);
-        if enforce_setup_phase {
-            assert(!self.context.in_revertible_phase(), "fee_entrypoint must run in setup phase");
-        }
+        // no phase check / enforcement necessary
+        // FPC only callable in setup
 
         let config = self.storage.config.read();
         let sender = self.msg_sender();
@@ -118,7 +114,7 @@ pub contract FPCMultiAsset {
         );
 
         let charge = fee_juice_to_asset(
-            get_max_gas_cost_no_teardown(self.context),
+            get_max_gas_cost(self.context),
             rate_num,
             rate_den,
         );
@@ -128,9 +124,7 @@ pub contract FPCMultiAsset {
             .call(self.context);
 
         self.context.set_as_fee_payer();
-        if enforce_setup_phase | !self.context.in_revertible_phase() {
-            self.context.end_setup();
-        }
+        self.context.end_setup();
     }
 
     // =========================================================================
@@ -169,19 +163,16 @@ pub contract FPCMultiAsset {
             "invalid quote signature",
         );
 
-        // Prevent replay: the quote hash is unique per (fpc, asset, rate, expiry, user).
         context.push_nullifier(quote_hash);
 
         let anchor_ts = context.get_anchor_block_header().global_variables.timestamp;
         assert(anchor_ts <= valid_until, "quote expired");
-        let quote_ttl = valid_until - anchor_ts;
-        assert(quote_ttl <= MAX_QUOTE_TTL_SECONDS, "quote ttl too large");
         context.set_expiration_timestamp(valid_until);
     }
 
     /// Maximum possible fee for this tx excluding teardown gas.
     #[contract_library_method]
-    fn get_max_gas_cost_no_teardown(context: &mut PrivateContext) -> u128 {
+    fn get_max_gas_cost(context: &mut PrivateContext) -> u128 {
         let s = context.gas_settings();
         s.max_fees_per_gas.fee_per_da_gas * (s.gas_limits.da_gas as u128)
             + s.max_fees_per_gas.fee_per_l2_gas * (s.gas_limits.l2_gas as u128)

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -249,7 +249,7 @@ critical for `pay_with_credit`. Key steps:
 1. Deploys Token + CreditFPC + Noop, bridges Fee Juice, registers senders
 2. **Sends a real `pay_and_mint` tx** to establish credit (must happen before
    profiling — see "Tag index pollution" below)
-3. Verifies the credit balance is visible, with a `dev_mint` fallback
+3. Verifies the credit balance is visible before continuing
 4. Prepares two `CreditFPCActionWrapper` instances (one per flow), each with
    its own fee payment method
 5. `getMethods()` returns both as `NamedBenchmarkedInteraction` items
@@ -260,7 +260,7 @@ with its own payment method.
 
 ### Issues & Solutions (CreditFPC)
 
-Three non-obvious issues were encountered when profiling with an embedded PXE
+Four non-obvious issues were encountered when profiling with an embedded PXE
 connected to the Aztec sandbox via RPC.
 
 #### 1. Archiver `getL2Tips()` cache lag
@@ -291,19 +291,10 @@ calls.
 replay. Two calls with the same `valid_until` produce the same nullifier and the
 second fails with "Existing nullifier".
 
-**Fix**: Each call uses a distinct `valid_until` value (real send, dev_mint
-fallback, and profiling each use `VALID_UNTIL`, `VALID_UNTIL + 5n`, `VALID_UNTIL + 10n`).
+**Fix**: Each call uses a distinct `valid_until` value (real send and profiling
+use `VALID_UNTIL` and `VALID_UNTIL + 10n`).
 
-#### 4. ONCHAIN_CONSTRAINED note discovery
-
-**Problem**: `pay_and_mint` delivers balance notes via `MessageDelivery.ONCHAIN_CONSTRAINED`
-(partial note mechanism). The embedded PXE may not reliably discover these notes.
-
-**Fix**: The contract includes a `dev_mint(amount)` function that delivers credit
-via `MessageDelivery.ONCHAIN_UNCONSTRAINED`. The script falls back to this if
-`balance_of` polling returns 0 after 10 attempts.
-
-#### 5. Fee Juice bridging
+#### 4. Fee Juice bridging
 
 **Problem**: CreditFPC needs Fee Juice bridged from L1 to L2 to act as a fee
 payer. The claim can fail transiently while the L1-to-L2 message propagates.

--- a/profiling/benchmarks/credit_fpc.benchmark.ts
+++ b/profiling/benchmarks/credit_fpc.benchmark.ts
@@ -641,78 +641,80 @@ export default class CreditFPCBenchmark {
       }
     }
 
-    // Fallback: use dev_mint with ONCHAIN_UNCONSTRAINED delivery.
+    // Fallback: send another real pay_and_mint to establish credits.
+    // Previous versions used dev_mint here, but that bypasses _finalize_mint
+    // and corrupts unspent_credits accounting.
     if (creditBalance < totalMaxCost) {
-      console.log('\nCredit notes not yet visible. Trying dev_mint fallback...');
+      console.log('\nCredit notes not yet visible. Sending another pay_and_mint...');
 
-      const DEV_NONCE = SEND_NONCE + 1n;
-      const devMintAmount = totalMaxCost * 3n;
-      const devTokenCharge = feeJuiceToAsset(devMintAmount, RATE_NUM, RATE_DEN);
+      const RETRY_NONCE = SEND_NONCE + 1n;
+      const retryCreditMint = totalMaxCost * 3n;
+      const retryTokenCharge = feeJuiceToAsset(retryCreditMint, RATE_NUM, RATE_DEN);
 
       await tokenAsUser.methods
-        .mint_to_private(userAddress, devTokenCharge + 10000n)
+        .mint_to_private(userAddress, retryTokenCharge + 10000n)
         .send({ from: userAddress });
 
-      const devTransferAuthWit = await wallet.createAuthWit(userAddress, {
+      const retryTransferAuthWit = await wallet.createAuthWit(userAddress, {
         caller: fpcAddress,
         action: tokenAsUser.methods.transfer_private_to_private(
           userAddress,
           operatorAddress,
-          devTokenCharge,
-          DEV_NONCE,
+          retryTokenCharge,
+          RETRY_NONCE,
         ),
       });
 
-      const DEV_VALID_UNTIL = VALID_UNTIL + 5n;
-      const devQuoteSigFields = await signQuote(
+      const RETRY_VALID_UNTIL = VALID_UNTIL + 5n;
+      const retryQuoteSigFields = await signQuote(
         schnorr,
         operatorSigningKey,
         fpcAddress,
         tokenAddress,
-        devMintAmount,
-        devTokenCharge,
-        DEV_VALID_UNTIL,
+        retryCreditMint,
+        retryTokenCharge,
+        RETRY_VALID_UNTIL,
         userAddress,
         QUOTE_DOMAIN_SEP,
       );
 
-      const devPayAndMintCall =
+      const retryPayAndMintCall =
         payAndMintMode === 'multi_asset_quoted'
           ? await creditFpcAsUser.methods
               .pay_and_mint(
                 tokenAddress,
-                DEV_NONCE,
-                devMintAmount,
-                devTokenCharge,
-                DEV_VALID_UNTIL,
-                devQuoteSigFields,
+                RETRY_NONCE,
+                retryCreditMint,
+                retryTokenCharge,
+                RETRY_VALID_UNTIL,
+                retryQuoteSigFields,
               )
               .getFunctionCall()
           : await creditFpcAsUser.methods
               .pay_and_mint(
-                DEV_NONCE,
-                devMintAmount,
-                devTokenCharge,
-                DEV_VALID_UNTIL,
-                devQuoteSigFields,
+                RETRY_NONCE,
+                retryCreditMint,
+                retryTokenCharge,
+                RETRY_VALID_UNTIL,
+                retryQuoteSigFields,
               )
               .getFunctionCall();
 
-      const devPayAndMint = new PayAndMintPaymentMethod(
+      const retryPayAndMint = new PayAndMintPaymentMethod(
         fpcAddress,
-        devPayAndMintCall,
-        devTransferAuthWit,
+        retryPayAndMintCall,
+        retryTransferAuthWit,
         payAndMintGasSettings,
       );
 
-      await creditFpcAsUser.methods
-        .dev_mint(totalMaxCost * 2n)
+      await noopAsUser.methods
+        .noop()
         .send({
-          fee: { paymentMethod: devPayAndMint, gasSettings: payAndMintGasSettings },
+          fee: { paymentMethod: retryPayAndMint, gasSettings: payAndMintGasSettings },
           from: userAddress,
           additionalScopes: [operatorAddress],
         });
-      console.log('dev_mint tx mined.');
+      console.log('Retry pay_and_mint tx mined.');
 
       await tokenAsUser.methods
         .mint_to_private(userAddress, 1n)
@@ -737,7 +739,7 @@ export default class CreditFPCBenchmark {
 
       if (creditBalance < totalMaxCost) {
         throw new Error(
-          `Credit balance ${creditBalance} still below required ${totalMaxCost} after dev_mint fallback.`,
+          `Credit balance ${creditBalance} still below required ${totalMaxCost} after retry pay_and_mint.`,
         );
       }
     }

--- a/scripts/contract/deploy-fpc-devnet.sh
+++ b/scripts/contract/deploy-fpc-devnet.sh
@@ -34,7 +34,7 @@ fi
 
 cd "${REPO_ROOT}"
 
-if [[ ! -f target/token_contract-Token.json || ! -f target/credit_fpc-CreditFPC.json || ( ! -f target/fpc-FPCMultiAsset.json && ! -f target/fpc-FPC.json ) ]]; then
+if [[ ! -f target/token_contract-Token.json || ! -f target/credit_fpc-BackedCreditFPC.json || ( ! -f target/fpc-FPCMultiAsset.json && ! -f target/fpc-FPC.json ) ]]; then
   echo "Compiling Aztec workspace artifacts..."
   aztec compile --workspace --force
   FPC_ARTIFACT="$(resolve_default_fpc_artifact)"

--- a/scripts/contract/deploy-fpc-devnet.ts
+++ b/scripts/contract/deploy-fpc-devnet.ts
@@ -6,7 +6,11 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { writeDevnetDeployManifest } from "./devnet-manifest.ts";
 
 type DeployEnvironment = "devnet" | "local";
-type FpcArtifactName = "FPC" | "FPCMultiAsset" | "CreditFPC";
+type FpcArtifactName =
+  | "FPC"
+  | "FPCMultiAsset"
+  | "CreditFPC"
+  | "BackedCreditFPC";
 
 type CliArgs = {
   environment: DeployEnvironment;
@@ -138,7 +142,7 @@ const FPC_ARTIFACT_PATH_CANDIDATES = [
 ] as const;
 const REQUIRED_ARTIFACTS = {
   token: path.join(REPO_ROOT, "target", "token_contract-Token.json"),
-  creditFpc: path.join(REPO_ROOT, "target", "credit_fpc-CreditFPC.json"),
+  creditFpc: path.join(REPO_ROOT, "target", "credit_fpc-BackedCreditFPC.json"),
 } as const;
 
 class CliError extends Error {
@@ -157,7 +161,7 @@ function usage(): string {
     "    --deployer-alias <alias> \\",
     "    --deployer-private-key <hex32> | --deployer-private-key-ref <ref> \\",
     "    --operator-secret-key <hex32> | --operator-secret-key-ref <ref> \\",
-    "    --fpc-artifact <path/to/*-FPC.json|*-FPCMultiAsset.json|*-CreditFPC.json> \\",
+    "    --fpc-artifact <path/to/*-FPC.json|*-FPCMultiAsset.json|*-BackedCreditFPC.json> \\",
     "    --out <path.json> \\",
     "    [--l1-rpc-url <url>] \\",
     "    [--operator <aztec_address>] \\",
@@ -1443,9 +1447,14 @@ function loadFpcArtifactSelection(
     );
   }
   const name = (parsed as { name: string }).name;
-  if (name !== "FPC" && name !== "FPCMultiAsset" && name !== "CreditFPC") {
+  if (
+    name !== "FPC" &&
+    name !== "FPCMultiAsset" &&
+    name !== "CreditFPC" &&
+    name !== "BackedCreditFPC"
+  ) {
     throw new CliError(
-      `Invalid --fpc-artifact at ${artifactPath}: unsupported contract name "${name}". Expected "FPC", "FPCMultiAsset", or "CreditFPC".`,
+      `Invalid --fpc-artifact at ${artifactPath}: unsupported contract name "${name}". Expected "FPC", "FPCMultiAsset", "CreditFPC", or "BackedCreditFPC".`,
     );
   }
   return { artifactPath, name };

--- a/scripts/contract/devnet-manifest.ts
+++ b/scripts/contract/devnet-manifest.ts
@@ -12,7 +12,11 @@ const DECIMAL_UINT_PATTERN = /^(0|[1-9][0-9]*)$/;
 const HEX_FIELD_PATTERN = /^0x[0-9a-fA-F]+$/;
 const HEX_32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
 
-export type FpcArtifactName = "FPC" | "FPCMultiAsset" | "CreditFPC";
+export type FpcArtifactName =
+  | "FPC"
+  | "FPCMultiAsset"
+  | "CreditFPC"
+  | "BackedCreditFPC";
 
 export type DevnetDeployManifest = {
   status: "deploy_ok";
@@ -504,10 +508,11 @@ function parseManifest(input: unknown): DevnetDeployManifest {
     if (
       artifactName !== "FPC" &&
       artifactName !== "FPCMultiAsset" &&
-      artifactName !== "CreditFPC"
+      artifactName !== "CreditFPC" &&
+      artifactName !== "BackedCreditFPC"
     ) {
       throw new ManifestValidationError(
-        'Invalid manifest.fpc_artifact.name: expected "FPC", "FPCMultiAsset", or "CreditFPC"',
+        'Invalid manifest.fpc_artifact.name: expected "FPC", "FPCMultiAsset", "CreditFPC", or "BackedCreditFPC"',
       );
     }
     const artifactPath = requireString(

--- a/scripts/contract/devnet-postdeploy-smoke.ts
+++ b/scripts/contract/devnet-postdeploy-smoke.ts
@@ -31,7 +31,7 @@ type CliArgs = {
   creditTopupWeiOverride: bigint | null;
 };
 
-type FpcVariant = "FPC" | "FPCMultiAsset" | "CreditFPC";
+type FpcVariant = "FPC" | "FPCMultiAsset" | "CreditFPC" | "BackedCreditFPC";
 
 type CliParseResult =
   | { kind: "help" }
@@ -201,7 +201,7 @@ function usage(): string {
     "Usage:",
     "  bunx tsx scripts/contract/devnet-postdeploy-smoke.ts \\",
     "    [--manifest <path.json>] \\",
-    "    [--fpc-artifact <path/to/*-FPC.json|*-FPCMultiAsset.json|*-CreditFPC.json>] \\",
+    "    [--fpc-artifact <path/to/*-FPC.json|*-FPCMultiAsset.json|*-BackedCreditFPC.json>] \\",
     "    [--l1-rpc-url <http(s)-url>] \\",
     "    [--operator-secret-key <hex32>] \\",
     "    [--l1-operator-private-key <hex32>] \\",
@@ -767,10 +767,11 @@ function resolveFpcArtifactSelection(
   if (
     variant !== "FPC" &&
     variant !== "FPCMultiAsset" &&
-    variant !== "CreditFPC"
+    variant !== "CreditFPC" &&
+    variant !== "BackedCreditFPC"
   ) {
     throw new CliError(
-      `Unsupported FPC artifact variant at ${artifactPath}: ${variant}. Expected FPC, FPCMultiAsset, or CreditFPC.`,
+      `Unsupported FPC artifact variant at ${artifactPath}: ${variant}. Expected FPC, FPCMultiAsset, CreditFPC, or BackedCreditFPC.`,
     );
   }
 
@@ -1190,7 +1191,8 @@ async function runSmoke(args: CliArgs): Promise<void> {
   const creditMinTopup =
     maxGasCostNoTeardown * args.topupSafetyMultiplier * 2n + 1_000_000n;
   const fpcTopupAmount =
-    fpcSelection.variant === "CreditFPC"
+    fpcSelection.variant === "CreditFPC" ||
+    fpcSelection.variant === "BackedCreditFPC"
       ? (args.creditTopupWeiOverride ?? creditMinTopup)
       : (args.fpcTopupWeiOverride ?? fpcMinTopup);
   if (args.fpcTopupWeiOverride && args.fpcTopupWeiOverride < fpcMinTopup) {
@@ -1234,7 +1236,10 @@ async function runSmoke(args: CliArgs): Promise<void> {
 
   const QUOTE_DOMAIN_SEPARATOR = deps.Fr.fromHexString("0x465043");
   let successfulTxCount = 0;
-  if (fpcSelection.variant !== "CreditFPC") {
+  if (
+    fpcSelection.variant !== "CreditFPC" &&
+    fpcSelection.variant !== "BackedCreditFPC"
+  ) {
     const fpcExpectedCharge = ceilDiv(
       maxGasCostNoTeardown * args.fpcRateNum,
       args.fpcRateDen,
@@ -1353,7 +1358,8 @@ async function runSmoke(args: CliArgs): Promise<void> {
       fpc.address.toField(),
       token.address.toField(),
       new deps.Fr(creditFjAmount),
-      new deps.Fr(creditAaAmount),
+      new deps.Fr(args.creditRateNum),
+      new deps.Fr(args.creditRateDen),
       new deps.Fr(creditValidUntil),
       operatorAddress.toField(),
     ]);
@@ -1377,10 +1383,11 @@ async function runSmoke(args: CliArgs): Promise<void> {
       .pay_and_mint(
         token.address,
         creditAuthwitNonce,
-        creditFjAmount,
-        creditAaAmount,
+        args.creditRateNum,
+        args.creditRateDen,
         creditValidUntil,
         creditQuoteSigBytes,
+        creditFjAmount,
       )
       .getFunctionCall();
     const creditPayAndMintMethod = {

--- a/scripts/services/credit-fpc-full-lifecycle-e2e.ts
+++ b/scripts/services/credit-fpc-full-lifecycle-e2e.ts
@@ -113,6 +113,8 @@ type QuoteResponse = {
 type QuoteInput = {
   fjAmount: bigint;
   aaPaymentAmount: bigint;
+  rateNum: bigint;
+  rateDen: bigint;
   validUntil: bigint;
   quoteSigBytes: number[];
 };
@@ -671,13 +673,17 @@ function computeAaPaymentFromFj(
 function parseQuoteResponse(
   quote: QuoteResponse,
   expectedAsset: AztecAddress,
+  config: FullE2EConfig,
 ): QuoteInput {
   const quoteSigBytes = Array.from(
     Buffer.from(quote.signature.replace(/^0x/, ""), "hex"),
   );
+  const { rateNum, rateDen } = getFinalRate(config);
   const parsed: QuoteInput = {
     fjAmount: BigInt(quote.fj_amount),
     aaPaymentAmount: BigInt(quote.aa_payment_amount),
+    rateNum,
+    rateDen,
     validUntil: BigInt(quote.valid_until),
     quoteSigBytes,
   };
@@ -693,6 +699,12 @@ function parseQuoteResponse(
   if (parsed.aaPaymentAmount <= 0n) {
     throw new Error(
       "Attestation quote returned non-positive aa_payment_amount",
+    );
+  }
+  const expectedAaPaymentAmount = ceilDiv(parsed.fjAmount * rateNum, rateDen);
+  if (parsed.aaPaymentAmount !== expectedAaPaymentAmount) {
+    throw new Error(
+      `Quote aa_payment_amount mismatch. expected=${expectedAaPaymentAmount} got=${parsed.aaPaymentAmount}`,
     );
   }
   if (
@@ -721,7 +733,8 @@ async function signQuoteForUser(
   fpcAddress: AztecAddress,
   acceptedAsset: AztecAddress,
   fjAmount: bigint,
-  aaPaymentAmount: bigint,
+  rateNum: bigint,
+  rateDen: bigint,
   validUntil: bigint,
   userAddress: AztecAddress,
 ): Promise<QuoteInput> {
@@ -733,7 +746,8 @@ async function signQuoteForUser(
     fpcAddress.toField(),
     acceptedAsset.toField(),
     new Fr(fjAmount),
-    new Fr(aaPaymentAmount),
+    new Fr(rateNum),
+    new Fr(rateDen),
     new Fr(validUntil),
     userAddress.toField(),
   ]);
@@ -743,7 +757,9 @@ async function signQuoteForUser(
   );
   return {
     fjAmount,
-    aaPaymentAmount,
+    aaPaymentAmount: ceilDiv(fjAmount * rateNum, rateDen),
+    rateNum,
+    rateDen,
     validUntil,
     quoteSigBytes: Array.from(signature.toBuffer()),
   };
@@ -811,10 +827,11 @@ async function executeFeePaidTx(
     .pay_and_mint(
       params.token.address,
       transferAuthwitNonce,
-      params.quote.fjAmount,
-      params.quote.aaPaymentAmount,
+      params.quote.rateNum,
+      params.quote.rateDen,
       params.quote.validUntil,
       params.quote.quoteSigBytes,
+      params.quote.fjAmount,
     )
     .getFunctionCall();
 
@@ -1289,7 +1306,7 @@ async function deployContractsAndWriteRuntimeConfig(
   const creditFpcArtifactPath = path.join(
     repoRoot,
     "target",
-    "credit_fpc-CreditFPC.json",
+    "credit_fpc-BackedCreditFPC.json",
   );
 
   const tokenArtifact = loadArtifact(tokenArtifactPath);
@@ -1498,6 +1515,7 @@ async function runFeePaidTargetTxAndAssert(
         config.httpTimeoutMs,
       ),
       result.token.address,
+      config,
     );
     tx1Quote = quote;
     if (quote.fjAmount !== requestedFjAmount) {
@@ -1526,10 +1544,11 @@ async function runFeePaidTargetTxAndAssert(
       .pay_and_mint(
         result.token.address,
         transferAuthwitNonce,
-        quote.fjAmount,
-        quote.aaPaymentAmount,
+        quote.rateNum,
+        quote.rateDen,
         quote.validUntil,
         quote.quoteSigBytes,
+        quote.fjAmount,
       )
       .getFunctionCall();
 
@@ -1712,7 +1731,8 @@ async function runFeePaidTargetTxAndAssert(
       .quote_used(
         result.token.address,
         tx1Quote.fjAmount,
-        tx1Quote.aaPaymentAmount,
+        tx1Quote.rateNum,
+        tx1Quote.rateDen,
         tx1Quote.validUntil,
         result.user,
       )
@@ -1764,6 +1784,7 @@ async function negativeQuoteReplayRejected(
       config.httpTimeoutMs,
     ),
     result.token.address,
+    config,
   );
 
   await executeFeePaidTx(config, result, {
@@ -1796,14 +1817,14 @@ async function negativeExpiredQuoteRejected(
   node: ReturnType<typeof createAztecNodeClient>,
 ): Promise<void> {
   const fjAmount = result.maxGasCostNoTeardown;
-  const aaPaymentAmount = computeAaPaymentFromFj(config, fjAmount);
   const latestTimestamp = await getLatestL2Timestamp(node);
   const expiredQuote = await signQuoteForUser(
     result,
     result.fpc.address,
     result.token.address,
     fjAmount,
-    aaPaymentAmount,
+    getFinalRate(config).rateNum,
+    getFinalRate(config).rateDen,
     latestTimestamp,
     result.user,
   );
@@ -1837,14 +1858,14 @@ async function negativeMintedCreditTooLowRejected(
   }
 
   const fjAmount = result.maxGasCostNoTeardown - 1n;
-  const aaPaymentAmount = computeAaPaymentFromFj(config, fjAmount);
   const latestTimestamp = await getLatestL2Timestamp(node);
   const lowMintQuote = await signQuoteForUser(
     result,
     result.fpc.address,
     result.token.address,
     fjAmount,
-    aaPaymentAmount,
+    getFinalRate(config).rateNum,
+    getFinalRate(config).rateDen,
     latestTimestamp + 600n,
     result.otherUser,
   );
@@ -1871,14 +1892,14 @@ async function negativeSenderBindingRejected(
   node: ReturnType<typeof createAztecNodeClient>,
 ): Promise<void> {
   const fjAmount = result.maxGasCostNoTeardown;
-  const aaPaymentAmount = computeAaPaymentFromFj(config, fjAmount);
   const latestTimestamp = await getLatestL2Timestamp(node);
   const quoteSignedForUser = await signQuoteForUser(
     result,
     result.fpc.address,
     result.token.address,
     fjAmount,
-    aaPaymentAmount,
+    getFinalRate(config).rateNum,
+    getFinalRate(config).rateDen,
     latestTimestamp + 600n,
     result.user,
   );
@@ -1911,7 +1932,8 @@ async function negativeDirectPayAndMintCallRejected(
     result.fpc.address,
     result.token.address,
     fjAmount,
-    aaPaymentAmount,
+    getFinalRate(config).rateNum,
+    getFinalRate(config).rateDen,
     latestTimestamp + 600n,
     result.user,
   );
@@ -1936,10 +1958,11 @@ async function negativeDirectPayAndMintCallRejected(
         .pay_and_mint(
           result.token.address,
           transferAuthwitNonce,
-          quote.fjAmount,
-          quote.aaPaymentAmount,
+          quote.rateNum,
+          quote.rateDen,
           quote.validUntil,
           quote.quoteSigBytes,
+          quote.fjAmount,
         )
         .send({
           from: result.user,
@@ -1999,7 +2022,7 @@ async function negativeInsufficientFeeJuiceSecondTxRejected(
   const fpcArtifactPath = path.join(
     result.repoRoot,
     "target",
-    "credit_fpc-CreditFPC.json",
+    "credit_fpc-BackedCreditFPC.json",
   );
   const tokenArtifact = loadArtifact(tokenArtifactPath);
   const fpcArtifact = loadArtifact(fpcArtifactPath);
@@ -2125,14 +2148,14 @@ async function negativeInsufficientFeeJuiceSecondTxRejected(
   const fjAmount =
     result.maxGasCostNoTeardown * config.creditMintMultiplier +
     config.creditMintBuffer;
-  const aaPaymentAmount = computeAaPaymentFromFj(config, fjAmount);
   const quoteAnchor = await getLatestL2Timestamp(node);
   const quote1 = await signQuoteForUser(
     result,
     isolatedFpc.address,
     isolatedToken.address,
     fjAmount,
-    aaPaymentAmount,
+    getFinalRate(config).rateNum,
+    getFinalRate(config).rateDen,
     quoteAnchor + 600n,
     result.user,
   );

--- a/scripts/services/fpc-services-smoke.ts
+++ b/scripts/services/fpc-services-smoke.ts
@@ -853,8 +853,9 @@ async function verifyAttestationAmountQuoteSignature(
   feePayerAddress: AztecAddress,
   tokenAddress: AztecAddress,
   user: AztecAddress,
-  fjAmount: bigint,
-  aaPaymentAmount: bigint,
+  mintAmount: bigint,
+  rateNum: bigint,
+  rateDen: bigint,
   validUntil: bigint,
   quoteSigBytes: number[],
   scenarioPrefix: string,
@@ -863,8 +864,9 @@ async function verifyAttestationAmountQuoteSignature(
     QUOTE_DOMAIN_SEPARATOR,
     feePayerAddress.toField(),
     tokenAddress.toField(),
-    new Fr(fjAmount),
-    new Fr(aaPaymentAmount),
+    new Fr(mintAmount),
+    new Fr(rateNum),
+    new Fr(rateDen),
     new Fr(validUntil),
     user.toField(),
   ]);
@@ -1225,7 +1227,8 @@ async function runServiceScenario(
         token.address,
         user,
         fjAmount,
-        aaPaymentAmount,
+        expectedRateNum,
+        expectedRateDen,
         validUntil,
         quoteSigBytes,
         scenarioPrefix,
@@ -1537,10 +1540,11 @@ async function runCreditFeeScenario(
     .pay_and_mint(
       token.address,
       transferAuthwitNonce,
-      fjCreditAmount,
-      aaPaymentAmount,
+      quote.rateNum,
+      quote.rateDen,
       quote.validUntil,
       quote.quoteSigBytes,
+      fjCreditAmount,
     )
     .getFunctionCall();
   const payAndMintPaymentMethod = {
@@ -1622,7 +1626,8 @@ async function runCreditFeeScenario(
     .quote_used(
       token.address,
       quote.fjAmount,
-      quote.aaPaymentAmount,
+      quote.rateNum,
+      quote.rateDen,
       quote.validUntil,
       user,
     )
@@ -1722,7 +1727,7 @@ async function main() {
     const creditFpcArtifactPath = path.join(
       repoRoot,
       "target",
-      "credit_fpc-CreditFPC.json",
+      "credit_fpc-BackedCreditFPC.json",
     );
     const tokenArtifact = loadArtifact(tokenArtifactPath);
     const fpcArtifact = needsFpc ? loadArtifact(fpcArtifactPath) : null;

--- a/services/attestation/src/signer.ts
+++ b/services/attestation/src/signer.ts
@@ -41,6 +41,16 @@ export interface RateQuoteParams {
   userAddress: AztecAddress;
 }
 
+export interface CreditRateQuoteParams {
+  fpcAddress: AztecAddress;
+  acceptedAsset: AztecAddress;
+  mintAmount: bigint;
+  rateNum: bigint;
+  rateDen: bigint;
+  validUntil: bigint;
+  userAddress: AztecAddress;
+}
+
 /** Signs a quote hash with Schnorr and returns the raw 64-byte signature as hex. */
 export interface QuoteSchnorrSigner {
   signQuoteHash(quoteHash: Fr): Promise<string>;
@@ -76,6 +86,21 @@ export function computeRateQuoteHash(params: RateQuoteParams): Promise<Fr> {
   ]);
 }
 
+export function computeCreditRateQuoteHash(
+  params: CreditRateQuoteParams,
+): Promise<Fr> {
+  return computeInnerAuthWitHash([
+    QUOTE_DOMAIN_SEPARATOR,
+    params.fpcAddress.toField(),
+    params.acceptedAsset.toField(),
+    new Fr(params.mintAmount),
+    new Fr(params.rateNum),
+    new Fr(params.rateDen),
+    new Fr(params.validUntil),
+    params.userAddress.toField(),
+  ]);
+}
+
 /**
  * Compute the quote hash and sign it with the operator's Schnorr key.
  * Returns the 64-byte signature as a hex string.
@@ -93,6 +118,14 @@ export async function signRateQuote(
   params: RateQuoteParams,
 ): Promise<string> {
   const quoteHash = await computeRateQuoteHash(params);
+  return signer.signQuoteHash(quoteHash);
+}
+
+export async function signCreditRateQuote(
+  signer: QuoteSchnorrSigner,
+  params: CreditRateQuoteParams,
+): Promise<string> {
+  const quoteHash = await computeCreditRateQuoteHash(params);
   return signer.signQuoteHash(quoteHash);
 }
 

--- a/services/attestation/test/credit-fpc-local-smoke.ts
+++ b/services/attestation/test/credit-fpc-local-smoke.ts
@@ -403,7 +403,7 @@ async function main() {
   const creditFpcArtifactPath = path.join(
     repoRoot,
     "target",
-    "credit_fpc-CreditFPC.json",
+    "credit_fpc-BackedCreditFPC.json",
   );
 
   const tokenArtifact = loadArtifact(tokenArtifactPath);
@@ -523,7 +523,8 @@ async function main() {
     creditFpc.address.toField(),
     token.address.toField(),
     new Fr(fjCreditAmount),
-    new Fr(aaPaymentAmount),
+    new Fr(config.rateNum),
+    new Fr(config.rateDen),
     new Fr(validUntil),
     user.toField(),
   ]);
@@ -562,10 +563,11 @@ async function main() {
     .pay_and_mint(
       token.address,
       transferAuthwitNonce,
-      fjCreditAmount,
-      aaPaymentAmount,
+      config.rateNum,
+      config.rateDen,
       validUntil,
       quoteSigBytes,
+      fjCreditAmount,
     )
     .getFunctionCall();
   const payAndMintPaymentMethod = {
@@ -664,7 +666,8 @@ async function main() {
     creditFpc.address.toField(),
     token.address.toField(),
     new Fr(fjCreditAmount),
-    new Fr(aaPaymentAmount),
+    new Fr(config.rateNum),
+    new Fr(config.rateDen),
     new Fr(negativeValidUntil),
     user.toField(),
   ]);
@@ -692,10 +695,11 @@ async function main() {
         .pay_and_mint(
           token.address,
           negativeTransferAuthwitNonce,
-          fjCreditAmount,
-          aaPaymentAmount,
+          config.rateNum,
+          config.rateDen,
           negativeValidUntil,
           negativeQuoteSigBytes,
+          fjCreditAmount,
         )
         .send({
           from: user,

--- a/services/attestation/test/signer.test.ts
+++ b/services/attestation/test/signer.test.ts
@@ -4,10 +4,13 @@ import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import { computeInnerAuthWitHash } from "@aztec/stdlib/auth-witness";
 import {
+  computeCreditRateQuoteHash,
   computeQuoteHash,
   computeQuoteInnerHash,
+  signCreditRateQuote,
   type QuoteParams,
   type QuoteSchnorrSigner,
+  type CreditRateQuoteParams,
   signQuote,
 } from "../src/signer.js";
 
@@ -30,6 +33,18 @@ function makeQuoteParams(): QuoteParams {
     acceptedAsset: ASSET,
     fjFeeAmount: 1_000_000n,
     aaPaymentAmount: 1020n,
+    validUntil: 1740000300n,
+    userAddress: USER,
+  };
+}
+
+function makeCreditRateQuoteParams(): CreditRateQuoteParams {
+  return {
+    fpcAddress: FPC,
+    acceptedAsset: ASSET,
+    mintAmount: 1_000_000n,
+    rateNum: 1020n,
+    rateDen: 1000n,
     validUntil: 1740000300n,
     userAddress: USER,
   };
@@ -91,5 +106,47 @@ describe("signer", () => {
     const userHash = await computeQuoteHash(params);
     const otherUserHash = await computeQuoteHash(otherUserParams);
     assert.equal(userHash.equals(otherUserHash), false);
+  });
+});
+
+describe("signer credit rate quote", () => {
+  it("computes credit rate quote hash with exact preimage order", async () => {
+    const params = makeCreditRateQuoteParams();
+
+    const expected = await computeInnerAuthWitHash([
+      Fr.fromHexString("0x465043"),
+      params.fpcAddress.toField(),
+      params.acceptedAsset.toField(),
+      new Fr(params.mintAmount),
+      new Fr(params.rateNum),
+      new Fr(params.rateDen),
+      new Fr(params.validUntil),
+      params.userAddress.toField(),
+    ]);
+
+    const actual = await computeCreditRateQuoteHash(params);
+    assert.equal(actual.equals(expected), true);
+
+    const wrongOrder = await computeInnerAuthWitHash([
+      Fr.fromHexString("0x465043"),
+      params.fpcAddress.toField(),
+      params.acceptedAsset.toField(),
+      new Fr(params.rateNum),
+      new Fr(params.mintAmount),
+      new Fr(params.rateDen),
+      new Fr(params.validUntil),
+      params.userAddress.toField(),
+    ]);
+    assert.equal(actual.equals(wrongOrder), false);
+  });
+
+  it("returns signature hex for credit rate quote", async () => {
+    const params = makeCreditRateQuoteParams();
+    const signer: QuoteSchnorrSigner = {
+      signQuoteHash: async () => "0xfacefeed",
+    };
+
+    const sig = await signCreditRateQuote(signer, params);
+    assert.equal(sig, "0xfacefeed");
   });
 });


### PR DESCRIPTION
Rename CreditFPC to BackedCreditFPC and enforce that the FPC's on-chain FeeJuice balance always covers outstanding unspent credits.

- Add `unspent_credits` public state and `_finalize_mint` solvency check
- Rework `pay_with_credit` to pessimistically deduct max_gas_cost
- Remove `_refund` and `dev_mint`; add `claim_fee_juice` for L1 bridging
- Remove MAX_QUOTE_TTL_SECONDS and conditional phase enforcement from FPC
- Add `pay_with_credit` Noir test suite
- Update deploy scripts, smoke tests, e2e tests, and benchmarks
- Add attestation signer utility and tests