### PR TITLE
feat(mock/counter): add always_revert function with Noir test

### DIFF
--- a/mock/counter/src/main.nr
+++ b/mock/counter/src/main.nr
@@ -1,3 +1,5 @@
+mod test;
+
 use aztec::macros::aztec;
 
 /// Mock counter contract based on the Aztec counter tutorial.
@@ -29,6 +31,16 @@ pub contract Counter {
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
         self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+    }
+
+    #[external("private")]
+    fn always_revert() {
+        self.enqueue_self._always_revert_public();
+    }
+
+    #[external("public")]
+    fn _always_revert_public() {
+        assert(self.context.this_address().is_zero(), "This function always reverts");
     }
 
     #[external("utility")]

--- a/mock/counter/src/test.nr
+++ b/mock/counter/src/test.nr
@@ -1,0 +1,2 @@
+pub mod always_revert;
+pub mod utils;

--- a/mock/counter/src/test/always_revert.nr
+++ b/mock/counter/src/test/always_revert.nr
@@ -1,0 +1,8 @@
+use crate::{Counter, test::utils};
+
+#[test(should_fail_with = "This function always reverts")]
+unconstrained fn always_revert_fails() {
+    let (mut env, counter_address, owner) = utils::setup();
+
+    let _ = env.call_private(owner, Counter::at(counter_address).always_revert());
+}

--- a/mock/counter/src/test/utils.nr
+++ b/mock/counter/src/test/utils.nr
@@ -1,0 +1,15 @@
+use crate::Counter;
+use aztec::{
+    protocol::address::AztecAddress,
+    test::helpers::test_environment::TestEnvironment,
+};
+
+pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress) {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_contract_account();
+
+    let initializer = Counter::interface().initialize(1, owner);
+    let counter_address = env.deploy("Counter").with_private_initializer(owner, initializer);
+
+    (env, counter_address, owner)
+}


### PR DESCRIPTION
## Summary
- Add `always_revert()` private function that enqueues a public call which unconditionally reverts
- Add `_always_revert_public()` public function with `assert(this_address().is_zero())`
- Add Noir test module with shared setup util and `should_fail_with` test