### PR TITLE
refactor(docker): slim down deploy image by removing Aztec toolchain

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,7 +20,7 @@ variable "PLATFORM_SUFFIX" {
 }
 
 group "default" {
-  targets = ["attestation", "topup", "deploy", "smoke"]
+  targets = ["attestation", "topup", "deploy", "contract", "smoke"]
 }
 
 group "services" {
@@ -83,9 +83,12 @@ target "deps" {
 
 target "contract" {
   context    = "."
-  dockerfile = "scripts/contract/Dockerfile.deploy"
-  target     = "compile"
+  dockerfile = "scripts/contract/Dockerfile.contract"
   platforms  = ["linux/amd64"]
+  tags = compact([
+    "${REGISTRY}nethermind/aztec-fpc-contract-artifact:${TAG}${PLATFORM_SUFFIX}",
+    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-contract-artifact:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
+  ])
 }
 
 target "deploy" {
@@ -97,7 +100,6 @@ target "deploy" {
     contract = "target:contract"
   }
   platforms  = PLATFORMS
-  target     = "deploy"
   tags = compact([
     "${REGISTRY}nethermind/aztec-fpc-contract-deployment:${TAG}${PLATFORM_SUFFIX}",
     GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-contract-deployment:${GIT_SHA}${PLATFORM_SUFFIX}" : "",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,7 +118,7 @@ services:
         condition: service_completed_successfully
 
   block-producer:
-    image: nethermind/aztec-fpc-contract-deployment:local
+    image: nethermind/aztec-fpc-contract-artifact:local
     entrypoint: ["bash", "/app/scripts/services/block-producer.sh"]
     volumes:
       - ./scripts:/app/scripts:ro

--- a/scripts/common/deploy-utils.ts
+++ b/scripts/common/deploy-utils.ts
@@ -8,7 +8,11 @@
  * already published before each attempt.
  */
 
-import { Contract, getContractClassFromArtifact } from "@aztec/aztec.js/contracts";
+import {
+  Contract,
+  type DeployOptions,
+  getContractClassFromArtifact,
+} from "@aztec/aztec.js/contracts";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -17,7 +21,6 @@ const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 3000;
 
 type DeployParams = Parameters<typeof Contract.deploy>;
-type SendOptions = Parameters<ReturnType<typeof Contract.deploy>["send"]>[0];
 
 /**
  * Deploy a contract with automatic retry on class publication races.
@@ -32,25 +35,21 @@ export async function deployContract(
   wallet: DeployParams[0],
   artifact: DeployParams[1],
   args: DeployParams[2],
-  sendOptions: Record<string, unknown> = {},
+  sendOptions: DeployOptions,
   constructorName?: DeployParams[3],
 ) {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const opts = { ...sendOptions };
 
-      if (attempt > 0) {
-        const classId = getContractClassFromArtifact(artifact).id;
-        const metadata = await wallet.getContractClassMetadata(classId);
-        if (metadata.isContractClassPubliclyRegistered) {
-          pinoLogger.info("Contract class already publicly registered, skipping class publication");
-          opts.skipClassPublication = true;
-        }
+      const classId = (await getContractClassFromArtifact(artifact)).id;
+      const metadata = await wallet.getContractClassMetadata(classId);
+      if (metadata.isContractClassPubliclyRegistered) {
+        pinoLogger.info("Contract class already publicly registered, skipping class publication");
+        opts.skipClassPublication = true;
       }
 
-      return await Contract.deploy(wallet, artifact, args, constructorName).send(
-        opts as SendOptions,
-      );
+      return await Contract.deploy(wallet, artifact, args, constructorName).send(opts);
     } catch (error) {
       if (isClassPublicationRace(error) && attempt < MAX_RETRIES) {
         pinoLogger.info(

--- a/scripts/contract/Dockerfile.contract
+++ b/scripts/contract/Dockerfile.contract
@@ -1,0 +1,22 @@
+ARG AZTEC_VERSION=4.0.0-devnet.2-patch.3
+
+FROM node:24-trixie-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl git g++ jq make python3 && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG AZTEC_VERSION
+RUN curl -sL https://install.aztec.network/${AZTEC_VERSION} | VERSION=${AZTEC_VERSION} bash -i
+
+ENV PATH="/root/.aztec/versions/${AZTEC_VERSION}/bin:/root/.aztec/versions/${AZTEC_VERSION}/node_modules/.bin:$PATH"
+
+WORKDIR /app
+
+COPY .aztecrc ./
+COPY Nargo.toml ./
+COPY contracts/ contracts/
+COPY mock/counter/ mock/counter/
+COPY vendor/ vendor/
+
+RUN aztec compile --workspace --force

--- a/scripts/contract/Dockerfile.deploy
+++ b/scripts/contract/Dockerfile.deploy
@@ -1,68 +1,9 @@
-ARG AZTEC_VERSION=4.0.0-devnet.2-patch.3
-
-# ══════════════════════════════════════════════════════════════
-# Stage 1: aztec — base image with aztec toolchain
-# ══════════════════════════════════════════════════════════════
-FROM node:24-trixie-slim AS aztec
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl git g++ jq make python3 && \
-    rm -rf /var/lib/apt/lists/*
-
-ARG AZTEC_VERSION
-RUN curl -sL https://install.aztec.network/${AZTEC_VERSION} | VERSION=${AZTEC_VERSION} bash -i
-
-ENV PATH="/root/.aztec/versions/${AZTEC_VERSION}/bin:/root/.aztec/versions/${AZTEC_VERSION}/node_modules/.bin:$PATH"
-
-# ══════════════════════════════════════════════════════════════
-# Stage 2: compile — contract compilation only
-#
-# The compile-base context is the aztec stage pinned to
-# linux/amd64 via docker-bake.hcl, because the Aztec bb binary
-# does not have the AVM Transpiler enabled on arm64.  Contract
-# artifacts are platform-independent JSON, so cross-copy is safe.
-# ══════════════════════════════════════════════════════════════
-FROM aztec AS compile
-
-WORKDIR /app
-
-COPY .aztecrc ./
-COPY Nargo.toml ./
-COPY contracts/ contracts/
-COPY mock/counter/ mock/counter/
-COPY vendor/ vendor/
-
-RUN aztec compile --workspace --force
-
-# ══════════════════════════════════════════════════════════════
-# Stage 3: runtime — common runtime image with JS dependencies
-# ══════════════════════════════════════════════════════════════
-FROM aztec AS runtime
+FROM deps
 
 ENV CRS_PATH=/app/.bb-crs
 
-# ── Install Bun ──
-COPY --from=oven/bun:1.3.9-slim /usr/local/bin/bun /usr/local/bin/bun
-COPY --from=oven/bun:1.3.9-slim /usr/local/bin/bunx /usr/local/bin/bunx
-
-WORKDIR /app
-
-# ── JS dependencies (reused from deps stage via bake context) ──
-COPY package.json bun.lock ./
-COPY sdk/package.json sdk/
-COPY scripts/package.json scripts/
-COPY services/attestation/package.json services/attestation/
-COPY services/topup/package.json services/topup/
-COPY --from=deps /app/node_modules node_modules/
-COPY --from=deps /app/scripts/node_modules scripts/node_modules/
-
 # ── Pull compiled contract artifacts from compile stage ──
 COPY --from=contract /app/target/ target/
-
-# ══════════════════════════════════════════════════════════════
-# Stage 4: deploy — deploying compiled contracts
-# ══════════════════════════════════════════════════════════════
-FROM runtime AS deploy
 
 # Install yq for YAML processing during config generation
 COPY --from=mikefarah/yq:4.45.4 /usr/bin/yq /usr/local/bin/yq

--- a/scripts/contract/deploy-fpc.sh
+++ b/scripts/contract/deploy-fpc.sh
@@ -11,7 +11,7 @@ if [[ ! -f target/token_contract-Token.json || ! -f target/fpc-FPCMultiAsset.jso
   aztec compile --workspace --force
 fi
 
-bunx tsx scripts/contract/deploy-fpc-devnet.ts "$@"
+bun run scripts/contract/deploy-fpc-devnet.ts "$@"
 
 # Generate service configs if manifest was written (skipped for preflight-only).
 # Set FPC_SKIP_CONFIG_GEN=1 to handle config generation externally.

--- a/scripts/services/fpc-full-lifecycle-e2e.ts
+++ b/scripts/services/fpc-full-lifecycle-e2e.ts
@@ -1365,7 +1365,7 @@ async function negativeExpiredQuoteRejected(
     result.user,
   );
 
-  await waitForNextBlock(node, 60_000);
+  await waitForNextBlock(node, 120_000);
 
   await expectFailure("negative expired quote rejected", ["quote expired"], () =>
     executeFeePaidTx(config, result, {

--- a/services/Dockerfile.common
+++ b/services/Dockerfile.common
@@ -1,16 +1,16 @@
 ARG SERVICE
 
 # ---------- deps: install all dependencies (dev + prod) ----------
-FROM oven/bun:1.3.9-slim AS deps
+FROM oven/bun:1.3.9-slim AS base
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      python3 \
-      make \
-      g++ && \
+    apt-get install -y --no-install-recommends g++ jq make python3 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+# ---------- deps: install all dependencies (dev + prod) ----------
+FROM base AS deps
 
 # Bun workspace resolution requires every member's package.json present
 # before `bun install` will accept the lockfile.
@@ -34,14 +34,7 @@ COPY services/${SERVICE}/src/ services/${SERVICE}/src/
 RUN cd services/${SERVICE} && bun run build
 
 # ---------- external-deps: only packages excluded from the bundle ----------
-FROM oven/bun:1.3.9-slim AS external-deps
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      python3 \
-      make \
-      g++ && \
-    rm -rf /var/lib/apt/lists/*
+FROM base AS external-deps
 
 WORKDIR /deps
 


### PR DESCRIPTION
## Summary
- Extract contract compilation into standalone `Dockerfile.contract`, removing the Aztec toolchain from the deploy image (~5GB → ~2GB)
- Rebase `Dockerfile.deploy` on the shared `deps` stage instead of bundling its own Node + Aztec layers
- Introduce a `base` stage in `Dockerfile.common` so `deps` and `external-deps` share the same OS packages
- Add `jq` to the shared base packages
- Switch `deploy-fpc.sh` from `bunx tsx` to `bun run`