### PR TITLE
fix(compose): enable e2e tests in smoke service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,6 +118,8 @@ services:
     image: nethermind/aztec-fpc-smoke:local
     profiles: ["smoke", "full"]
     command:
+      - "scripts/services/fpc-full-lifecycle-e2e.ts"
+      - "scripts/services/credit-fpc-full-lifecycle-e2e.ts"
       - "scripts/services/fpc-services-smoke.ts"
       - "services/attestation/test/fee-entrypoint-local-smoke.ts"
       - "services/attestation/test/credit-fpc-local-smoke.ts"
@@ -125,7 +127,9 @@ services:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_LOCAL_OPERATOR_SECRET_KEY: "${FPC_LOCAL_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_SMOKE_L1_RPC_URL: "http://anvil:8545"
+      FPC_FULL_E2E_L1_RPC_URL: "http://anvil:8545"
       CREDIT_FPC_SMOKE_L1_RPC_URL: "http://anvil:8545"
+      FPC_CREDIT_FULL_E2E_L1_RPC_URL: "http://anvil:8545"
       FPC_SERVICES_SMOKE_L1_RPC_URL: "http://anvil:8545"
     depends_on:
       deploy:


### PR DESCRIPTION
## Summary
- Add `fpc-full-lifecycle-e2e.ts` and `credit-fpc-full-lifecycle-e2e.ts` to the smoke service command list
- Add missing `FPC_FULL_E2E_L1_RPC_URL` and `FPC_CREDIT_FULL_E2E_L1_RPC_URL` env vars so the scripts resolve anvil instead of falling back to `127.0.0.1`