### PR TITLE
feat(scripts): add always-revert E2E smoke test

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -93,6 +93,10 @@ jobs:
         if: always()
         run: docker compose --profile full logs --timestamps smoke-same-token-transfer
 
+      - name: Print smoke-always-revert logs
+        if: always()
+        run: docker compose --profile full logs --timestamps smoke-always-revert
+
       - name: Print e2e-fpc logs
         if: always()
         run: docker compose --profile full logs --timestamps e2e-fpc
@@ -108,6 +112,10 @@ jobs:
       - name: Print topup logs
         if: always()
         run: docker compose --profile full logs --timestamps topup
+
+      - name: Print aztec-node logs
+        if: always()
+        run: docker compose --profile full logs --timestamps aztec-node
 
       - name: Tear down
         if: always()

--- a/deployments/local/fpc-config.yaml
+++ b/deployments/local/fpc-config.yaml
@@ -1,0 +1,26 @@
+# fpc-config.yaml — operator-tunable service settings.
+# Shared fields (fpc_address, accepted_asset, aztec_node_url, l1_rpc_url)
+# are injected from the deploy output at generation time.
+
+attestation:
+  accepted_asset_name: "humanUSDC"
+  market_rate_num: 1
+  market_rate_den: 1000
+  fee_bips: 200
+  port: 3000
+  quote_validity_seconds: 1800
+  quote_auth_mode: "disabled"
+  quote_rate_limit_enabled: true
+  quote_rate_limit_max_requests: 60
+  quote_rate_limit_window_seconds: 60
+  quote_rate_limit_max_tracked_keys: 10000
+
+topup:
+  threshold: "100000000000000000"
+  top_up_amount: "1000000000000000000"
+  bridge_state_path: ".topup-bridge-state.json"
+  ops_port: 3001
+  check_interval_ms: 60000
+  confirmation_timeout_ms: 180000
+  confirmation_poll_initial_ms: 1000
+  confirmation_poll_max_ms: 15000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,4 @@
+name: aztec-fpc
 services:
   anvil:
     image: ghcr.io/foundry-rs/foundry:v1.4.1
@@ -48,7 +49,7 @@ services:
   deploy:
     image: nethermind/aztec-fpc-contract-deployment:local
     volumes:
-      - ./deployments:/app/data
+      - ./deployments/local:/app/data
       - deploy-crs-cache:/app/.bb-crs
     environment:
       FPC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
@@ -64,7 +65,7 @@ services:
   fund-l1-fee-juice:
     image: ghcr.io/foundry-rs/foundry:v1.4.1
     volumes:
-      - ./deployments:/app/data:ro
+      - ./deployments/local:/app/data:ro
       - ./scripts:/app/scripts:ro
     entrypoint: ["bash", "/app/scripts/services/fund-l1-fee-juice.sh"]
     environment:
@@ -84,7 +85,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./deployments:/app/data:ro
+      - ./deployments/local:/app/data:ro
     command: ["--config", "/app/data/attestation/config.yaml"]
     environment:
       AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
@@ -98,7 +99,7 @@ services:
     ports:
       - "3001:3001"
     volumes:
-      - ./deployments:/app/data:ro
+      - ./deployments/local:/app/data:ro
     command: ["--config", "/app/data/topup/config.yaml"]
     environment:
       AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
@@ -134,7 +135,7 @@ services:
     command:
       - "scripts/contract/devnet-postdeploy-smoke.ts"
     volumes:
-      - ./deployments:/app/data:ro
+      - ./deployments/local:/app/data:ro
     environment:
       FPC_DEVNET_SMOKE_MANIFEST: "/app/data/manifest.json"
       L1_RPC_URL: "http://anvil:8545"
@@ -192,7 +193,29 @@ services:
     command:
       - "scripts/same-token-transfer/same-token-transfer-smoke.ts"
     volumes:
-      - ./deployments:/app/data:ro
+      - ./deployments/local:/app/data:ro
+    environment:
+      AZTEC_NODE_URL: "http://aztec-node:8080"
+      FPC_ATTESTATION_URL: "http://attestation:3000"
+      FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
+    depends_on:
+      block-producer:
+        condition: service_started
+      deploy:
+        condition: service_completed_successfully
+      attestation:
+        condition: service_healthy
+      topup:
+        condition: service_healthy
+
+  smoke-always-revert:
+    image: nethermind/aztec-fpc-smoke:local
+    profiles: ["smoke", "full"]
+    command:
+      - "scripts/always-revert/always-revert-smoke.ts"
+    volumes:
+      - ./deployments/local:/app/data:ro
     environment:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_ATTESTATION_URL: "http://attestation:3000"
@@ -220,6 +243,8 @@ services:
       e2e-fpc:
         condition: service_completed_successfully
       smoke-same-token-transfer:
+        condition: service_completed_successfully
+      smoke-always-revert:
         condition: service_completed_successfully
       attestation:
         condition: service_healthy

--- a/scripts/always-revert/always-revert-smoke.sh
+++ b/scripts/always-revert/always-revert-smoke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/always-revert-smoke.XXXXXX")"
+source "$REPO_ROOT/scripts/common/node-setup.sh"
+
+setup_require_cmds "[always-revert]" aztec bun node
+cd "$REPO_ROOT"
+
+setup_node \
+  --log-prefix "[always-revert]" \
+  --repo-root "$REPO_ROOT" \
+  --tmp-dir "$TMP_DIR" \
+  --reset-mode "always"
+
+if [[ ! -x "$REPO_ROOT/node_modules/.bin/tsx" ]]; then
+  echo "[always-revert] Installing workspace dependencies (tsx not found)" >&2
+  bun install
+fi
+
+echo "[always-revert] Compiling contracts workspace"
+aztec compile
+
+# Deploy contracts WITHOUT bridge flags — this deploys Token, FPC, and Faucet
+# (no bridge, no counter). The faucet is deployed automatically when no
+# --accepted-asset or bridge address is provided.
+echo "[always-revert] Deploying contracts (faucet mode, no bridge)"
+FPC_L1_DEPLOYER_KEY="${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}" \
+FPC_OUT="$TMP_DIR/always-revert-manifest.json" \
+FPC_L1_RPC_URL="$(setup_l1_rpc_url)" \
+FPC_SKIP_CONFIG_GEN=1 \
+  bash "$REPO_ROOT/scripts/contract/deploy-fpc.sh"
+
+if [[ ! -f "$TMP_DIR/always-revert-manifest.json" ]]; then
+  echo "[always-revert] ERROR: deployment did not produce manifest" >&2
+  exit 1
+fi
+
+echo "[always-revert] Running always-revert smoke flow"
+FPC_COLD_START_MANIFEST="$TMP_DIR/always-revert-manifest.json" \
+  bunx tsx "$REPO_ROOT/scripts/always-revert/always-revert-smoke.ts"

--- a/scripts/always-revert/always-revert-smoke.ts
+++ b/scripts/always-revert/always-revert-smoke.ts
@@ -1,0 +1,44 @@
+/**
+ * Always-revert E2E smoke test entrypoint.
+ *
+ * Exercises the FPC fee payment mechanism when app logic reverts.
+ * A brand-new user gets tokens from the faucet (public), shields them
+ * (private), then calls always_revert() via FPC — verifying that fees
+ * are still collected even when app logic fails.
+ *
+ * Assumes contracts are already deployed (handled by always-revert-smoke.sh).
+ *
+ * CLI arguments are the same as same-token-transfer (parsed by ./cli.ts),
+ * with an additional --iterations flag.
+ */
+
+import pino from "pino";
+import { CliError, parseCliArgs, usage } from "./cli.ts";
+import { setup } from "./setup.ts";
+import { testAlwaysRevert } from "./test-always-revert.ts";
+
+const pinoLogger = pino();
+
+async function main() {
+  const result = parseCliArgs(process.argv.slice(2));
+  if (result.kind === "help") return;
+
+  const ctx = await setup(result.args);
+  await testAlwaysRevert(ctx);
+
+  pinoLogger.info("[always-revert] PASS: always-revert E2E smoke test succeeded");
+  process.exit(0);
+}
+
+main().catch((error) => {
+  if (error instanceof CliError) {
+    pinoLogger.error(`[always-revert] ERROR: ${error.message}`);
+    pinoLogger.error("");
+    pinoLogger.error(usage());
+  } else {
+    pinoLogger.error(
+      `[always-revert] Unexpected error: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+    );
+  }
+  process.exit(1);
+});

--- a/scripts/always-revert/cli.ts
+++ b/scripts/always-revert/cli.ts
@@ -1,0 +1,248 @@
+/**
+ * CLI types and parsing for always-revert-smoke.
+ *
+ * Exports:
+ *   - CliArgs        — parsed argument bag
+ *   - CliParseResult  — discriminated union (help | args)
+ *   - CliError        — thrown on invalid input
+ *   - parseCliArgs()  — parse process.argv
+ *   - usage()         — help text
+ */
+
+import path from "node:path";
+import pino from "pino";
+
+const pinoLogger = pino();
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type CliArgs = {
+  nodeUrl: string;
+  attestationUrl: string;
+  manifestPath: string;
+  operatorSecretKey: string;
+  aaPaymentAmount: bigint;
+  daGasLimit: number;
+  l2GasLimit: number;
+  feePerDaGas: bigint | null;
+  feePerL2Gas: bigint | null;
+  messageTimeoutSeconds: number;
+  iterations: number;
+};
+
+export type CliParseResult = { kind: "help" } | { kind: "args"; args: CliArgs };
+
+export class CliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+export function usage(): string {
+  return [
+    "Usage:",
+    "  bunx tsx scripts/always-revert/always-revert-smoke.ts [options]",
+    "",
+    "All arguments are optional. CLI args take precedence over env vars.",
+    "",
+    "Required (via env or CLI):",
+    "  --attestation-url <url>          Attestation server base URL [env: FPC_ATTESTATION_URL]",
+    "  --manifest <path>                Deployment manifest path [env: FPC_COLD_START_MANIFEST]",
+    "  --operator-secret-key <hex32>    Operator secret key [env: FPC_OPERATOR_SECRET_KEY]",
+    "",
+    "Network:",
+    "  --node-url <url>                 Aztec node URL (default: http://localhost:8080) [env: AZTEC_NODE_URL]",
+    "",
+    "Amounts:",
+    "  --aa-payment-amount <uint>       AA payment amount (default: 1000000000) [env: FPC_COLD_START_AA_PAYMENT_AMOUNT]",
+    "",
+    "Gas:",
+    "  --da-gas-limit <uint>            DA gas limit (default: 1000000) [env: FPC_SMOKE_DA_GAS_LIMIT]",
+    "  --l2-gas-limit <uint>            L2 gas limit (default: 1000000) [env: FPC_SMOKE_L2_GAS_LIMIT]",
+    "  --fee-per-da-gas <uint>          Override fee per DA gas [env: FPC_SMOKE_FEE_PER_DA_GAS]",
+    "  --fee-per-l2-gas <uint>          Override fee per L2 gas [env: FPC_SMOKE_FEE_PER_L2_GAS]",
+    "",
+    "Timing:",
+    "  --message-timeout <uint>         FeeJuice balance wait timeout seconds (default: 120) [env: FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS]",
+    "",
+    "Test:",
+    "  --iterations <uint>              Number of always-revert iterations (default: 3) [env: FPC_SMOKE_ITERATIONS]",
+    "",
+    "  --help, -h                       Show this help",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Private parsing helpers
+// ---------------------------------------------------------------------------
+
+const HEX_32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+const DECIMAL_UINT_PATTERN = /^(0|[1-9][0-9]*)$/;
+
+function nextArg(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new CliError(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function parseHttpUrl(value: string, fieldName: string): string {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new CliError(`Invalid ${fieldName}: expected http(s) URL, got "${value}"`);
+    }
+    return parsed.toString();
+  } catch (error) {
+    if (error instanceof CliError) throw error;
+    throw new CliError(`Invalid ${fieldName}: expected URL, got "${value}"`);
+  }
+}
+
+function parseHex32(value: string, fieldName: string): string {
+  if (!HEX_32_PATTERN.test(value)) {
+    throw new CliError(`Invalid ${fieldName}: expected 32-byte 0x-prefixed hex value`);
+  }
+  return value;
+}
+
+function parsePositiveBigInt(value: string, fieldName: string): bigint {
+  const trimmed = value.trim();
+  if (!DECIMAL_UINT_PATTERN.test(trimmed)) {
+    throw new CliError(`Invalid ${fieldName}: expected positive integer, got "${value}"`);
+  }
+  const parsed = BigInt(trimmed);
+  if (parsed <= 0n) {
+    throw new CliError(`Invalid ${fieldName}: must be positive`);
+  }
+  return parsed;
+}
+
+function parsePositiveInt(value: string, fieldName: string): number {
+  const big = parsePositiveBigInt(value, fieldName);
+  if (big > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new CliError(`Invalid ${fieldName}: exceeds Number.MAX_SAFE_INTEGER`);
+  }
+  return Number(big);
+}
+
+function parseNonNegativeInt(value: string, fieldName: string): number {
+  const trimmed = value.trim();
+  if (!DECIMAL_UINT_PATTERN.test(trimmed)) {
+    throw new CliError(`Invalid ${fieldName}: expected non-negative integer, got "${value}"`);
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw new CliError(`Invalid ${fieldName}: expected non-negative integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Main parser
+// ---------------------------------------------------------------------------
+
+export function parseCliArgs(argv: string[]): CliParseResult {
+  let nodeUrl: string = process.env.AZTEC_NODE_URL ?? "http://localhost:8080";
+  let attestationUrl: string | null = process.env.FPC_ATTESTATION_URL ?? null;
+  let manifestPath: string | null = process.env.FPC_COLD_START_MANIFEST ?? null;
+  let operatorSecretKey: string | null = process.env.FPC_OPERATOR_SECRET_KEY ?? null;
+  let aaPaymentAmount: string = process.env.FPC_COLD_START_AA_PAYMENT_AMOUNT ?? "1000000000";
+  let daGasLimit: string = process.env.FPC_SMOKE_DA_GAS_LIMIT ?? "1000000";
+  let l2GasLimit: string = process.env.FPC_SMOKE_L2_GAS_LIMIT ?? "1000000";
+  let feePerDaGas: string | null = process.env.FPC_SMOKE_FEE_PER_DA_GAS ?? null;
+  let feePerL2Gas: string | null = process.env.FPC_SMOKE_FEE_PER_L2_GAS ?? null;
+  let messageTimeoutSeconds: string = process.env.FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS ?? "120";
+  let iterations: string = process.env.FPC_SMOKE_ITERATIONS ?? "3";
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--node-url":
+        nodeUrl = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--attestation-url":
+        attestationUrl = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--manifest":
+        manifestPath = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--operator-secret-key":
+        operatorSecretKey = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--aa-payment-amount":
+        aaPaymentAmount = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--da-gas-limit":
+        daGasLimit = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--l2-gas-limit":
+        l2GasLimit = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--fee-per-da-gas":
+        feePerDaGas = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--fee-per-l2-gas":
+        feePerL2Gas = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--message-timeout":
+        messageTimeoutSeconds = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--iterations":
+        iterations = nextArg(argv, i, arg);
+        i += 1;
+        break;
+      case "--help":
+      case "-h":
+        pinoLogger.info(usage());
+        return { kind: "help" };
+      default:
+        throw new CliError(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!attestationUrl) {
+    throw new CliError("Missing --attestation-url or FPC_ATTESTATION_URL");
+  }
+  if (!manifestPath) {
+    throw new CliError("Missing --manifest or FPC_COLD_START_MANIFEST");
+  }
+  if (!operatorSecretKey) {
+    throw new CliError("Missing --operator-secret-key or FPC_OPERATOR_SECRET_KEY");
+  }
+
+  return {
+    kind: "args",
+    args: {
+      nodeUrl: parseHttpUrl(nodeUrl, "--node-url"),
+      attestationUrl: parseHttpUrl(attestationUrl, "--attestation-url"),
+      manifestPath: path.resolve(manifestPath),
+      operatorSecretKey: parseHex32(operatorSecretKey, "--operator-secret-key"),
+      aaPaymentAmount: parsePositiveBigInt(aaPaymentAmount, "--aa-payment-amount"),
+      daGasLimit: parsePositiveInt(daGasLimit, "--da-gas-limit"),
+      l2GasLimit: parsePositiveInt(l2GasLimit, "--l2-gas-limit"),
+      feePerDaGas: feePerDaGas ? parsePositiveBigInt(feePerDaGas, "--fee-per-da-gas") : null,
+      feePerL2Gas: feePerL2Gas ? parsePositiveBigInt(feePerL2Gas, "--fee-per-l2-gas") : null,
+      messageTimeoutSeconds: parseNonNegativeInt(messageTimeoutSeconds, "--message-timeout"),
+      iterations: parsePositiveInt(iterations, "--iterations"),
+    },
+  };
+}

--- a/scripts/always-revert/setup.ts
+++ b/scripts/always-revert/setup.ts
@@ -1,0 +1,207 @@
+/**
+ * Environment bootstrap for always-revert smoke tests.
+ *
+ * Connects to the Aztec node, registers accounts and contracts, and waits for
+ * the topup service to fund the FPC with FeeJuice. Unlike the cold-start setup,
+ * this flow uses a faucet instead of an L1 bridge — no L1 token infrastructure
+ * is needed.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { ContractArtifact } from "@aztec/aztec.js/abi";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { Contract } from "@aztec/aztec.js/contracts";
+import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
+import { Fr } from "@aztec/aztec.js/fields";
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import { SPONSORED_FPC_SALT } from "@aztec/constants";
+import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
+import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
+import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
+import type { NoirCompiledContract } from "@aztec/stdlib/noir";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import pino from "pino";
+import { deriveAccount } from "../common/script-credentials.ts";
+import { type CliArgs, CliError } from "./cli.ts";
+
+const pinoLogger = pino();
+
+// ---------------------------------------------------------------------------
+// TestContext — everything tests need
+// ---------------------------------------------------------------------------
+
+export type TestContext = {
+  args: CliArgs;
+  node: ReturnType<typeof createAztecNodeClient>;
+  wallet: EmbeddedWallet;
+  operator: AztecAddress;
+  attestationUrl: string;
+  fpc: Contract;
+  token: Contract;
+  faucet: Contract;
+  counter: Contract;
+  fpcAddress: AztecAddress;
+  tokenAddress: AztecAddress;
+  sponsoredFeePayment: SponsoredFeePaymentMethod;
+  feePerDaGas: bigint;
+  feePerL2Gas: bigint;
+  fjFeeAmount: bigint;
+};
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function loadArtifact(artifactPath: string): ContractArtifact {
+  const raw = readFileSync(artifactPath, "utf8");
+  const parsed = JSON.parse(raw) as NoirCompiledContract;
+  try {
+    return loadContractArtifact(parsed);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.includes("Contract's public bytecode has not been transpiled")
+    ) {
+      return loadContractArtifactForPublic(parsed);
+    }
+    throw err;
+  }
+}
+
+function resolveFpcArtifactPath(repoRoot: string): string {
+  for (const name of ["fpc-FPCMultiAsset.json", "fpc-FPC.json"]) {
+    const p = path.join(repoRoot, "target", name);
+    if (existsSync(p)) return p;
+  }
+  throw new Error("FPC artifact not found in target/");
+}
+
+async function registerAndGet(
+  node: ReturnType<typeof createAztecNodeClient>,
+  wallet: EmbeddedWallet,
+  address: AztecAddress,
+  artifact: ContractArtifact,
+) {
+  const instance = await node.getContract(address);
+  if (!instance) {
+    throw new Error(`Contract not found on node: ${address.toString()}`);
+  }
+  await wallet.registerContract(instance, artifact);
+  return Contract.at(address, artifact, wallet);
+}
+
+// ---------------------------------------------------------------------------
+// setup()
+// ---------------------------------------------------------------------------
+
+export async function setup(args: CliArgs): Promise<TestContext> {
+  const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+  pinoLogger.info("[always-revert] starting");
+  pinoLogger.info(`[always-revert] node_url=${args.nodeUrl}`);
+  pinoLogger.info(`[always-revert] manifest=${args.manifestPath}`);
+
+  // 1. Read manifest
+  if (!existsSync(args.manifestPath)) {
+    throw new CliError(`Manifest not found: ${args.manifestPath}`);
+  }
+  const manifest = JSON.parse(readFileSync(args.manifestPath, "utf8")) as DevnetDeployManifest;
+
+  if (!manifest.contracts.faucet) {
+    throw new Error("Manifest missing contracts.faucet (required for always-revert)");
+  }
+  if (!manifest.contracts.counter) {
+    throw new Error("Manifest missing contracts.counter (required for always-revert)");
+  }
+  const fpcAddress = AztecAddress.fromString(manifest.contracts.fpc);
+  const tokenAddress = AztecAddress.fromString(manifest.contracts.accepted_asset);
+  const faucetAddress = AztecAddress.fromString(manifest.contracts.faucet);
+  const counterAddress = AztecAddress.fromString(manifest.contracts.counter);
+
+  pinoLogger.info(
+    `[always-revert] manifest loaded. fpc=${manifest.contracts.fpc} token=${manifest.contracts.accepted_asset} faucet=${manifest.contracts.faucet}`,
+  );
+
+  // 2. Connect to node
+  const node = createAztecNodeClient(args.nodeUrl);
+  await waitForNode(node);
+  const wallet = await EmbeddedWallet.create(node, {
+    pxeConfig: { proverEnabled: true },
+  });
+
+  // 3. Setup operator account
+  const operatorSecretFr = Fr.fromHexString(args.operatorSecretKey);
+  const operatorAccount = await deriveAccount(operatorSecretFr, wallet);
+  const operator = operatorAccount.address;
+
+  pinoLogger.info(`[always-revert] operator=${operator.toString()}`);
+
+  // 4. Register deployed contracts
+  const tokenArtifact = loadArtifact(path.join(repoRoot, "target", "token_contract-Token.json"));
+  const fpcArtifact = loadArtifact(resolveFpcArtifactPath(repoRoot));
+  const faucetArtifact = loadArtifact(path.join(repoRoot, "target", "faucet-Faucet.json"));
+  const counterArtifact = loadArtifact(path.join(repoRoot, "target", "mock_counter-Counter.json"));
+
+  const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
+  const fpc = await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
+  const faucet = await registerAndGet(node, wallet, faucetAddress, faucetArtifact);
+  const counter = await registerAndGet(node, wallet, counterAddress, counterArtifact);
+
+  // Register the canonical SponsoredFPC contract (address derived from artifact + salt)
+  const sponsoredFpcInstance = await getContractInstanceFromInstantiationParams(
+    SponsoredFPCContractArtifact,
+    { salt: new Fr(SPONSORED_FPC_SALT) },
+  );
+  await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
+  const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcInstance.address);
+
+  // 5. Compute gas parameters
+  const minFees = await node.getCurrentMinFees();
+  const feePerDaGas = args.feePerDaGas ?? minFees.feePerDaGas;
+  const feePerL2Gas = args.feePerL2Gas ?? minFees.feePerL2Gas;
+  const maxGasCost = BigInt(args.daGasLimit) * feePerDaGas + BigInt(args.l2GasLimit) * feePerL2Gas;
+  const fjFeeAmount = maxGasCost;
+
+  pinoLogger.info(
+    `[always-revert] gas parameters. fee_per_da_gas=${feePerDaGas} fee_per_l2_gas=${feePerL2Gas} max_gas_cost=${maxGasCost}`,
+  );
+
+  // 6. Wait for topup service to fund FPC with FeeJuice
+  pinoLogger.info("[always-revert] waiting for FPC FeeJuice balance > 0 (via topup service)");
+
+  const FJ_POLL_MS = 2_000;
+  const FJ_TIMEOUT_MS = args.messageTimeoutSeconds * 1_000;
+  const fjDeadline = Date.now() + FJ_TIMEOUT_MS;
+  let fjBalance = 0n;
+  while (Date.now() <= fjDeadline) {
+    fjBalance = await getFeeJuiceBalance(fpcAddress, node);
+    if (fjBalance > 0n) break;
+    await new Promise((resolve) => setTimeout(resolve, FJ_POLL_MS));
+  }
+  if (fjBalance === 0n) {
+    throw new Error(`Timed out waiting for FPC FeeJuice balance on ${fpcAddress.toString()}`);
+  }
+
+  pinoLogger.info(`[always-revert] FPC FeeJuice balance=${fjBalance}`);
+
+  return {
+    args,
+    node,
+    wallet,
+    operator,
+    attestationUrl: args.attestationUrl,
+    fpc,
+    token,
+    faucet,
+    fpcAddress,
+    tokenAddress,
+    sponsoredFeePayment,
+    feePerDaGas,
+    feePerL2Gas,
+    fjFeeAmount,
+    counter,
+  };
+}

--- a/scripts/always-revert/test-always-revert.ts
+++ b/scripts/always-revert/test-always-revert.ts
@@ -1,0 +1,312 @@
+/**
+ * Always-revert test: faucet drip -> shield -> always_revert via FPC fee_entrypoint.
+ *
+ * Exercises the FPC fee payment mechanism when app logic reverts:
+ * 1. Deploy user account via SponsoredFPC
+ * 2. Faucet drip + shield tokens (batched in one tx via SponsoredFPC)
+ * 3. Loop N iterations of always_revert() calls via FPC, asserting:
+ *    - The tx is mined (included in a block) despite app logic reverting
+ *    - The FPC's FeeJuice balance decreases (fee was paid)
+ *    - The operator's token balance increases (AA payment collected)
+ *    - The user's token balance decreases (AA payment deducted)
+ */
+
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { BatchCall, type Contract } from "@aztec/aztec.js/contracts";
+import { Fr } from "@aztec/aztec.js/fields";
+import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
+import { TxExecutionResult } from "@aztec/aztec.js/tx";
+import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import type { AuthWitness } from "@aztec/stdlib/auth-witness";
+import { Gas, GasFees } from "@aztec/stdlib/gas";
+import { ExecutionPayload } from "@aztec/stdlib/tx";
+import type { EmbeddedWallet } from "@aztec/wallets/embedded";
+import pino from "pino";
+import { PrivateBalanceTracker } from "../common/balance-tracker.ts";
+import { type AccountData, deriveAccount } from "../common/script-credentials.ts";
+import type { TestContext } from "./setup.ts";
+
+const pinoLogger = pino();
+
+const LOG_PREFIX = "[always-revert]";
+
+// ---------------------------------------------------------------------------
+// Local helper: fetch quote from attestation server
+// ---------------------------------------------------------------------------
+
+type QuoteResponse = {
+  accepted_asset: string;
+  fj_amount: string;
+  aa_payment_amount: string;
+  valid_until: string;
+  signature: string;
+};
+
+async function fetchQuote(
+  attestationUrl: string,
+  user: AztecAddress,
+  acceptedAsset: AztecAddress,
+  fjAmount: bigint,
+): Promise<QuoteResponse> {
+  const quoteUrl = new URL(attestationUrl);
+  const normalizedPath = quoteUrl.pathname.replace(/\/+$/u, "");
+  quoteUrl.pathname = normalizedPath.endsWith("/quote")
+    ? normalizedPath
+    : `${normalizedPath}/quote`;
+  quoteUrl.searchParams.set("user", user.toString());
+  quoteUrl.searchParams.set("accepted_asset", acceptedAsset.toString());
+  quoteUrl.searchParams.set("fj_amount", fjAmount.toString());
+
+  const response = await fetch(quoteUrl.toString());
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Quote request failed (${response.status}): ${body}`);
+  }
+  return (await response.json()) as QuoteResponse;
+}
+
+function decodeSignatureHex(signatureHex: string): number[] {
+  const normalized = signatureHex.startsWith("0x") ? signatureHex.slice(2) : signatureHex;
+  return Array.from(Buffer.from(normalized, "hex"));
+}
+
+// ---------------------------------------------------------------------------
+// Local helper: build FPC fee_entrypoint payment method + authwit
+// ---------------------------------------------------------------------------
+
+async function buildFpcPaymentMethod(opts: {
+  attestationUrl: string;
+  wallet: EmbeddedWallet;
+  user: AztecAddress;
+  operator: AztecAddress;
+  fpc: Contract;
+  fpcAddress: AztecAddress;
+  token: Contract;
+  tokenAddress: AztecAddress;
+  fjFeeAmount: bigint;
+  feePerDaGas: bigint;
+  feePerL2Gas: bigint;
+  daGasLimit: number;
+  l2GasLimit: number;
+}) {
+  // 1. Fetch quote from attestation server
+  const quote = await fetchQuote(
+    opts.attestationUrl,
+    opts.user,
+    opts.tokenAddress,
+    opts.fjFeeAmount,
+  );
+  const aaPaymentAmount = BigInt(quote.aa_payment_amount);
+  const validUntil = BigInt(quote.valid_until);
+  const signatureBytes = decodeSignatureHex(quote.signature);
+
+  // 2. Build transfer authwit: token.transfer_private_to_private(user, operator, aaPaymentAmount, nonce)
+  const nonce = Fr.random();
+
+  const transferCall = await opts.token.methods
+    .transfer_private_to_private(opts.user, opts.operator, aaPaymentAmount, nonce)
+    .getFunctionCall();
+
+  // 3. Create authwit for FPC to call the transfer on user's behalf
+  const transferAuthwit: AuthWitness = await opts.wallet.createAuthWit(opts.user, {
+    caller: opts.fpcAddress,
+    call: transferCall,
+  });
+
+  // 4. Build fee_entrypoint call
+  const feeEntrypointCall = await opts.fpc.methods
+    .fee_entrypoint(
+      opts.tokenAddress,
+      nonce,
+      opts.fjFeeAmount,
+      aaPaymentAmount,
+      validUntil,
+      signatureBytes,
+    )
+    .getFunctionCall();
+
+  // 5. Build payment method and gas settings
+  const paymentMethod = {
+    getAsset: async () => ProtocolContractAddress.FeeJuice,
+    getExecutionPayload: async () =>
+      new ExecutionPayload([feeEntrypointCall], [transferAuthwit], [], [], opts.fpcAddress),
+    getFeePayer: async () => opts.fpcAddress,
+    getGasSettings: () => undefined,
+  };
+
+  const gasSettings = {
+    gasLimits: new Gas(opts.daGasLimit, opts.l2GasLimit),
+    teardownGasLimits: new Gas(0, 0),
+    maxFeesPerGas: new GasFees(opts.feePerDaGas, opts.feePerL2Gas),
+  };
+
+  return { paymentMethod, gasSettings, aaPaymentAmount };
+}
+
+// ---------------------------------------------------------------------------
+// Main test
+// ---------------------------------------------------------------------------
+
+export async function testAlwaysRevert(ctx: TestContext): Promise<void> {
+  const {
+    args,
+    node,
+    operator,
+    attestationUrl,
+    fpc,
+    token,
+    faucet,
+    counter,
+    fpcAddress,
+    tokenAddress,
+    sponsoredFeePayment,
+    feePerDaGas,
+    feePerL2Gas,
+    fjFeeAmount,
+  } = ctx;
+
+  const { iterations } = args;
+
+  // 0. Create a fresh user for this test
+  const userData: AccountData = await deriveAccount(Fr.random(), ctx.wallet);
+  const user = userData.address;
+  pinoLogger.info(`${LOG_PREFIX} user=${user.toString()}`);
+
+  // Query faucet config to get drip amount
+  const faucetConfig = await faucet.methods.get_config().simulate({ from: user });
+  const dripAmount = BigInt(faucetConfig.drip_amount.toString());
+  pinoLogger.info(`${LOG_PREFIX} faucet drip_amount=${dripAmount}`);
+
+  // =========================================================================
+  // Phase 1: Deploy user account via SponsoredFPC
+  // =========================================================================
+
+  const deployMethod = await userData.accountManager.getDeployMethod();
+  await deployMethod.send({
+    from: AztecAddress.ZERO,
+    fee: {
+      paymentMethod: sponsoredFeePayment,
+    },
+    skipClassPublication: true,
+  });
+
+  pinoLogger.info(`${LOG_PREFIX} PASS: user account deployed via SponsoredFPC`);
+
+  // =========================================================================
+  // Phase 2: Faucet drip + shield tokens (batched in one tx via SponsoredFPC)
+  // =========================================================================
+
+  const shieldAmount = dripAmount;
+  pinoLogger.info(`${LOG_PREFIX} batching faucet drip + shield (${shieldAmount} tokens)`);
+
+  const batch = new BatchCall(ctx.wallet, [
+    faucet.methods.drip(user),
+    token.methods.transfer_public_to_private(user, user, shieldAmount, Fr.random()),
+  ]);
+  await batch.send({
+    from: user,
+    fee: {
+      paymentMethod: sponsoredFeePayment,
+    },
+  });
+
+  // Initialize balance trackers
+  const operatorStartBalance = BigInt(
+    (await token.methods.balance_of_private(operator).simulate({ from: operator })).toString(),
+  );
+
+  // Assert: drip landed in public, then shield moved it all to private
+  const userBal = new PrivateBalanceTracker(token, user, "User", 0n);
+  await userBal.change(shieldAmount);
+
+  pinoLogger.info(`${LOG_PREFIX} PASS: faucet drip + shield succeeded`);
+
+  // =========================================================================
+  // Phase 3: always_revert iterations via FPC fee_entrypoint
+  // =========================================================================
+
+  pinoLogger.info(`${LOG_PREFIX} starting ${iterations} always_revert iteration(s)`);
+
+  const operatorBal = new PrivateBalanceTracker(
+    token,
+    operator,
+    "Operator",
+    operatorStartBalance,
+    "atLeast",
+  );
+
+  const fpcPaymentOpts = {
+    attestationUrl,
+    wallet: ctx.wallet,
+    user,
+    operator,
+    fpc,
+    fpcAddress,
+    token,
+    tokenAddress,
+    fjFeeAmount,
+    feePerDaGas,
+    feePerL2Gas,
+    daGasLimit: args.daGasLimit,
+    l2GasLimit: args.l2GasLimit,
+  };
+
+  const fjStart = await getFeeJuiceBalance(fpcAddress, node);
+  pinoLogger.info(`${LOG_PREFIX} FPC FeeJuice balance before iterations=${fjStart}`);
+
+  for (let i = 0; i < iterations; i += 1) {
+    pinoLogger.info(`${LOG_PREFIX} iteration ${i + 1}/${iterations}`);
+
+    // Record FPC FeeJuice balance before this iteration
+    const fjBefore = await getFeeJuiceBalance(fpcAddress, node);
+
+    // Build FPC payment
+    const { aaPaymentAmount, ...fee } = await buildFpcPaymentMethod(fpcPaymentOpts);
+
+    // Send always_revert with dontThrowOnRevert so we get the receipt back
+    const receipt = await counter.methods.always_revert().send({
+      from: user,
+      fee,
+      wait: { dontThrowOnRevert: true },
+    });
+
+    // Assert: tx was mined (included in a block)
+    if (!receipt.isMined()) {
+      throw new Error(`Iteration ${i + 1}: tx was not mined (status=${receipt.status})`);
+    }
+    pinoLogger.info(`${LOG_PREFIX} iteration ${i + 1}: tx mined (status=${receipt.status})`);
+
+    // Assert: app logic reverted
+    if (receipt.executionResult !== TxExecutionResult.APP_LOGIC_REVERTED) {
+      throw new Error(
+        `Iteration ${i + 1}: expected APP_LOGIC_REVERTED, got ${receipt.executionResult}`,
+      );
+    }
+    pinoLogger.info(`${LOG_PREFIX} iteration ${i + 1}: executionResult=${receipt.executionResult}`);
+
+    // Assert: FPC FeeJuice decreased (fee was paid from FPC's FeeJuice)
+    const fjAfter = await getFeeJuiceBalance(fpcAddress, node);
+    if (fjAfter >= fjBefore) {
+      throw new Error(
+        `Iteration ${i + 1}: FPC FeeJuice did not decrease (before=${fjBefore} after=${fjAfter})`,
+      );
+    }
+    pinoLogger.info(
+      `${LOG_PREFIX} iteration ${i + 1}: FPC FeeJuice ${fjBefore} -> ${fjAfter} (delta=${fjBefore - fjAfter})`,
+    );
+
+    // Assert: operator token balance increased by aaPaymentAmount
+    await operatorBal.change(aaPaymentAmount);
+
+    // Assert: user token balance decreased by aaPaymentAmount
+    await userBal.change(-aaPaymentAmount);
+
+    pinoLogger.info(`${LOG_PREFIX} PASS: iteration ${i + 1}/${iterations}`);
+  }
+
+  // Final summary
+  const fjEnd = await getFeeJuiceBalance(fpcAddress, node);
+  pinoLogger.info(
+    `${LOG_PREFIX} all ${iterations} iteration(s) complete. FPC FeeJuice: ${fjStart} -> ${fjEnd} (total delta=${fjStart - fjEnd})`,
+  );
+}


### PR DESCRIPTION
## Summary
- Add `scripts/always-revert/` E2E smoke test that verifies FPC fee payment works correctly when app logic reverts
- Test deploys a fresh user via SponsoredFPC, funds via faucet+shield, then loops N `always_revert()` calls asserting: tx is mined, `APP_LOGIC_REVERTED` execution result, FPC FeeJuice decreases, operator token balance increases, user token balance decreases
- CLI supports `--iterations` flag (default 3, env `FPC_SMOKE_ITERATIONS`) to control number of revert iterations
- Add `smoke-always-revert` Docker Compose service (profiles: `smoke`, `full`) with same dependencies as `smoke-same-token-transfer`, wired into the `wait` gate