### PR TITLE
feat(deploy): run verification script after FPC deployment

### DIFF
--- a/scripts/contract/Dockerfile.deploy
+++ b/scripts/contract/Dockerfile.deploy
@@ -67,6 +67,8 @@ COPY --from=mikefarah/yq:4.45.4 /usr/bin/yq /usr/local/bin/yq
 COPY scripts/contract/deploy-fpc-devnet.ts scripts/contract/
 COPY scripts/contract/deploy-fpc.sh scripts/contract/
 COPY scripts/contract/devnet-manifest.ts scripts/contract/
+COPY scripts/contract/verify-fpc-devnet-deployment.ts scripts/contract/
+COPY services/attestation/src/fpc-immutables.ts services/attestation/src/
 COPY scripts/common/ scripts/common/
 COPY scripts/config/ scripts/config/
 

--- a/scripts/contract/deploy-fpc.sh
+++ b/scripts/contract/deploy-fpc.sh
@@ -13,16 +13,29 @@ fi
 
 bunx tsx scripts/contract/deploy-fpc-devnet.ts "$@"
 
+# Resolve manifest path once for subsequent steps.
+_DATA_DIR="${FPC_DATA_DIR:-./deployments}"
+OUT_PATH="${FPC_OUT:-$_DATA_DIR/manifest.json}"
+
 # Generate service configs if manifest was written (skipped for preflight-only).
 # Set FPC_SKIP_CONFIG_GEN=1 to handle config generation externally.
 if [[ "${FPC_SKIP_CONFIG_GEN:-0}" != "1" ]]; then
-  _DATA_DIR="${FPC_DATA_DIR:-./deployments}"
-  OUT_PATH="${FPC_OUT:-$_DATA_DIR/manifest.json}"
   if [[ -f "$OUT_PATH" ]]; then
     FPC_DATA_DIR="$_DATA_DIR" \
       FPC_DEPLOY_MANIFEST="$OUT_PATH" \
       bash scripts/config/generate-service-configs.sh
   else
     echo "Skipping config generation (manifest not found at $OUT_PATH)."
+  fi
+fi
+
+# Verify deployed contracts on the node (skipped for preflight-only).
+# Set FPC_SKIP_VERIFY=1 to skip verification.
+if [[ "${FPC_SKIP_VERIFY:-0}" != "1" ]]; then
+  if [[ -f "$OUT_PATH" ]]; then
+    bunx tsx scripts/contract/verify-fpc-devnet-deployment.ts \
+      --manifest "$OUT_PATH"
+  else
+    echo "Skipping verification (manifest not found at $OUT_PATH)."
   fi
 fi

--- a/scripts/contract/verify-fpc-devnet-deployment.ts
+++ b/scripts/contract/verify-fpc-devnet-deployment.ts
@@ -480,20 +480,25 @@ async function main(): Promise<void> {
   const deps = await loadAztecDeps();
   const node = deps.createAztecNodeClient(manifest.network.node_url);
 
-  await Promise.race([
-    deps.waitForNode(node),
-    new Promise((_, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            new CliError(
-              `Timed out waiting for node readiness at ${manifest.network.node_url}`,
+  let nodeReadyTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      deps.waitForNode(node),
+      new Promise((_, reject) => {
+        nodeReadyTimer = setTimeout(
+          () =>
+            reject(
+              new CliError(
+                `Timed out waiting for node readiness at ${manifest.network.node_url}`,
+              ),
             ),
-          ),
-        args.nodeReadyTimeoutMs,
-      ),
-    ),
-  ]);
+          args.nodeReadyTimeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(nodeReadyTimer);
+  }
   console.log("[verify-fpc-devnet] node connectivity check passed");
 
   let lastIssues: string[] = [];


### PR DESCRIPTION
## Summary
- Hoist `_DATA_DIR` / `OUT_PATH` resolution so the manifest path is computed once and shared by subsequent steps
- Invoke `verify-fpc-devnet-deployment.ts` after config generation in `deploy-fpc.sh`
- Skip verification when no manifest exists on disk (preflight-only mode)
- Support `FPC_SKIP_VERIFY=1` env var to bypass verification