### PR TITLE
feat(compose): add block-producer service for continuous chain advancement

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -131,6 +131,17 @@ services:
       fund-l1-fee-juice:
         condition: service_completed_successfully
 
+  block-producer:
+    image: nethermind/aztec-fpc-contract-deployment:local
+    entrypoint: ["bash", "/app/scripts/services/block-producer.sh"]
+    volumes:
+      - ./scripts:/app/scripts:ro
+    environment:
+      AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
+    depends_on:
+      aztec-node:
+        condition: service_healthy
+
   postdeploy:
     image: nethermind/aztec-fpc-smoke:local
     profiles: ["postdeploy"]

--- a/scripts/services/block-producer.sh
+++ b/scripts/services/block-producer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AZTEC_NODE_URL:?AZTEC_NODE_URL is required}"
+
+if [[ -z "${SPONSORED_FPC_ADDRESS:-}" ]]; then
+  echo "block-producer: resolving canonical SponsoredFPC address..."
+  SPONSORED_FPC_ADDRESS=$(aztec get-canonical-sponsored-fpc-address | grep -oP '0x[0-9a-f]+')
+fi
+echo "block-producer: registering SponsoredFPC contract..."
+aztec-wallet register-contract "${SPONSORED_FPC_ADDRESS}" SponsoredFPC
+
+echo "block-producer: advancing chain continuously (fpc=${SPONSORED_FPC_ADDRESS})"
+
+while true; do
+  echo "block-producer: sending create-account transaction..."
+  aztec-wallet create-account \
+    --payment "method=fpc-sponsored,fpc=${SPONSORED_FPC_ADDRESS}" \
+    2>&1 || echo "block-producer: transaction failed, retrying..."
+done


### PR DESCRIPTION
## Summary
- Add `block-producer` Docker Compose service that repeatedly sends `aztec-wallet create-account` transactions to keep the chain advancing
- Add `block-producer.sh` script that resolves the canonical SponsoredFPC address at startup and loops with configurable interval
- Service depends on `aztec-node` health and uses `AZTEC_NODE_URL` consistently with other services