### PR TITLE
fix(docker): pin compile stage to amd64 for AVM Transpiler support

### DIFF
--- a/scripts/contract/Dockerfile.deploy
+++ b/scripts/contract/Dockerfile.deploy
@@ -16,8 +16,12 @@ ENV PATH="/root/.aztec/versions/${AZTEC_VERSION}/bin:/root/.aztec/versions/${AZT
 
 # ══════════════════════════════════════════════════════════════
 # Stage 2: compile — contract compilation only
+#
+# Pinned to linux/amd64 because the Aztec bb binary does not
+# have the AVM Transpiler enabled on arm64.  Contract artifacts
+# are platform-independent JSON, so cross-copy is safe.
 # ══════════════════════════════════════════════════════════════
-FROM aztec AS compile
+FROM --platform=linux/amd64 aztec AS compile
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Pin `Dockerfile.deploy` compile stage to `linux/amd64` to fix arm64 multi-arch build failure
- The upstream Aztec `bb` binary does not enable the AVM Transpiler on arm64, causing `aztec compile` to fail
- Contract artifacts are platform-independent JSON, so cross-platform copy from the amd64 compile stage is safe

Closes #192