### PR TITLE
ci(docker): split test logs into separate always-run steps

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -81,8 +81,17 @@ jobs:
       - name: Run services and tests
         run: docker compose --profile full up wait --wait
 
-      - name: Test logs
-        run: docker compose --profile full logs --timestamps smoke-services smoke-fee-entrypoint e2e-fpc
+      - name: Print smoke-services logs
+        if: always()
+        run: docker compose --profile full logs --timestamps smoke-services
+
+      - name: Print smoke-fee-entrypoint logs
+        if: always()
+        run: docker compose --profile full logs --timestamps smoke-fee-entrypoint
+
+      - name: Print e2e-fpc logs
+        if: always()
+        run: docker compose --profile full logs --timestamps e2e-fpc
 
       - name: Tear down
         if: always()


### PR DESCRIPTION
## Summary
- Split the single "Test logs" CI step into three separate steps (one per service: `smoke-services`, `smoke-fee-entrypoint`, `e2e-fpc`)
- Added `if: always()` so logs are printed even when tests fail