### PR TITLE
refactor(docker): mount scripts volume instead of copying in smoke image

### DIFF
--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -20,9 +20,6 @@ COPY services/topup/config.example.yaml services/topup/
 # ── Compiled contract artifacts ──
 COPY --from=deploy /app/target/ target/
 
-# ── Smoke & deploy scripts ──
-COPY scripts/ scripts/
-
 # ── Build services ──
 RUN bun run --filter @aztec-fpc/attestation --if-present build && \
     bun run --filter @aztec-fpc/topup --if-present build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -135,6 +135,7 @@ services:
       - "scripts/contract/devnet-postdeploy-smoke.ts"
     volumes:
       - ./deployments:/app/data:ro
+      - ./scripts:/app/scripts:ro
     environment:
       FPC_DEVNET_SMOKE_MANIFEST: "/app/data/manifest.json"
       L1_RPC_URL: "http://anvil:8545"
@@ -151,6 +152,8 @@ services:
     profiles: ["smoke", "full"]
     command:
       - "services/attestation/test/fee-entrypoint-local-smoke.ts"
+    volumes:
+      - ./scripts:/app/scripts:ro
     environment:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_SMOKE_L1_RPC_URL: "http://anvil:8545"
@@ -163,6 +166,8 @@ services:
     profiles: ["smoke", "full"]
     command:
       - "scripts/services/fpc-services-smoke.ts"
+    volumes:
+      - ./scripts:/app/scripts:ro
     environment:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_LOCAL_OPERATOR_SECRET_KEY: "${FPC_LOCAL_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
@@ -178,6 +183,7 @@ services:
       - "scripts/services/fpc-full-lifecycle-e2e.ts"
     volumes:
       - ./artifacts/compose-e2e/fpc:/artifacts/fpc
+      - ./scripts:/app/scripts:ro
     environment:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_FULL_E2E_L1_RPC_URL: "http://anvil:8545"


### PR DESCRIPTION
## Summary
- Remove `COPY scripts/ scripts/` from `Dockerfile.smoke` to avoid baking scripts into the image
- Add `./scripts:/app/scripts:ro` volume mount to all smoke-image services (`postdeploy`, `smoke-fee-entrypoint`, `smoke-services`, `e2e-fpc`)