### PR TITLE
refactor(fpc): rename get_max_gas_cost_no_teardown to get_max_gas_cost

### DIFF
--- a/contracts/fpc/src/main.nr
+++ b/contracts/fpc/src/main.nr
@@ -102,7 +102,7 @@ pub contract FPCMultiAsset {
             quote_sig,
         );
 
-        let max_fee = get_max_gas_cost_no_teardown(self.context);
+        let max_fee = get_max_gas_cost(self.context);
         assert(fj_fee_amount == max_fee, "quoted fee amount mismatch");
 
         Token::at(accepted_asset)
@@ -156,9 +156,9 @@ pub contract FPCMultiAsset {
         context.set_expiration_timestamp(valid_until);
     }
 
-    /// Maximum possible fee for this tx excluding teardown gas.
+    /// Maximum possible fee for this tx.
     #[contract_library_method]
-    fn get_max_gas_cost_no_teardown(context: &mut PrivateContext) -> u128 {
+    fn get_max_gas_cost(context: &mut PrivateContext) -> u128 {
         let s = context.gas_settings();
         s.max_fees_per_gas.fee_per_da_gas * (s.gas_limits.da_gas as u128)
             + s.max_fees_per_gas.fee_per_l2_gas * (s.gas_limits.l2_gas as u128)


### PR DESCRIPTION
The function calculates the full max gas cost, so the "_no_teardown" suffix was misleading.