### PR TITLE
fix(docker): use bake target for cross-platform compile stage

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -81,11 +81,21 @@ target "deps" {
   platforms  = PLATFORMS
 }
 
+target "contract" {
+  context    = "."
+  dockerfile = "scripts/contract/Dockerfile.deploy"
+  target     = "compile"
+  platforms  = ["linux/amd64"]
+}
+
 target "deploy" {
   inherits   = ["_labels"]
   context    = "."
   dockerfile = "scripts/contract/Dockerfile.deploy"
-  contexts   = { deps = "target:deps" }
+  contexts   = {
+    deps     = "target:deps"
+    contract = "target:contract"
+  }
   platforms  = PLATFORMS
   target     = "deploy"
   tags = compact([

--- a/scripts/contract/Dockerfile.deploy
+++ b/scripts/contract/Dockerfile.deploy
@@ -1,5 +1,4 @@
 ARG AZTEC_VERSION=4.0.0-devnet.2-patch.3
-ARG COMPILE_PLATFORM=linux/amd64
 
 # ══════════════════════════════════════════════════════════════
 # Stage 1: aztec — base image with aztec toolchain
@@ -18,11 +17,12 @@ ENV PATH="/root/.aztec/versions/${AZTEC_VERSION}/bin:/root/.aztec/versions/${AZT
 # ══════════════════════════════════════════════════════════════
 # Stage 2: compile — contract compilation only
 #
-# Pinned to linux/amd64 because the Aztec bb binary does not
-# have the AVM Transpiler enabled on arm64.  Contract artifacts
-# are platform-independent JSON, so cross-copy is safe.
+# The compile-base context is the aztec stage pinned to
+# linux/amd64 via docker-bake.hcl, because the Aztec bb binary
+# does not have the AVM Transpiler enabled on arm64.  Contract
+# artifacts are platform-independent JSON, so cross-copy is safe.
 # ══════════════════════════════════════════════════════════════
-FROM --platform=$COMPILE_PLATFORM aztec AS compile
+FROM aztec AS compile
 
 WORKDIR /app
 
@@ -54,7 +54,7 @@ COPY --from=deps /app/node_modules node_modules/
 COPY --from=deps /app/scripts/node_modules scripts/node_modules/
 
 # ── Pull compiled contract artifacts from compile stage ──
-COPY --from=compile /app/target/ target/
+COPY --from=contract /app/target/ target/
 
 # ══════════════════════════════════════════════════════════════
 # Stage 4: deploy — deploying compiled contracts


### PR DESCRIPTION
## Summary
- Replace `FROM --platform` on local stage with a dedicated `compile-base` bake target pinned to `linux/amd64`
- The compile stage now receives the cross-platform aztec image via a bake context, matching the existing pattern used by `deps` and service base targets
- Remove the unused `COMPILE_PLATFORM` build arg from the Dockerfile
- Add `PLATFORMS` env var to CI workflow for multi-platform builds