### PR TITLE
WIP: feat(fpc): add cold-start entrypoint for claim-and-pay in one tx

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -3,6 +3,7 @@ members = [
     "contracts/fpc",
     "contracts/faucet",
     "contracts/noop",
+    "contracts/token_bridge",
     "mock/counter",
     "vendor/aztec-standards/src/generic_proxy",
     "vendor/aztec-standards/src/token_contract",

--- a/contracts/fpc/Nargo.toml
+++ b/contracts/fpc/Nargo.toml
@@ -7,4 +7,5 @@ compiler_version = ">=0.25.0"
 [dependencies]
 aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.3", directory = "noir-projects/aztec-nr/aztec" }
 token = { path = "../../vendor/aztec-standards/src/token_contract" }
+token_bridge_contract = { path = "../token_bridge" }
 schnorr = { tag = "v0.1.3", git = "https://github.com/noir-lang/schnorr" }

--- a/contracts/fpc/src/main.nr
+++ b/contracts/fpc/src/main.nr
@@ -30,8 +30,12 @@ pub contract FPCMultiAsset {
     };
     use std::embedded_curve_ops::EmbeddedCurvePoint;
     use token::Token;
+    use token_bridge_contract::TokenBridge;
 
     global QUOTE_DOMAIN_SEPARATOR: Field = 0x465043;
+    // "FPCs" -- distinct domain separator for cold-start quotes to prevent
+    // cross-entrypoint replay between fee_entrypoint and cold_start_entrypoint.
+    global COLD_START_QUOTE_DOMAIN_SEPARATOR: Field = 0x46504373;
     // Quotes must expire within this many seconds from the tx anchor timestamp.
     global MAX_QUOTE_TTL_SECONDS: u64 = 3600;
     global GRUMPKIN_CURVE_B: Field = 17;
@@ -116,6 +120,120 @@ pub contract FPCMultiAsset {
         }
     }
 
+    /// Cold-start entrypoint: claim bridged tokens and pay gas in one tx.
+    ///
+    /// This function is the transaction root (msg_sender = None). There is no
+    /// account entrypoint -- the FPC call is the kernel's sole initial call.
+    /// This prevents batching of arbitrary reverting calls after setup.
+    ///
+    /// Flow:
+    ///   Setup:  guard root call, verify claim covers fee, verify quote, set fee payer
+    ///   App:    claim from bridge, transfer fee to operator
+    #[external("private")]
+    #[allow_phase_change]
+    fn cold_start_entrypoint(
+        user: AztecAddress,
+        accepted_asset: AztecAddress,
+        bridge: AztecAddress,
+        claim_amount: u128,
+        claim_secret: Field,
+        claim_secret_hash: Field,
+        message_leaf_index: Field,
+        authwit_nonce: Field,
+        fj_fee_amount: u128,
+        aa_payment_amount: u128,
+        valid_until: u64,
+        quote_sig: [u8; 64],
+    ) {
+        // (a) Guard: this must be the transaction root.
+        //
+        // The Aztec kernel populates msg_sender as None only for the very first
+        // private call frame. If any contract had called us -- including the
+        // user's account entrypoint dispatching batched calls -- msg_sender would
+        // be Some(caller). Therefore this assertion is a reliable, unforgeable
+        // proof that no additional app logic exists in this transaction.
+        assert(self.context.maybe_msg_sender().is_none(), "must be tx entrypoint");
+
+        let max_fees = self.context.gas_settings().max_fees_per_gas;
+        let enforce_setup_phase =
+            (max_fees.fee_per_da_gas > 0) | (max_fees.fee_per_l2_gas > 0);
+        if enforce_setup_phase {
+            assert(
+                !self.context.in_revertible_phase(),
+                "cold_start_entrypoint must run in setup phase",
+            );
+        }
+
+        let config = self.storage.config.read();
+
+        // (b) Verify the claim is large enough to cover the fee.
+        //     Checked here in setup so the app-phase transfer cannot fail.
+        assert(claim_amount >= aa_payment_amount, "claim insufficient to cover fee");
+
+        // (c) Verify operator quote.
+        //
+        //     The extended preimage includes claim_amount and claim_secret_hash,
+        //     binding the operator's attestation to a specific bridge deposit.
+        //     Using COLD_START_QUOTE_DOMAIN_SEPARATOR prevents cross-entrypoint replay.
+        assert_valid_cold_start_quote(
+            self.context,
+            EmbeddedCurvePoint {
+                x: config.operator_pubkey_x,
+                y: config.operator_pubkey_y,
+                is_infinite: false,
+            },
+            accepted_asset,
+            fj_fee_amount,
+            aa_payment_amount,
+            valid_until,
+            user,
+            claim_amount,
+            claim_secret_hash,
+            quote_sig,
+        );
+
+        let max_fee = get_max_gas_cost(self.context);
+        assert(fj_fee_amount == max_fee, "quoted fee amount mismatch");
+
+        // (d) Declare fee payer and close the setup phase.
+        //     All state changes from this point on are in the revertible phase,
+        //     but since this function is the tx root (see (a)), there is nothing
+        //     else that could revert and leave the FPC at a loss.
+        self.context.set_as_fee_payer();
+        if enforce_setup_phase | !self.context.in_revertible_phase() {
+            self.context.end_setup();
+        }
+
+        // === Revertible (app) phase ===
+
+        // (e) Claim tokens from the bridge into the user's private balance.
+        //
+        //     The operator's signature binds claim_secret_hash and claim_amount,
+        //     so the operator has already verified off-chain that a valid pending
+        //     deposit exists. If the claim fails despite a valid operator signature,
+        //     it is an operator-side error, not a user attack.
+        TokenBridge::at(bridge)
+            .claim_private(
+                user,
+                claim_amount,
+                claim_secret,
+                message_leaf_index,
+            )
+            .call(self.context);
+
+        // (f) Transfer the fee from the user's (freshly claimed) private balance
+        //     to the operator. Cannot fail: claim_amount >= aa_payment_amount was
+        //     asserted in setup, and the user pre-signed the authwit for this transfer.
+        Token::at(accepted_asset)
+            .transfer_private_to_private(
+                user,
+                config.operator,
+                aa_payment_amount,
+                authwit_nonce,
+            )
+            .call(self.context);
+    }
+
     /// Compute the quote hash and verify the operator's Schnorr signature
     /// inline. Pushes a nullifier to prevent replay.
     ///
@@ -148,6 +266,51 @@ pub contract FPCMultiAsset {
         context.push_nullifier(quote_hash);
 
         let anchor_ts = context.get_anchor_block_header().global_variables.timestamp;
+        assert(anchor_ts <= valid_until, "quote expired");
+        let quote_ttl = valid_until - anchor_ts;
+        assert(quote_ttl <= MAX_QUOTE_TTL_SECONDS, "quote ttl too large");
+        context.set_expiration_timestamp(valid_until);
+    }
+
+    /// Verify operator cold-start quote with extended preimage that binds
+    /// the signature to a specific bridge deposit (claim_amount + claim_secret_hash).
+    ///
+    /// Uses COLD_START_QUOTE_DOMAIN_SEPARATOR to prevent cross-entrypoint replay.
+    #[contract_library_method]
+    fn assert_valid_cold_start_quote(
+        context: &mut PrivateContext,
+        operator_pubkey: EmbeddedCurvePoint,
+        accepted_asset: AztecAddress,
+        fj_fee_amount: u128,
+        aa_payment_amount: u128,
+        valid_until: u64,
+        user_address: AztecAddress,
+        claim_amount: u128,
+        claim_secret_hash: Field,
+        quote_sig: [u8; 64],
+    ) {
+        let quote_hash = compute_inner_authwit_hash([
+            COLD_START_QUOTE_DOMAIN_SEPARATOR,
+            context.this_address().to_field(),
+            accepted_asset.to_field(),
+            fj_fee_amount as Field,
+            aa_payment_amount as Field,
+            valid_until as Field,
+            user_address.to_field(),
+            claim_amount as Field,
+            claim_secret_hash,
+        ]);
+
+        schnorr::assert_valid_signature(
+            operator_pubkey,
+            quote_sig,
+            quote_hash.to_be_bytes::<32>(),
+        );
+
+        context.push_nullifier(quote_hash);
+
+        let anchor_ts =
+            context.get_anchor_block_header().global_variables.timestamp;
         assert(anchor_ts <= valid_until, "quote expired");
         let quote_ttl = valid_until - anchor_ts;
         assert(quote_ttl <= MAX_QUOTE_TTL_SECONDS, "quote ttl too large");

--- a/contracts/fpc/src/test.nr
+++ b/contracts/fpc/src/test.nr
@@ -1,2 +1,3 @@
+pub mod cold_start_entrypoint;
 pub mod fee_entrypoint;
 pub mod utils;

--- a/contracts/fpc/src/test/cold_start_entrypoint.nr
+++ b/contracts/fpc/src/test/cold_start_entrypoint.nr
@@ -1,0 +1,195 @@
+use crate::{FPCMultiAsset, test::utils};
+use aztec::protocol::constants::NULL_MSG_SENDER_CONTRACT_ADDRESS;
+use aztec::test::helpers::authwit::add_private_authwit_from_call;
+use token::Token;
+
+global TRANSFER_AUTHWIT_NONCE: Field = 100;
+global CLAIM_SECRET: Field = 0xdeadbeef;
+global CLAIM_SECRET_HASH: Field = 0xcafebabe;
+global MESSAGE_LEAF_INDEX: Field = 0;
+
+/// TXE limitation: the L1-to-L2 message tree is always zero-filled, so                                                                              
+/// `TokenBridge::claim_private` (which calls `consume_l1_to_l2_message`)                                                                          
+/// cannot find the message hash and the oracle rejects the call.                                                                                    
+/// This test validates the setup phase (root-call guard, claim-covers-fee                                                                           
+/// check, quote signature, fee payer declaration) and expects the bridge                                                                            
+/// claim to fail.                                        
+#[test(should_fail_with = "No L1 to L2 message found")]
+unconstrained fn cold_start_happy_path() {
+    let (mut env, fpc_address, token_address, bridge_address, _operator, user) = utils::setup();
+    let fpc = FPCMultiAsset::at(fpc_address);
+
+    let fj_fee_amount = utils::max_gas_cost_no_teardown(env);
+    let aa_payment_amount = fj_fee_amount;
+    let claim_amount = aa_payment_amount + (1000 as u128);
+    let valid_until = env.last_block_timestamp() + 3600;
+
+    let quote_sig = utils::sign_cold_start_quote(
+        fpc_address,
+        token_address,
+        fj_fee_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+        claim_amount,
+        CLAIM_SECRET_HASH,
+    );
+
+    let _ = env.call_private(
+        NULL_MSG_SENDER_CONTRACT_ADDRESS,
+        fpc.cold_start_entrypoint(
+            user,
+            token_address,
+            bridge_address,
+            claim_amount,
+            CLAIM_SECRET,
+            CLAIM_SECRET_HASH,
+            MESSAGE_LEAF_INDEX,
+            TRANSFER_AUTHWIT_NONCE,
+            fj_fee_amount,
+            aa_payment_amount,
+            valid_until,
+            quote_sig,
+        ),
+    );
+}
+
+/// cold_start_entrypoint requires msg_sender = None (tx root). When called
+/// through env.call_private(user, ...) the msg_sender is set to `user`,
+/// so the root-call guard must reject it.
+#[test(should_fail_with = "must be tx entrypoint")]
+unconstrained fn cold_start_rejects_non_root_caller() {
+    let (mut env, fpc_address, token_address, bridge_address, _operator, user) = utils::setup();
+    let fpc = FPCMultiAsset::at(fpc_address);
+
+    let fj_fee_amount = utils::max_gas_cost_no_teardown(env);
+    let aa_payment_amount = fj_fee_amount;
+    let claim_amount = aa_payment_amount + (1000 as u128);
+    let valid_until = env.last_block_timestamp() + 3600;
+
+    let quote_sig = utils::sign_cold_start_quote(
+        fpc_address,
+        token_address,
+        fj_fee_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+        claim_amount,
+        CLAIM_SECRET_HASH,
+    );
+
+    let _ = env.call_private(
+        user,
+        fpc.cold_start_entrypoint(
+            user,
+            token_address,
+            bridge_address,
+            claim_amount,
+            CLAIM_SECRET,
+            CLAIM_SECRET_HASH,
+            MESSAGE_LEAF_INDEX,
+            TRANSFER_AUTHWIT_NONCE,
+            fj_fee_amount,
+            aa_payment_amount,
+            valid_until,
+            quote_sig,
+        ),
+    );
+}
+
+/// A cold-start quote (COLD_START_QUOTE_DOMAIN_SEPARATOR) must not be
+/// accepted by fee_entrypoint (QUOTE_DOMAIN_SEPARATOR) and vice versa.
+/// This test signs with the cold-start domain and submits through fee_entrypoint.
+#[test(should_fail_with = "Cannot satisfy constraint")]
+unconstrained fn cold_start_quote_rejected_by_fee_entrypoint() {
+    let (mut env, fpc_address, token_address, _bridge_address, operator, user) = utils::setup();
+    let fpc = FPCMultiAsset::at(fpc_address);
+    let token = Token::at(token_address);
+
+    let fj_fee_amount = utils::max_gas_cost_no_teardown(env);
+    let aa_payment_amount = fj_fee_amount;
+    let claim_amount = aa_payment_amount + (500 as u128);
+    let mint_amount = aa_payment_amount + (1000 as u128);
+    env.call_private(operator, token.mint_to_private(user, mint_amount));
+
+    let valid_until = env.last_block_timestamp() + 3600;
+
+    // Sign with cold-start domain separator
+    let cold_start_sig = utils::sign_cold_start_quote(
+        fpc_address,
+        token_address,
+        fj_fee_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+        claim_amount,
+        CLAIM_SECRET_HASH,
+    );
+
+    let transfer_call = token.transfer_private_to_private(
+        user,
+        operator,
+        aa_payment_amount,
+        TRANSFER_AUTHWIT_NONCE,
+    );
+    add_private_authwit_from_call(env, user, fpc_address, transfer_call);
+
+    // Submit through fee_entrypoint -- should fail because the signature
+    // was computed with COLD_START_QUOTE_DOMAIN_SEPARATOR, not QUOTE_DOMAIN_SEPARATOR.
+    let _ = env.call_private(
+        user,
+        fpc.fee_entrypoint(
+            token_address,
+            TRANSFER_AUTHWIT_NONCE,
+            fj_fee_amount,
+            aa_payment_amount,
+            valid_until,
+            cold_start_sig,
+        ),
+    );
+}
+
+/// A regular fee_entrypoint quote (QUOTE_DOMAIN_SEPARATOR) must not be
+/// accepted by cold_start_entrypoint (COLD_START_QUOTE_DOMAIN_SEPARATOR).
+/// This test signs with the regular domain and submits through cold_start_entrypoint.
+///
+/// Note: This test will hit "must be tx entrypoint" first because we call
+/// via env.call_private (non-root). This validates that both guards are active.
+#[test(should_fail_with = "Cannot satisfy constraint")]
+unconstrained fn regular_quote_rejected_by_cold_start_entrypoint() {
+    let (mut env, fpc_address, token_address, bridge_address, _operator, user) = utils::setup();
+    let fpc = FPCMultiAsset::at(fpc_address);
+
+    let fj_fee_amount = utils::max_gas_cost_no_teardown(env);
+    let aa_payment_amount = fj_fee_amount;
+    let claim_amount = aa_payment_amount + (500 as u128);
+    let valid_until = env.last_block_timestamp() + 3600;
+
+    // Sign with regular domain separator
+    let regular_sig = utils::sign_quote(
+        fpc_address,
+        token_address,
+        fj_fee_amount,
+        aa_payment_amount,
+        valid_until,
+        user,
+    );
+
+    let _ = env.call_private(
+        NULL_MSG_SENDER_CONTRACT_ADDRESS,
+        fpc.cold_start_entrypoint(
+            user,
+            token_address,
+            bridge_address,
+            claim_amount,
+            CLAIM_SECRET,
+            CLAIM_SECRET_HASH,
+            MESSAGE_LEAF_INDEX,
+            TRANSFER_AUTHWIT_NONCE,
+            fj_fee_amount,
+            aa_payment_amount,
+            valid_until,
+            regular_sig,
+        ),
+    );
+}

--- a/contracts/fpc/src/test/fee_entrypoint.nr
+++ b/contracts/fpc/src/test/fee_entrypoint.nr
@@ -8,7 +8,7 @@ global TRANSFER_AUTHWIT_NONCE_2: Field = 43;
 
 #[test(should_fail_with = "invalid operator")]
 unconstrained fn constructor_rejects_zero_operator() {
-    let (mut env, _, _, operator, _) = utils::setup();
+    let (mut env, _, _, _, operator, _) = utils::setup();
 
     let pk = utils::test_operator_pubkey();
     let fpc_initializer = FPCMultiAsset::interface().constructor(AztecAddress::zero(), pk.x, pk.y);
@@ -17,7 +17,7 @@ unconstrained fn constructor_rejects_zero_operator() {
 
 #[test]
 unconstrained fn fee_entrypoint_happy_path_transfers_expected_charge() {
-    let (mut env, fpc_address, token_address, operator, user) = utils::setup();
+    let (mut env, fpc_address, token_address, _bridge_address, operator, user) = utils::setup();
     let fpc = FPCMultiAsset::at(fpc_address);
     let token = Token::at(token_address);
 
@@ -68,7 +68,7 @@ unconstrained fn fee_entrypoint_happy_path_transfers_expected_charge() {
 
 #[test(should_fail_with = "quoted fee amount mismatch")]
 unconstrained fn fee_entrypoint_rejects_mismatched_fj_fee_amount() {
-    let (mut env, fpc_address, token_address, _operator, user) = utils::setup();
+    let (mut env, fpc_address, token_address, _bridge_address, _operator, user) = utils::setup();
     let fpc = FPCMultiAsset::at(fpc_address);
 
     let actual_fj_fee_amount = utils::max_gas_cost_no_teardown(env);
@@ -100,7 +100,7 @@ unconstrained fn fee_entrypoint_rejects_mismatched_fj_fee_amount() {
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
 unconstrained fn fee_entrypoint_requires_fresh_transfer_authwit_each_call() {
-    let (mut env, fpc_address, token_address, operator, user) = utils::setup();
+    let (mut env, fpc_address, token_address, _bridge_address, operator, user) = utils::setup();
     let fpc = FPCMultiAsset::at(fpc_address);
     let token = Token::at(token_address);
 
@@ -166,7 +166,7 @@ unconstrained fn fee_entrypoint_requires_fresh_transfer_authwit_each_call() {
 
 #[test(should_fail_with = "quote expired")]
 unconstrained fn fee_entrypoint_rejects_expired_quote() {
-    let (mut env, fpc_address, token_address, _operator, user) = utils::setup();
+    let (mut env, fpc_address, token_address, _bridge_address, _operator, user) = utils::setup();
     let fpc = FPCMultiAsset::at(fpc_address);
 
     let fj_fee_amount = utils::max_gas_cost_no_teardown(env);
@@ -202,7 +202,7 @@ unconstrained fn fee_entrypoint_rejects_expired_quote() {
 
 #[test(should_fail_with = "quote ttl too large")]
 unconstrained fn fee_entrypoint_rejects_overlong_quote_ttl() {
-    let (mut env, fpc_address, token_address, _operator, user) = utils::setup();
+    let (mut env, fpc_address, token_address, _bridge_address, _operator, user) = utils::setup();
     let fpc = FPCMultiAsset::at(fpc_address);
 
     let fj_fee_amount = utils::max_gas_cost_no_teardown(env);
@@ -235,7 +235,7 @@ unconstrained fn fee_entrypoint_rejects_overlong_quote_ttl() {
 
 #[test(should_fail)]
 unconstrained fn fee_entrypoint_rejects_quote_bound_to_another_user() {
-    let (mut env, fpc_address, token_address, operator, user) = utils::setup();
+    let (mut env, fpc_address, token_address, _bridge_address, operator, user) = utils::setup();
     let fpc = FPCMultiAsset::at(fpc_address);
     let token = Token::at(token_address);
     let other_user = env.create_contract_account();

--- a/contracts/fpc/src/test/utils.nr
+++ b/contracts/fpc/src/test/utils.nr
@@ -1,13 +1,16 @@
 use crate::FPCMultiAsset;
 use aztec::{
     authwit::auth::compute_inner_authwit_hash,
-    protocol::{address::AztecAddress, traits::ToField},
+    protocol::address::{AztecAddress, EthAddress},
+    protocol::traits::ToField,
     test::helpers::test_environment::TestEnvironment,
 };
 use std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_scalar_mul};
 use token::Token;
+use token_bridge_contract::TokenBridge;
 
 global QUOTE_DOMAIN_SEPARATOR: Field = 0x465043;
+global COLD_START_QUOTE_DOMAIN_SEPARATOR: Field = 0x46504373;
 
 /// Grumpkin generator point.
 global G1: EmbeddedCurvePoint = EmbeddedCurvePoint {
@@ -157,7 +160,14 @@ unconstrained fn add_u256(a_hi: u128, a_lo: u128, b_hi: u128, b_lo: u128) -> (u1
     }
 }
 
-pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress, AztecAddress) {
+pub unconstrained fn setup() -> (
+    TestEnvironment,
+    AztecAddress,
+    AztecAddress,
+    AztecAddress,
+    AztecAddress,
+    AztecAddress,
+) {
     let mut env = TestEnvironment::new();
 
     let user = env.create_contract_account();
@@ -173,12 +183,18 @@ pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, Az
     let token_address =
         env.deploy("@token_contract/Token").with_public_initializer(operator, token_initializer);
 
+    let bridge_initializer =
+        TokenBridge::interface().constructor(token_address, EthAddress::from_field(0));
+    let bridge_address = env
+        .deploy("@token_bridge_contract/TokenBridge")
+        .with_public_initializer(operator, bridge_initializer);
+
     let pk = test_operator_pubkey();
     let fpc_initializer = FPCMultiAsset::interface().constructor(operator, pk.x, pk.y);
     let fpc_address =
         env.deploy("FPCMultiAsset").with_public_initializer(operator, fpc_initializer);
 
-    (env, fpc_address, token_address, operator, user)
+    (env, fpc_address, token_address, bridge_address, operator, user)
 }
 
 pub unconstrained fn max_gas_cost_no_teardown(env: TestEnvironment) -> u128 {
@@ -207,6 +223,33 @@ pub unconstrained fn sign_quote(
         aa_payment_amount as Field,
         valid_until as Field,
         user_address.to_field(),
+    ]);
+    let message: [u8; 32] = quote_hash.to_be_bytes();
+    test_schnorr_sign(message)
+}
+
+/// Compute the cold-start quote hash and return a valid Schnorr signature
+/// for it using the test signing key.
+pub unconstrained fn sign_cold_start_quote(
+    fpc_address: AztecAddress,
+    accepted_asset: AztecAddress,
+    fj_fee_amount: u128,
+    aa_payment_amount: u128,
+    valid_until: u64,
+    user_address: AztecAddress,
+    claim_amount: u128,
+    claim_secret_hash: Field,
+) -> [u8; 64] {
+    let quote_hash = compute_inner_authwit_hash([
+        COLD_START_QUOTE_DOMAIN_SEPARATOR,
+        fpc_address.to_field(),
+        accepted_asset.to_field(),
+        fj_fee_amount as Field,
+        aa_payment_amount as Field,
+        valid_until as Field,
+        user_address.to_field(),
+        claim_amount as Field,
+        claim_secret_hash,
     ]);
     let message: [u8; 32] = quote_hash.to_be_bytes();
     test_schnorr_sign(message)

--- a/contracts/token_bridge/Nargo.toml
+++ b/contracts/token_bridge/Nargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "token_bridge_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.3", directory = "noir-projects/aztec-nr/aztec" }
+token_portal_content_hash_lib = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.3", directory = "noir-projects/noir-contracts/contracts/libs/token_portal_content_hash_lib" }
+token = { path = "../../vendor/aztec-standards/src/token_contract" }

--- a/contracts/token_bridge/src/config.nr
+++ b/contracts/token_bridge/src/config.nr
@@ -1,0 +1,13 @@
+use aztec::protocol::{
+    address::{AztecAddress, EthAddress},
+    traits::{Deserialize, Packable, Serialize},
+};
+use std::meta::derive;
+
+// PublicImmutable has constant read cost in private regardless of the size of what it stores, so we put all immutable
+// values in a single struct
+#[derive(Deserialize, Eq, Packable, Serialize)]
+pub struct Config {
+    pub token: AztecAddress,
+    pub portal: EthAddress,
+}

--- a/contracts/token_bridge/src/main.nr
+++ b/contracts/token_bridge/src/main.nr
@@ -1,0 +1,141 @@
+mod config;
+
+// Minimal implementation of the token bridge that can move funds between L1 <> L2.
+// The bridge has a corresponding Portal contract on L1 that it is attached to
+// And corresponds to a Token on L2 that uses the `AuthWit` accounts pattern.
+// Bridge has to be set as a minter on the token before it can be used
+
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract TokenBridge {
+    use crate::config::Config;
+
+    use aztec::{protocol::address::{AztecAddress, EthAddress}, state_vars::PublicImmutable};
+
+    use token_portal_content_hash_lib::{
+        get_mint_to_private_content_hash, get_mint_to_public_content_hash,
+        get_withdraw_content_hash,
+    };
+
+    use token::Token;
+
+    use aztec::macros::{functions::{external, initializer, view}, storage::storage};
+
+    // Storage structure, containing all storage, and specifying what slots they use.
+    #[storage]
+    struct Storage<Context> {
+        config: PublicImmutable<Config, Context>,
+    }
+
+    // Constructs the contract.
+    #[external("public")]
+    #[initializer]
+    fn constructor(token: AztecAddress, portal: EthAddress) {
+        self.storage.config.initialize(Config { token, portal });
+    }
+
+    #[external("private")]
+    #[view]
+    fn get_config() -> Config {
+        self.storage.config.read()
+    }
+
+    #[external("public")]
+    #[view]
+    fn get_config_public() -> Config {
+        self.storage.config.read()
+    }
+
+    // docs:start:claim_public
+    // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount publicly
+    #[external("public")]
+    fn claim_public(to: AztecAddress, amount: u128, secret: Field, message_leaf_index: Field) {
+        let content_hash = get_mint_to_public_content_hash(to, amount);
+
+        let config = self.storage.config.read();
+
+        // Consume message and emit nullifier
+        self.context.consume_l1_to_l2_message(
+            content_hash,
+            secret,
+            config.portal,
+            message_leaf_index,
+        );
+
+        // Mint tokens
+        self.call(Token::at(config.token).mint_to_public(to, amount));
+    }
+    // docs:end:claim_public
+
+    // docs:start:exit_to_l1_public
+    // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message publicly
+    // Requires `msg.sender` to give approval to the bridge to burn tokens on their behalf using witness signatures
+    #[external("public")]
+    fn exit_to_l1_public(
+        recipient: EthAddress, // ethereum address to withdraw to
+        amount: u128,
+        caller_on_l1: EthAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
+        authwit_nonce: Field, // nonce used in the approval message by `msg.sender` to let bridge burn their tokens on L2
+    ) {
+        let config = self.storage.config.read();
+
+        // Send an L2 to L1 message
+        let content = get_withdraw_content_hash(recipient, amount, caller_on_l1);
+        self.context.message_portal(config.portal, content);
+
+        // Burn tokens
+        self.call(Token::at(config.token).burn_public(self.msg_sender(), amount, authwit_nonce));
+    }
+    // docs:end:exit_to_l1_public
+
+    /// Claims the bridged tokens and makes them accessible in private. Note that recipient's address is not revealed
+    /// but the amount is. Hence it's most likely possible to determine to which L1 deposit this claim corresponds to
+    /// (unless there are multiple pending deposits of the same amount).
+    #[external("private")]
+    fn claim_private(
+        recipient: AztecAddress, // recipient of the bridged tokens
+        amount: u128,
+        secret_for_L1_to_L2_message_consumption: Field, // secret used to consume the L1 to L2 message
+        message_leaf_index: Field,
+    ) {
+        let config = self.storage.config.read();
+
+        // Consume L1 to L2 message and emit nullifier
+        let content_hash = get_mint_to_private_content_hash(amount);
+        self.context.consume_l1_to_l2_message(
+            content_hash,
+            secret_for_L1_to_L2_message_consumption,
+            config.portal,
+            message_leaf_index,
+        );
+
+        // At last we mint the tokens
+        self.call(Token::at(config.token).mint_to_private(recipient, amount));
+    }
+
+    // docs:start:exit_to_l1_private
+    // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message privately
+    // Requires `msg.sender` (caller of the method) to give approval to the bridge to burn tokens on their behalf using witness signatures
+    #[external("private")]
+    fn exit_to_l1_private(
+        token: AztecAddress,
+        recipient: EthAddress, // ethereum address to withdraw to
+        amount: u128,
+        caller_on_l1: EthAddress, // ethereum address that can call this function on the L1 portal (0x0 if anyone can call)
+        authwit_nonce: Field, // nonce used in the approval message by `msg.sender` to let bridge burn their tokens on L2
+    ) {
+        let config = self.storage.config.read();
+
+        // Assert that user provided token address is same as seen in storage.
+        assert_eq(config.token, token, "Token address is not the same as seen in storage");
+
+        // Send an L2 to L1 message
+        let content = get_withdraw_content_hash(recipient, amount, caller_on_l1);
+        self.context.message_portal(config.portal, content);
+
+        // Burn tokens
+        self.call(Token::at(token).burn_private(self.msg_sender(), amount, authwit_nonce));
+    }
+    // docs:end:exit_to_l1_private
+}

--- a/services/attestation/src/server.ts
+++ b/services/attestation/src/server.ts
@@ -1,11 +1,12 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import Fastify from "fastify";
+import { Fr } from "@aztec/aztec.js/fields";
+import Fastify, { type FastifyInstance } from "fastify";
 import type { Config } from "./config.js";
 import { computeFinalRate, resolveSelectedAssetPolicy } from "./config.js";
 import { AttestationMetrics, type QuoteOutcome } from "./metrics.js";
-import type { QuoteSchnorrSigner } from "./signer.js";
-import { signQuote, signRateQuote } from "./signer.js";
+import type { ColdStartQuoteParams, QuoteSchnorrSigner } from "./signer.js";
+import { signColdStartQuote, signQuote, signRateQuote } from "./signer.js";
 
 function badRequest(message: string) {
   return { error: { code: "BAD_REQUEST", message } };
@@ -245,6 +246,11 @@ interface QuoteRequestQuery {
   fj_amount?: string;
 }
 
+interface ColdStartQuoteRequestQuery extends QuoteRequestQuery {
+  claim_amount?: string;
+  claim_secret_hash?: string;
+}
+
 type SelectedAssetPolicy = NonNullable<ReturnType<typeof resolveSelectedAssetPolicy>>;
 
 interface ParsedQuoteRequest {
@@ -348,6 +354,58 @@ function parseQuoteRequest(config: Config, query: QuoteRequestQuery): QuoteReque
       acceptedAsset: parsedAcceptedAsset.value,
       selectedAssetPolicy,
       fjFeeAmount,
+    },
+  };
+}
+
+interface ParsedColdStartQuoteRequest extends ParsedQuoteRequest {
+  claimAmount: bigint;
+  claimSecretHash: string;
+}
+
+type ColdStartQuoteRequestParseResult =
+  | { ok: true; value: ParsedColdStartQuoteRequest }
+  | { ok: false; message: string };
+
+function parseRequiredHexField(
+  value: string | undefined,
+  label: string,
+): { ok: true; value: string } | { ok: false; message: string } {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return { ok: false, message: `Missing required query param: ${label}` };
+  }
+  if (!/^0x[0-9a-fA-F]+$/i.test(trimmed)) {
+    return { ok: false, message: `Invalid ${label}: expected 0x-prefixed hex` };
+  }
+  return { ok: true, value: trimmed };
+}
+
+function parseColdStartQuoteRequest(
+  config: Config,
+  query: ColdStartQuoteRequestQuery,
+): ColdStartQuoteRequestParseResult {
+  const baseResult = parseQuoteRequest(config, query);
+  if (!baseResult.ok) {
+    return baseResult;
+  }
+
+  const claimAmount = parsePositiveU128Decimal(query.claim_amount);
+  if (!claimAmount) {
+    return { ok: false, message: "Missing or invalid query param: claim_amount" };
+  }
+
+  const parsedClaimSecretHash = parseRequiredHexField(query.claim_secret_hash, "claim_secret_hash");
+  if (!parsedClaimSecretHash.ok) {
+    return parsedClaimSecretHash;
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...baseResult.value,
+      claimAmount,
+      claimSecretHash: parsedClaimSecretHash.value,
     },
   };
 }
@@ -504,6 +562,7 @@ export function buildServer(
       accepted_assets: "/accepted-assets",
       asset: "/asset",
       quote: "/quote",
+      cold_start_quote: "/cold-start-quote",
     },
     supported_assets: supportedAssets,
   }));
@@ -639,5 +698,159 @@ export function buildServer(
     }
   });
 
+  registerColdStartQuoteEndpoint(app, {
+    config,
+    fpcAddress,
+    metrics,
+    nowUnixSeconds,
+    quoteSigner,
+    rateLimiter,
+    validUntil,
+  });
+
   return app;
+}
+
+function registerColdStartQuoteEndpoint(
+  app: FastifyInstance,
+  ctx: {
+    config: Config;
+    fpcAddress: AztecAddress;
+    metrics: AttestationMetrics;
+    nowUnixSeconds: () => Promise<bigint> | bigint;
+    quoteSigner: QuoteSchnorrSigner;
+    rateLimiter: FixedWindowRateLimiter | undefined;
+    validUntil: (nowSeconds: bigint) => bigint;
+  },
+) {
+  const { config, fpcAddress, metrics, nowUnixSeconds, quoteSigner, rateLimiter, validUntil } = ctx;
+
+  app.get<{
+    Querystring: ColdStartQuoteRequestQuery;
+  }>("/cold-start-quote", async (req, reply) => {
+    const observe = createQuoteObserver(metrics);
+    const nowSeconds = BigInt(await nowUnixSeconds());
+
+    const rateLimitRejection = consumeQuoteRateLimit(
+      rateLimiter,
+      config,
+      req.headers,
+      req.ip,
+      nowSeconds,
+    );
+    if (rateLimitRejection) {
+      req.log.warn(
+        {
+          event: "cold_start_quote_rate_limited",
+          identity_kind: rateLimitRejection.identityKind,
+          retry_after_seconds: rateLimitRejection.retryAfterSeconds,
+        },
+        "Rate limited cold-start quote request",
+      );
+      observe("rate_limited");
+      return reply
+        .header("retry-after", rateLimitRejection.retryAfterSeconds.toString())
+        .code(429)
+        .send(rateLimited());
+    }
+
+    if (!isQuoteAuthorized(config, req.headers)) {
+      req.log.warn(
+        {
+          event: "cold_start_quote_auth_rejected",
+          mode: config.quote_auth.mode,
+        },
+        "Rejected unauthorized cold-start quote request",
+      );
+      observe("unauthorized");
+      return reply.code(401).send(unauthorized());
+    }
+
+    const parsedRequest = parseColdStartQuoteRequest(config, req.query);
+    if (!parsedRequest.ok) {
+      observe("bad_request");
+      return reply.code(400).send(badRequest(parsedRequest.message));
+    }
+
+    const {
+      userAddress,
+      acceptedAsset,
+      selectedAssetPolicy,
+      fjFeeAmount,
+      claimAmount,
+      claimSecretHash,
+    } = parsedRequest.value;
+
+    try {
+      const quotePricing = computeQuotePricing(
+        selectedAssetPolicy,
+        fjFeeAmount,
+        nowSeconds,
+        validUntil,
+      );
+      if (!quotePricing.ok) {
+        observe("bad_request");
+        return reply.code(400).send(badRequest(quotePricing.message));
+      }
+
+      const { validUntil: quoteValidUntil, aaPaymentAmount } = quotePricing.value;
+
+      if (claimAmount < aaPaymentAmount) {
+        observe("bad_request");
+        return reply.code(400).send(badRequest("claim_amount must be >= aa_payment_amount"));
+      }
+
+      const coldStartParams: ColdStartQuoteParams = {
+        fpcAddress,
+        acceptedAsset,
+        fjFeeAmount,
+        aaPaymentAmount,
+        validUntil: quoteValidUntil,
+        userAddress,
+        claimAmount,
+        claimSecretHash: Fr.fromHexString(claimSecretHash),
+      };
+      const signature = await signColdStartQuote(quoteSigner, coldStartParams);
+
+      req.log.info(
+        {
+          event: "cold_start_quote_issued",
+          user: userAddress.toString(),
+          accepted_asset: selectedAssetPolicy.address,
+          valid_until: quoteValidUntil.toString(),
+          fj_amount: fjFeeAmount.toString(),
+          aa_payment_amount: aaPaymentAmount.toString(),
+          claim_amount: claimAmount.toString(),
+          claim_secret_hash: claimSecretHash,
+        },
+        "Cold-start quote issued",
+      );
+      observe("success");
+
+      return {
+        accepted_asset: selectedAssetPolicy.address,
+        fj_amount: fjFeeAmount.toString(),
+        aa_payment_amount: aaPaymentAmount.toString(),
+        valid_until: quoteValidUntil.toString(),
+        claim_amount: claimAmount.toString(),
+        claim_secret_hash: claimSecretHash,
+        signature,
+      };
+    } catch (error) {
+      observe("internal_error");
+      req.log.error(
+        {
+          err: error,
+          user: userAddress.toString(),
+        },
+        "Failed to issue cold-start quote",
+      );
+      return reply.code(500).send({
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Internal server error",
+        },
+      });
+    }
+  });
 }

--- a/services/attestation/src/signer.ts
+++ b/services/attestation/src/signer.ts
@@ -22,6 +22,9 @@ import { computeInnerAuthWitHash } from "@aztec/stdlib/auth-witness";
 // Must match QUOTE_DOMAIN_SEPARATOR in main.nr ("FPC" = 0x465043)
 const QUOTE_DOMAIN_SEPARATOR = Fr.fromHexString("0x465043");
 
+// Must match COLD_START_QUOTE_DOMAIN_SEPARATOR in main.nr ("FPCs" = 0x46504373)
+const COLD_START_QUOTE_DOMAIN_SEPARATOR = Fr.fromHexString("0x46504373");
+
 export interface QuoteParams {
   fpcAddress: AztecAddress;
   /** Selected per-request payment asset. */
@@ -92,5 +95,44 @@ export async function signRateQuote(
   params: RateQuoteParams,
 ): Promise<string> {
   const quoteHash = await computeRateQuoteHash(params);
+  return signer.signQuoteHash(quoteHash);
+}
+
+export interface ColdStartQuoteParams {
+  fpcAddress: AztecAddress;
+  acceptedAsset: AztecAddress;
+  fjFeeAmount: bigint;
+  aaPaymentAmount: bigint;
+  validUntil: bigint;
+  userAddress: AztecAddress;
+  claimAmount: bigint;
+  claimSecretHash: Fr;
+}
+
+/**
+ * Compute the cold-start quote hash with extended preimage that binds
+ * the signature to a specific bridge deposit (claim_amount + claim_secret_hash).
+ *
+ * Uses COLD_START_QUOTE_DOMAIN_SEPARATOR to prevent cross-entrypoint replay.
+ */
+export function computeColdStartQuoteHash(params: ColdStartQuoteParams): Promise<Fr> {
+  return computeInnerAuthWitHash([
+    COLD_START_QUOTE_DOMAIN_SEPARATOR,
+    params.fpcAddress.toField(),
+    params.acceptedAsset.toField(),
+    new Fr(params.fjFeeAmount),
+    new Fr(params.aaPaymentAmount),
+    new Fr(params.validUntil),
+    params.userAddress.toField(),
+    new Fr(params.claimAmount),
+    params.claimSecretHash,
+  ]);
+}
+
+export async function signColdStartQuote(
+  signer: QuoteSchnorrSigner,
+  params: ColdStartQuoteParams,
+): Promise<string> {
+  const quoteHash = await computeColdStartQuoteHash(params);
   return signer.signQuoteHash(quoteHash);
 }

--- a/services/attestation/test/server.test.ts
+++ b/services/attestation/test/server.test.ts
@@ -137,6 +137,7 @@ describe("server", () => {
           accepted_assets: "/accepted-assets",
           asset: "/asset",
           quote: "/quote",
+          cold_start_quote: "/cold-start-quote",
         },
         supported_assets: [
           {

--- a/services/attestation/test/signer.test.ts
+++ b/services/attestation/test/signer.test.ts
@@ -4,9 +4,12 @@ import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import { computeInnerAuthWitHash } from "@aztec/stdlib/auth-witness";
 import {
+  type ColdStartQuoteParams,
+  computeColdStartQuoteHash,
   computeQuoteHash,
   type QuoteParams,
   type QuoteSchnorrSigner,
+  signColdStartQuote,
   signQuote,
 } from "../src/signer.js";
 
@@ -23,6 +26,10 @@ const OTHER_USER = AztecAddress.fromString(
   "0x1b755492d6dd51deb08b7e51a33133186687ea13527f07921fd74640dc8dec24",
 );
 
+const CLAIM_SECRET_HASH = Fr.fromHexString(
+  "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+);
+
 function makeQuoteParams(): QuoteParams {
   return {
     fpcAddress: FPC,
@@ -31,6 +38,19 @@ function makeQuoteParams(): QuoteParams {
     aaPaymentAmount: 1020n,
     validUntil: 1740000300n,
     userAddress: USER,
+  };
+}
+
+function makeColdStartQuoteParams(): ColdStartQuoteParams {
+  return {
+    fpcAddress: FPC,
+    acceptedAsset: ASSET,
+    fjFeeAmount: 1_000_000n,
+    aaPaymentAmount: 1020n,
+    validUntil: 1740000300n,
+    userAddress: USER,
+    claimAmount: 5000n,
+    claimSecretHash: CLAIM_SECRET_HASH,
   };
 }
 
@@ -83,5 +103,81 @@ describe("signer", () => {
     const userHash = await computeQuoteHash(params);
     const otherUserHash = await computeQuoteHash(otherUserParams);
     assert.equal(userHash.equals(otherUserHash), false);
+  });
+});
+
+describe("cold-start signer", () => {
+  it("computes cold-start quote hash with extended preimage", async () => {
+    const params = makeColdStartQuoteParams();
+
+    const expected = await computeInnerAuthWitHash([
+      Fr.fromHexString("0x46504373"), // "FPCs"
+      params.fpcAddress.toField(),
+      params.acceptedAsset.toField(),
+      new Fr(params.fjFeeAmount),
+      new Fr(params.aaPaymentAmount),
+      new Fr(params.validUntil),
+      params.userAddress.toField(),
+      new Fr(params.claimAmount),
+      params.claimSecretHash,
+    ]);
+
+    const actual = await computeColdStartQuoteHash(params);
+    assert.equal(actual.equals(expected), true);
+  });
+
+  it("cold-start hash differs from regular quote hash", async () => {
+    const quoteParams = makeQuoteParams();
+    const coldStartParams = makeColdStartQuoteParams();
+
+    const regularHash = await computeQuoteHash(quoteParams);
+    const coldStartHash = await computeColdStartQuoteHash(coldStartParams);
+    assert.equal(regularHash.equals(coldStartHash), false);
+  });
+
+  it("binds cold-start hash to claim_amount", async () => {
+    const params = makeColdStartQuoteParams();
+    const differentClaimParams: ColdStartQuoteParams = {
+      ...params,
+      claimAmount: params.claimAmount + 1n,
+    };
+
+    const hash1 = await computeColdStartQuoteHash(params);
+    const hash2 = await computeColdStartQuoteHash(differentClaimParams);
+    assert.equal(hash1.equals(hash2), false);
+  });
+
+  it("binds cold-start hash to claim_secret_hash", async () => {
+    const params = makeColdStartQuoteParams();
+    const differentSecretParams: ColdStartQuoteParams = {
+      ...params,
+      claimSecretHash: Fr.fromHexString("0xdeadbeef"),
+    };
+
+    const hash1 = await computeColdStartQuoteHash(params);
+    const hash2 = await computeColdStartQuoteHash(differentSecretParams);
+    assert.equal(hash1.equals(hash2), false);
+  });
+
+  it("binds cold-start hash to user address", async () => {
+    const params = makeColdStartQuoteParams();
+    const otherUserParams: ColdStartQuoteParams = {
+      ...params,
+      userAddress: OTHER_USER,
+    };
+
+    const userHash = await computeColdStartQuoteHash(params);
+    const otherUserHash = await computeColdStartQuoteHash(otherUserParams);
+    assert.equal(userHash.equals(otherUserHash), false);
+  });
+
+  it("returns signature hex from signer for cold-start quote", async () => {
+    const params = makeColdStartQuoteParams();
+    const signer: QuoteSchnorrSigner = {
+      signQuoteHash: async () => "0xcoldstart",
+    };
+
+    const sig = await signColdStartQuote(signer, params);
+    assert.equal(sig, "0xcoldstart");
   });
 });


### PR DESCRIPTION
## Summary
- Add `cold_start_entrypoint` to FPC contract — allows users with zero private balance to claim bridged tokens and pay gas in a single transaction
- Guard the entrypoint as tx root (`maybe_msg_sender().is_none()`) to prevent batching attacks
- Use `COLD_START_QUOTE_DOMAIN_SEPARATOR` (0x46504373) to prevent cross-entrypoint replay with `fee_entrypoint`
- Extended quote preimage binds operator signature to specific bridge deposit (claim_amount + claim_secret_hash)
- Add `token_bridge_contract` from aztec-packages as a git dependency for real `TokenBridge::claim_private` calls
- Add `/cold-start-quote` attestation endpoint with parsing, validation, and cold-start quote signing
- Add `signColdStartQuote` and `computeColdStartQuoteHash` to signer with domain-separated preimage
- Add Noir tests for root-call guard and domain separation
- Add TS tests for cold-start signer (preimage, domain separation, binding) and discovery endpoint