### PR TITLE
fix(viem): use fallback transport to match ExtendedViemWalletClient type

### DIFF
--- a/scripts/common/deploy-utils.ts
+++ b/scripts/common/deploy-utils.ts
@@ -8,6 +8,9 @@
  */
 
 import { Contract } from "@aztec/aztec.js/contracts";
+import pino from "pino";
+
+const pinoLogger = pino();
 
 type DeployParams = Parameters<typeof Contract.deploy>;
 
@@ -33,9 +36,7 @@ export async function deployContract(
     );
   } catch (error) {
     if (isClassPublicationRace(error)) {
-      console.log(
-        "[deploy] Contract class publication race detected, waiting for sync before retry",
-      );
+      pinoLogger.info("Contract class publication race detected, waiting for sync before retry");
       // Give the PXE time to sync the block containing the class publication
       // from the winning script before retrying with skipClassPublication.
       await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/scripts/common/script-credentials.ts
+++ b/scripts/common/script-credentials.ts
@@ -21,8 +21,11 @@ import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { createLogger } from "@aztec/foundation/log";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
 import type { EmbeddedWallet } from "@aztec/wallets/embedded";
-import { createWalletClient, type Hex, http, publicActions } from "viem";
+import pino from "pino";
+import { createWalletClient, fallback, type Hex, http, publicActions } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+const pinoLogger = pino();
 
 /** Timeout for L1→L2 message readiness. */
 const L1_TO_L2_MESSAGE_TIMEOUT_SECONDS = 120;
@@ -64,7 +67,7 @@ export async function resolveScriptAccounts(
   // Generate a random L1 account and fund it via Anvil.
   const l1Key = generatePrivateKey();
   const l1Account = privateKeyToAccount(l1Key);
-  console.log(`[script-credentials] generated L1 account ${l1Account.address}`);
+  pinoLogger.info(`generated L1 account ${l1Account.address}`);
 
   await fundL1Account(l1RpcUrl, l1Account.address);
 
@@ -73,11 +76,11 @@ export async function resolveScriptAccounts(
   // Set up L1 portal for bridging FeeJuice.
   const l1WalletClient = createWalletClient({
     account: l1Account,
-    transport: http(l1RpcUrl),
+    transport: fallback([http(l1RpcUrl)]),
   }).extend(publicActions);
   const portal = await L1FeeJuicePortalManager.new(
     node,
-    l1WalletClient as Parameters<typeof L1FeeJuicePortalManager.new>[1],
+    l1WalletClient,
     createLogger("script-credentials:bridge"),
   );
 
@@ -91,7 +94,7 @@ export async function resolveScriptAccounts(
 
   // Mint additional L1 FeeJuice so the L1 account retains a balance.
   await portal.getTokenManager().mint(l1Account.address);
-  console.log(`[script-credentials] minted L1 FeeJuice for ${l1Account.address}`);
+  pinoLogger.info(`minted L1 FeeJuice for ${l1Account.address}`);
 
   // Wait for L1→L2 messages, then deploy accounts with claimed FeeJuice.
   for (let i = 0; i < preResults.length; i++) {
@@ -127,7 +130,7 @@ async function fundL1Account(l1RpcUrl: string, address: string): Promise<void> {
   if (result.error) {
     throw new Error(`anvil_setBalance RPC error: ${result.error.message}`);
   }
-  console.log(`[script-credentials] funded L1 account ${address} with 1 ETH`);
+  pinoLogger.info(`funded L1 account ${address} with 1 ETH`);
 }
 
 // ---------------------------------------------------------------------------
@@ -160,14 +163,12 @@ async function preClaim(
     account.signingKey,
   );
   const l2Address = accountManager.address;
-  console.log(`[script-credentials] registered L2 account ${role}=${l2Address.toString()}`);
+  pinoLogger.info(`registered L2 account ${role}=${l2Address.toString()}`);
 
   // 2. Bridge FeeJuice L1→L2 for this account.
   const l2Claim = await portal.bridgeTokensPublic(l2Address, undefined, true);
   const messageHash = Fr.fromHexString(l2Claim.messageHash as string);
-  console.log(
-    `[script-credentials] bridged FeeJuice L1→L2 for account[${index}]=${l2Address.toString()}`,
-  );
+  pinoLogger.info(`bridged FeeJuice L1→L2 for account[${index}]=${l2Address.toString()}`);
 
   return {
     account,
@@ -193,7 +194,7 @@ async function deployWithClaim(
     timeoutSeconds: L1_TO_L2_MESSAGE_TIMEOUT_SECONDS,
     forPublicConsumption: false,
   });
-  console.log(`[script-credentials] L1→L2 message ready for account[${index}]`);
+  pinoLogger.info(`L1→L2 message ready for account[${index}]`);
 
   const feePayment = new FeeJuicePaymentMethodWithClaim(l2Address, pending.claim);
   const deployMethod = await accountManager.getDeployMethod();
@@ -203,5 +204,5 @@ async function deployWithClaim(
     skipClassPublication: true,
     skipInstancePublication: false,
   });
-  console.log(`[script-credentials] deployed L2 account[${index}]=${l2Address.toString()}`);
+  pinoLogger.info(`deployed L2 account[${index}]=${l2Address.toString()}`);
 }

--- a/services/topup/src/bridge.ts
+++ b/services/topup/src/bridge.ts
@@ -10,7 +10,15 @@ import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import { L1FeeJuicePortalManager, type L2AmountClaim } from "@aztec/aztec.js/ethereum";
 import type { AztecNode } from "@aztec/aztec.js/node";
 import { createLogger, type Logger } from "@aztec/foundation/log";
-import { type Chain, createWalletClient, defineChain, type Hex, http, publicActions } from "viem";
+import {
+  type Chain,
+  createWalletClient,
+  defineChain,
+  fallback,
+  type Hex,
+  http,
+  publicActions,
+} from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import * as viemChains from "viem/chains";
 
@@ -149,9 +157,9 @@ export async function bridgeFeeJuice(
       const walletClient = deps.createWalletClient({
         account,
         chain,
-        transport: deps.http(l1RpcUrl),
+        transport: fallback([deps.http(l1RpcUrl)]),
       });
-      const extendedClient = walletClient.extend(publicActions) as unknown as ExtendedWalletClient;
+      const extendedClient = walletClient.extend(publicActions) as ExtendedWalletClient;
       const portalManager = await deps.createPortalManager(node, extendedClient, logger);
       claim = await portalManager.bridgeTokensPublic(fpcL2Address, amount);
       break;


### PR DESCRIPTION
## Summary
- Use `fallback([http(...)])` transport so viem client type matches aztec's `ExtendedViemWalletClient`
- Remove unsafe type assertion in `script-credentials.ts`
- Replace double cast (`as unknown as`) with single cast (`as`) in `bridge.ts`