### PR TITLE
feat(sdk): add FpcClient with composable FPC payment method

### DIFF
--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -5,10 +5,12 @@ COPY tsconfig.base.json ./
 COPY services/attestation/tsconfig.json services/attestation/
 COPY services/topup/tsconfig.json services/topup/
 
-# ── Service source & build ──
+# ── Service & SDK source ──
 COPY services/attestation/src/ services/attestation/src/
 COPY services/topup/src/ services/topup/src/
 COPY contract-deployment/src/ contract-deployment/src/
+COPY sdk/src/ sdk/src/
+COPY sdk/tsconfig.json sdk/
 
 # ── Test files ──
 COPY services/attestation/test/ services/attestation/test/
@@ -23,8 +25,9 @@ COPY --from=deploy /app/target/ target/
 # ── Smoke & deploy scripts ──
 COPY scripts/ scripts/
 
-# ── Build services ──
-RUN bun run --filter @aztec-fpc/attestation --if-present build && \
+# ── Build SDK & services ──
+RUN bun run --filter @aztec-fpc/sdk --if-present build && \
+    bun run --filter @aztec-fpc/attestation --if-present build && \
     bun run --filter @aztec-fpc/topup --if-present build
 
 ENTRYPOINT ["bun", "run", "--sequential"]

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aztec-fpc/contract-deployment": "workspace:*",
+        "@aztec-fpc/sdk": "workspace:*",
         "@aztec/accounts": "4.0.0-devnet.2-patch.3",
         "@aztec/aztec.js": "4.0.0-devnet.2-patch.3",
         "@aztec/constants": "4.0.0-devnet.2-patch.3",

--- a/scripts/always-revert/setup.ts
+++ b/scripts/always-revert/setup.ts
@@ -23,6 +23,7 @@ import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contra
 import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import { FpcClient } from "@aztec-fpc/sdk";
 import pino from "pino";
 import { deriveAccount } from "../common/script-credentials.ts";
 import { type CliArgs, CliError } from "./cli.ts";
@@ -38,17 +39,13 @@ export type TestContext = {
   node: ReturnType<typeof createAztecNodeClient>;
   wallet: EmbeddedWallet;
   operator: AztecAddress;
-  attestationUrl: string;
-  fpc: Contract;
+  fpcClient: FpcClient;
+  fpcAddress: AztecAddress;
+  tokenAddress: AztecAddress;
   token: Contract;
   faucet: Contract;
   counter: Contract;
-  fpcAddress: AztecAddress;
-  tokenAddress: AztecAddress;
   sponsoredFeePayment: SponsoredFeePaymentMethod;
-  feePerDaGas: bigint;
-  feePerL2Gas: bigint;
-  fjFeeAmount: bigint;
 };
 
 // ---------------------------------------------------------------------------
@@ -139,14 +136,14 @@ export async function setup(args: CliArgs): Promise<TestContext> {
 
   pinoLogger.info(`[always-revert] operator=${operator.toString()}`);
 
-  // 4. Register deployed contracts
+  // 4. Register deployed contracts (faucet + counter for non-FPC operations)
   const tokenArtifact = loadArtifact(path.join(repoRoot, "target", "token_contract-Token.json"));
   const fpcArtifact = loadArtifact(resolveFpcArtifactPath(repoRoot));
   const faucetArtifact = loadArtifact(path.join(repoRoot, "target", "faucet-Faucet.json"));
   const counterArtifact = loadArtifact(path.join(repoRoot, "target", "mock_counter-Counter.json"));
 
   const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
-  const fpc = await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
+  await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
   const faucet = await registerAndGet(node, wallet, faucetAddress, faucetArtifact);
   const counter = await registerAndGet(node, wallet, counterAddress, counterArtifact);
 
@@ -158,16 +155,15 @@ export async function setup(args: CliArgs): Promise<TestContext> {
   await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
   const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcInstance.address);
 
-  // 5. Compute gas parameters
-  const minFees = await node.getCurrentMinFees();
-  const feePerDaGas = args.feePerDaGas ?? minFees.feePerDaGas;
-  const feePerL2Gas = args.feePerL2Gas ?? minFees.feePerL2Gas;
-  const maxGasCost = BigInt(args.daGasLimit) * feePerDaGas + BigInt(args.l2GasLimit) * feePerL2Gas;
-  const fjFeeAmount = maxGasCost;
-
-  pinoLogger.info(
-    `[always-revert] gas parameters. fee_per_da_gas=${feePerDaGas} fee_per_l2_gas=${feePerL2Gas} max_gas_cost=${maxGasCost}`,
-  );
+  // 5. Create FpcClient
+  const fpcClient = new FpcClient({
+    fpcAddress,
+    operator,
+    node,
+    attestationBaseUrl: args.attestationUrl,
+    daGasLimit: args.daGasLimit,
+    l2GasLimit: args.l2GasLimit,
+  });
 
   // 6. Wait for topup service to fund FPC with FeeJuice
   pinoLogger.info("[always-revert] waiting for FPC FeeJuice balance > 0 (via topup service)");
@@ -192,16 +188,12 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     node,
     wallet,
     operator,
-    attestationUrl: args.attestationUrl,
-    fpc,
-    token,
-    faucet,
+    fpcClient,
     fpcAddress,
     tokenAddress,
-    sponsoredFeePayment,
-    feePerDaGas,
-    feePerL2Gas,
-    fjFeeAmount,
+    token,
+    faucet,
     counter,
+    sponsoredFeePayment,
   };
 }

--- a/scripts/always-revert/test-always-revert.ts
+++ b/scripts/always-revert/test-always-revert.ts
@@ -12,15 +12,10 @@
  */
 
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { BatchCall, type Contract } from "@aztec/aztec.js/contracts";
+import { BatchCall } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
-import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
 import { TxExecutionResult } from "@aztec/aztec.js/tx";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
-import type { AuthWitness } from "@aztec/stdlib/auth-witness";
-import { Gas, GasFees } from "@aztec/stdlib/gas";
-import { ExecutionPayload } from "@aztec/stdlib/tx";
-import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
 import { PrivateBalanceTracker } from "../common/balance-tracker.ts";
 import { type AccountData, deriveAccount } from "../common/script-credentials.ts";
@@ -31,119 +26,6 @@ const pinoLogger = pino();
 const LOG_PREFIX = "[always-revert]";
 
 // ---------------------------------------------------------------------------
-// Local helper: fetch quote from attestation server
-// ---------------------------------------------------------------------------
-
-type QuoteResponse = {
-  accepted_asset: string;
-  fj_amount: string;
-  aa_payment_amount: string;
-  valid_until: string;
-  signature: string;
-};
-
-async function fetchQuote(
-  attestationUrl: string,
-  user: AztecAddress,
-  acceptedAsset: AztecAddress,
-  fjAmount: bigint,
-): Promise<QuoteResponse> {
-  const quoteUrl = new URL(attestationUrl);
-  const normalizedPath = quoteUrl.pathname.replace(/\/+$/u, "");
-  quoteUrl.pathname = normalizedPath.endsWith("/quote")
-    ? normalizedPath
-    : `${normalizedPath}/quote`;
-  quoteUrl.searchParams.set("user", user.toString());
-  quoteUrl.searchParams.set("accepted_asset", acceptedAsset.toString());
-  quoteUrl.searchParams.set("fj_amount", fjAmount.toString());
-
-  const response = await fetch(quoteUrl.toString());
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Quote request failed (${response.status}): ${body}`);
-  }
-  return (await response.json()) as QuoteResponse;
-}
-
-function decodeSignatureHex(signatureHex: string): number[] {
-  const normalized = signatureHex.startsWith("0x") ? signatureHex.slice(2) : signatureHex;
-  return Array.from(Buffer.from(normalized, "hex"));
-}
-
-// ---------------------------------------------------------------------------
-// Local helper: build FPC fee_entrypoint payment method + authwit
-// ---------------------------------------------------------------------------
-
-async function buildFpcPaymentMethod(opts: {
-  attestationUrl: string;
-  wallet: EmbeddedWallet;
-  user: AztecAddress;
-  operator: AztecAddress;
-  fpc: Contract;
-  fpcAddress: AztecAddress;
-  token: Contract;
-  tokenAddress: AztecAddress;
-  fjFeeAmount: bigint;
-  feePerDaGas: bigint;
-  feePerL2Gas: bigint;
-  daGasLimit: number;
-  l2GasLimit: number;
-}) {
-  // 1. Fetch quote from attestation server
-  const quote = await fetchQuote(
-    opts.attestationUrl,
-    opts.user,
-    opts.tokenAddress,
-    opts.fjFeeAmount,
-  );
-  const aaPaymentAmount = BigInt(quote.aa_payment_amount);
-  const validUntil = BigInt(quote.valid_until);
-  const signatureBytes = decodeSignatureHex(quote.signature);
-
-  // 2. Build transfer authwit: token.transfer_private_to_private(user, operator, aaPaymentAmount, nonce)
-  const nonce = Fr.random();
-
-  const transferCall = await opts.token.methods
-    .transfer_private_to_private(opts.user, opts.operator, aaPaymentAmount, nonce)
-    .getFunctionCall();
-
-  // 3. Create authwit for FPC to call the transfer on user's behalf
-  const transferAuthwit: AuthWitness = await opts.wallet.createAuthWit(opts.user, {
-    caller: opts.fpcAddress,
-    call: transferCall,
-  });
-
-  // 4. Build fee_entrypoint call
-  const feeEntrypointCall = await opts.fpc.methods
-    .fee_entrypoint(
-      opts.tokenAddress,
-      nonce,
-      opts.fjFeeAmount,
-      aaPaymentAmount,
-      validUntil,
-      signatureBytes,
-    )
-    .getFunctionCall();
-
-  // 5. Build payment method and gas settings
-  const paymentMethod = {
-    getAsset: async () => ProtocolContractAddress.FeeJuice,
-    getExecutionPayload: async () =>
-      new ExecutionPayload([feeEntrypointCall], [transferAuthwit], [], [], opts.fpcAddress),
-    getFeePayer: async () => opts.fpcAddress,
-    getGasSettings: () => undefined,
-  };
-
-  const gasSettings = {
-    gasLimits: new Gas(opts.daGasLimit, opts.l2GasLimit),
-    teardownGasLimits: new Gas(0, 0),
-    maxFeesPerGas: new GasFees(opts.feePerDaGas, opts.feePerL2Gas),
-  };
-
-  return { paymentMethod, gasSettings, aaPaymentAmount };
-}
-
-// ---------------------------------------------------------------------------
 // Main test
 // ---------------------------------------------------------------------------
 
@@ -152,17 +34,13 @@ export async function testAlwaysRevert(ctx: TestContext): Promise<void> {
     args,
     node,
     operator,
-    attestationUrl,
-    fpc,
+    fpcClient,
+    fpcAddress,
+    tokenAddress,
     token,
     faucet,
     counter,
-    fpcAddress,
-    tokenAddress,
     sponsoredFeePayment,
-    feePerDaGas,
-    feePerL2Gas,
-    fjFeeAmount,
   } = ctx;
 
   const { iterations } = args;
@@ -235,22 +113,6 @@ export async function testAlwaysRevert(ctx: TestContext): Promise<void> {
     "atLeast",
   );
 
-  const fpcPaymentOpts = {
-    attestationUrl,
-    wallet: ctx.wallet,
-    user,
-    operator,
-    fpc,
-    fpcAddress,
-    token,
-    tokenAddress,
-    fjFeeAmount,
-    feePerDaGas,
-    feePerL2Gas,
-    daGasLimit: args.daGasLimit,
-    l2GasLimit: args.l2GasLimit,
-  };
-
   const fjStart = await getFeeJuiceBalance(fpcAddress, node);
   pinoLogger.info(`${LOG_PREFIX} FPC FeeJuice balance before iterations=${fjStart}`);
 
@@ -261,12 +123,17 @@ export async function testAlwaysRevert(ctx: TestContext): Promise<void> {
     const fjBefore = await getFeeJuiceBalance(fpcAddress, node);
 
     // Build FPC payment
-    const { aaPaymentAmount, ...fee } = await buildFpcPaymentMethod(fpcPaymentOpts);
+    const fpcResult = await fpcClient.createPaymentMethod({
+      wallet: ctx.wallet,
+      user,
+      tokenAddress,
+    });
+    const aaPaymentAmount = BigInt(fpcResult.quote.aa_payment_amount);
 
     // Send always_revert with dontThrowOnRevert so we get the receipt back
     const receipt = await counter.methods.always_revert().send({
       from: user,
-      fee,
+      fee: fpcResult.fee,
       wait: { dontThrowOnRevert: true },
     });
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,6 +13,7 @@
     "@aztec/wallets": "4.0.0-devnet.2-patch.3",
     "viem": "^2.18.0",
     "pino": "^10.3.1",
-    "@aztec-fpc/contract-deployment": "workspace:*"
+    "@aztec-fpc/contract-deployment": "workspace:*",
+    "@aztec-fpc/sdk": "workspace:*"
   }
 }

--- a/scripts/same-token-transfer/setup.ts
+++ b/scripts/same-token-transfer/setup.ts
@@ -23,6 +23,7 @@ import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contra
 import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import { FpcClient } from "@aztec-fpc/sdk";
 import pino from "pino";
 import { deriveAccount } from "../common/script-credentials.ts";
 import { type CliArgs, CliError } from "./cli.ts";
@@ -38,17 +39,13 @@ export type TestContext = {
   node: ReturnType<typeof createAztecNodeClient>;
   wallet: EmbeddedWallet;
   operator: AztecAddress;
-  attestationUrl: string;
-  fpc: Contract;
+  fpcClient: FpcClient;
+  fpcAddress: AztecAddress;
+  tokenAddress: AztecAddress;
   token: Contract;
   faucet: Contract;
   counter: Contract;
-  fpcAddress: AztecAddress;
-  tokenAddress: AztecAddress;
   sponsoredFeePayment: SponsoredFeePaymentMethod;
-  feePerDaGas: bigint;
-  feePerL2Gas: bigint;
-  fjFeeAmount: bigint;
 };
 
 // ---------------------------------------------------------------------------
@@ -139,14 +136,14 @@ export async function setup(args: CliArgs): Promise<TestContext> {
 
   pinoLogger.info(`[same-token-transfer] operator=${operator.toString()}`);
 
-  // 4. Register deployed contracts
+  // 4. Register deployed contracts (faucet + counter for non-FPC operations)
   const tokenArtifact = loadArtifact(path.join(repoRoot, "target", "token_contract-Token.json"));
   const fpcArtifact = loadArtifact(resolveFpcArtifactPath(repoRoot));
   const faucetArtifact = loadArtifact(path.join(repoRoot, "target", "faucet-Faucet.json"));
   const counterArtifact = loadArtifact(path.join(repoRoot, "target", "mock_counter-Counter.json"));
 
   const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
-  const fpc = await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
+  await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
   const faucet = await registerAndGet(node, wallet, faucetAddress, faucetArtifact);
   const counter = await registerAndGet(node, wallet, counterAddress, counterArtifact);
 
@@ -158,16 +155,15 @@ export async function setup(args: CliArgs): Promise<TestContext> {
   await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
   const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcInstance.address);
 
-  // 5. Compute gas parameters
-  const minFees = await node.getCurrentMinFees();
-  const feePerDaGas = args.feePerDaGas ?? minFees.feePerDaGas;
-  const feePerL2Gas = args.feePerL2Gas ?? minFees.feePerL2Gas;
-  const maxGasCost = BigInt(args.daGasLimit) * feePerDaGas + BigInt(args.l2GasLimit) * feePerL2Gas;
-  const fjFeeAmount = maxGasCost;
-
-  pinoLogger.info(
-    `[same-token-transfer] gas parameters. fee_per_da_gas=${feePerDaGas} fee_per_l2_gas=${feePerL2Gas} max_gas_cost=${maxGasCost}`,
-  );
+  // 5. Create FpcClient
+  const fpcClient = new FpcClient({
+    fpcAddress,
+    operator,
+    node,
+    attestationBaseUrl: args.attestationUrl,
+    daGasLimit: args.daGasLimit,
+    l2GasLimit: args.l2GasLimit,
+  });
 
   // 6. Wait for topup service to fund FPC with FeeJuice
   pinoLogger.info("[same-token-transfer] waiting for FPC FeeJuice balance > 0 (via topup service)");
@@ -192,16 +188,12 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     node,
     wallet,
     operator,
-    attestationUrl: args.attestationUrl,
-    fpc,
-    token,
-    faucet,
+    fpcClient,
     fpcAddress,
     tokenAddress,
-    sponsoredFeePayment,
-    feePerDaGas,
-    feePerL2Gas,
-    fjFeeAmount,
+    token,
+    faucet,
     counter,
+    sponsoredFeePayment,
   };
 }

--- a/scripts/same-token-transfer/test-same-token-transfer.ts
+++ b/scripts/same-token-transfer/test-same-token-transfer.ts
@@ -10,13 +10,8 @@
  */
 
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { BatchCall, type Contract } from "@aztec/aztec.js/contracts";
+import { BatchCall } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
-import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
-import type { AuthWitness } from "@aztec/stdlib/auth-witness";
-import { Gas, GasFees } from "@aztec/stdlib/gas";
-import { ExecutionPayload } from "@aztec/stdlib/tx";
-import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
 import { PrivateBalanceTracker } from "../common/balance-tracker.ts";
 import { type AccountData, deriveAccount } from "../common/script-credentials.ts";
@@ -27,138 +22,12 @@ const pinoLogger = pino();
 const LOG_PREFIX = "[same-token-transfer]";
 
 // ---------------------------------------------------------------------------
-// Local helper: fetch quote from attestation server
-// ---------------------------------------------------------------------------
-
-type QuoteResponse = {
-  accepted_asset: string;
-  fj_amount: string;
-  aa_payment_amount: string;
-  valid_until: string;
-  signature: string;
-};
-
-async function fetchQuote(
-  attestationUrl: string,
-  user: AztecAddress,
-  acceptedAsset: AztecAddress,
-  fjAmount: bigint,
-): Promise<QuoteResponse> {
-  const quoteUrl = new URL(attestationUrl);
-  const normalizedPath = quoteUrl.pathname.replace(/\/+$/u, "");
-  quoteUrl.pathname = normalizedPath.endsWith("/quote")
-    ? normalizedPath
-    : `${normalizedPath}/quote`;
-  quoteUrl.searchParams.set("user", user.toString());
-  quoteUrl.searchParams.set("accepted_asset", acceptedAsset.toString());
-  quoteUrl.searchParams.set("fj_amount", fjAmount.toString());
-
-  const response = await fetch(quoteUrl.toString());
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Quote request failed (${response.status}): ${body}`);
-  }
-  return (await response.json()) as QuoteResponse;
-}
-
-function decodeSignatureHex(signatureHex: string): number[] {
-  const normalized = signatureHex.startsWith("0x") ? signatureHex.slice(2) : signatureHex;
-  return Array.from(Buffer.from(normalized, "hex"));
-}
-
-// ---------------------------------------------------------------------------
-// Local helper: build FPC fee_entrypoint payment method + authwit
-// ---------------------------------------------------------------------------
-
-async function buildFpcPaymentMethod(opts: {
-  attestationUrl: string;
-  wallet: EmbeddedWallet;
-  user: AztecAddress;
-  operator: AztecAddress;
-  fpc: Contract;
-  fpcAddress: AztecAddress;
-  token: Contract;
-  tokenAddress: AztecAddress;
-  fjFeeAmount: bigint;
-  feePerDaGas: bigint;
-  feePerL2Gas: bigint;
-  daGasLimit: number;
-  l2GasLimit: number;
-}) {
-  // 1. Fetch quote from attestation server
-  const quote = await fetchQuote(
-    opts.attestationUrl,
-    opts.user,
-    opts.tokenAddress,
-    opts.fjFeeAmount,
-  );
-  const aaPaymentAmount = BigInt(quote.aa_payment_amount);
-  const validUntil = BigInt(quote.valid_until);
-  const signatureBytes = decodeSignatureHex(quote.signature);
-
-  // 2. Build transfer authwit: token.transfer_private_to_private(user, operator, aaPaymentAmount, nonce)
-  const nonce = Fr.random();
-
-  const transferCall = await opts.token.methods
-    .transfer_private_to_private(opts.user, opts.operator, aaPaymentAmount, nonce)
-    .getFunctionCall();
-
-  // 3. Create authwit for FPC to call the transfer on user's behalf
-  const transferAuthwit: AuthWitness = await opts.wallet.createAuthWit(opts.user, {
-    caller: opts.fpcAddress,
-    call: transferCall,
-  });
-
-  // 4. Build fee_entrypoint call
-  const feeEntrypointCall = await opts.fpc.methods
-    .fee_entrypoint(
-      opts.tokenAddress,
-      nonce,
-      opts.fjFeeAmount,
-      aaPaymentAmount,
-      validUntil,
-      signatureBytes,
-    )
-    .getFunctionCall();
-
-  // 5. Build payment method and gas settings
-  const paymentMethod = {
-    getAsset: async () => ProtocolContractAddress.FeeJuice,
-    getExecutionPayload: async () =>
-      new ExecutionPayload([feeEntrypointCall], [transferAuthwit], [], [], opts.fpcAddress),
-    getFeePayer: async () => opts.fpcAddress,
-    getGasSettings: () => undefined,
-  };
-
-  const gasSettings = {
-    gasLimits: new Gas(opts.daGasLimit, opts.l2GasLimit),
-    teardownGasLimits: new Gas(0, 0),
-    maxFeesPerGas: new GasFees(opts.feePerDaGas, opts.feePerL2Gas),
-  };
-
-  return { paymentMethod, gasSettings, aaPaymentAmount };
-}
-
-// ---------------------------------------------------------------------------
 // Main test
 // ---------------------------------------------------------------------------
 
 export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
-  const {
-    args,
-    operator,
-    attestationUrl,
-    fpc,
-    token,
-    faucet,
-    counter,
-    fpcAddress,
-    tokenAddress,
-    sponsoredFeePayment,
-    feePerDaGas,
-    feePerL2Gas,
-    fjFeeAmount,
-  } = ctx;
+  const { args, operator, fpcClient, tokenAddress, token, faucet, counter, sponsoredFeePayment } =
+    ctx;
 
   const { aaPaymentAmount } = args;
 
@@ -175,8 +44,6 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
   // =========================================================================
   // Phase 1: Deploy user account via SponsoredFPC
   // =========================================================================
-
-  // pinoLogger.info(`${LOG_PREFIX} deploying user account via SponsoredFPC`);
 
   const deployMethod = await userData.accountManager.getDeployMethod();
   await deployMethod.send({
@@ -232,32 +99,20 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
     "atLeast",
   );
 
-  const fpcPaymentOpts = {
-    attestationUrl,
-    wallet: ctx.wallet,
-    user,
-    operator,
-    fpc,
-    fpcAddress,
-    token,
-    tokenAddress,
-    fjFeeAmount,
-    feePerDaGas,
-    feePerL2Gas,
-    daGasLimit: args.daGasLimit,
-    l2GasLimit: args.l2GasLimit,
-  };
-
   const counterBefore = BigInt(
     (await counter.methods.get_counter(user).simulate({ from: user })).toString(),
   );
 
-  const { aaPaymentAmount: counterFeePayment, ...counterFee } =
-    await buildFpcPaymentMethod(fpcPaymentOpts);
+  const counterFpc = await fpcClient.createPaymentMethod({
+    wallet: ctx.wallet,
+    user,
+    tokenAddress,
+  });
+  const counterFeePayment = BigInt(counterFpc.quote.aa_payment_amount);
 
   await counter.methods.increment(user).send({
     from: user,
-    fee: counterFee,
+    fee: counterFpc.fee,
   });
 
   const counterAfter = BigInt(
@@ -315,12 +170,15 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
   // const recipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
   // const transferAmount = aaPaymentAmount;
 
-  // const { aaPaymentAmount: transferFeePayment, ...transferFee } =
-  //   await buildFpcPaymentMethod(fpcPaymentOpts);
+  // const transferFpc = await fpcClient.createPaymentMethod({
+  //   wallet: ctx.wallet,
+  //   user,
+  // });
+  // const transferFeePayment = BigInt(transferFpc.quote.aa_payment_amount);
 
   // await token.methods.transfer_private_to_private(user, recipient, transferAmount, 0).send({
   //   from: user,
-  //   fee: transferFee,
+  //   fee: { paymentMethod: transferFpc.paymentMethod },
   // });
 
   // const recipientBal = new PrivateBalanceTracker(token, recipient, "Recipient", 0n);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -11,6 +11,13 @@ export {
   SponsoredTxFailedError,
 } from "./errors";
 export type {
+  CreatePaymentMethodInput,
+  FpcClientConfig,
+  FpcPaymentMethodResult,
+  QuoteResponse,
+} from "./payment-method";
+export { FpcClient } from "./payment-method";
+export type {
   ContractArtifactJson,
   CreateSponsoredCounterClientInput,
   ExecuteSponsoredCallInput,

--- a/sdk/src/internal/contracts.ts
+++ b/sdk/src/internal/contracts.ts
@@ -123,7 +123,7 @@ function resolveDefaultArtifactPath(label: DefaultArtifactLabel): string | undef
   return undefined;
 }
 
-function requireDefaultArtifact(label: DefaultArtifactLabel): ContractArtifact {
+export function requireDefaultArtifact(label: DefaultArtifactLabel): ContractArtifact {
   const cached = defaultArtifactCache[label];
   if (cached) {
     return cached;

--- a/sdk/src/payment-method.ts
+++ b/sdk/src/payment-method.ts
@@ -1,0 +1,147 @@
+import type { AztecAddress } from "@aztec/aztec.js/addresses";
+import { Contract, type InteractionFeeOptions } from "@aztec/aztec.js/contracts";
+import type { FeePaymentMethod } from "@aztec/aztec.js/fee";
+import { Fr } from "@aztec/aztec.js/fields";
+import type { AztecNode } from "@aztec/aztec.js/node";
+import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
+import type { Wallet as AccountWallet } from "@aztec/aztec.js/wallet";
+import { Gas, GasFees, GasSettings } from "@aztec/stdlib/gas";
+import { ExecutionPayload } from "@aztec/stdlib/tx";
+
+import { requireDefaultArtifact } from "./internal/contracts";
+
+export type FpcClientConfig = {
+  fpcAddress: AztecAddress;
+  operator: AztecAddress;
+  node: AztecNode;
+  attestationBaseUrl: string;
+  daGasLimit: number;
+  l2GasLimit: number;
+};
+
+export type CreatePaymentMethodInput = {
+  wallet: AccountWallet;
+  user: AztecAddress;
+  tokenAddress: AztecAddress;
+};
+
+export type QuoteResponse = {
+  accepted_asset: string;
+  fj_amount: string;
+  aa_payment_amount: string;
+  valid_until: string;
+  signature: string;
+};
+
+export type FpcPaymentMethodResult = {
+  fee: InteractionFeeOptions;
+  nonce: Fr;
+  quote: QuoteResponse;
+};
+
+async function fetchQuote(
+  attestationBaseUrl: string,
+  user: AztecAddress,
+  acceptedAsset: AztecAddress,
+  fjAmount: bigint,
+): Promise<QuoteResponse> {
+  const quoteUrl = new URL(attestationBaseUrl);
+  const normalizedPath = quoteUrl.pathname.replace(/\/+$/u, "");
+  quoteUrl.pathname = normalizedPath.endsWith("/quote")
+    ? normalizedPath
+    : `${normalizedPath}/quote`;
+  quoteUrl.searchParams.set("user", user.toString());
+  quoteUrl.searchParams.set("accepted_asset", acceptedAsset.toString());
+  quoteUrl.searchParams.set("fj_amount", fjAmount.toString());
+
+  const response = await fetch(quoteUrl.toString());
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Quote request failed (${response.status}): ${body}`);
+  }
+  return (await response.json()) as QuoteResponse;
+}
+
+async function attachContract(
+  address: AztecAddress,
+  label: "fpc" | "token",
+  node: AztecNode,
+  wallet: AccountWallet,
+): Promise<Contract> {
+  const artifact = requireDefaultArtifact(label);
+  const instance = await node.getContract(address);
+  if (!instance) {
+    throw new Error(`${label} contract not found on node at ${address.toString()}`);
+  }
+  await wallet.registerContract(instance, artifact);
+  return Contract.at(address, artifact, wallet);
+}
+
+export class FpcClient {
+  private readonly config: FpcClientConfig;
+
+  constructor(config: FpcClientConfig) {
+    this.config = config;
+  }
+
+  async createPaymentMethod(input: CreatePaymentMethodInput): Promise<FpcPaymentMethodResult> {
+    const { fpcAddress, operator, node, attestationBaseUrl, daGasLimit, l2GasLimit } = this.config;
+    const { wallet, user, tokenAddress } = input;
+
+    // 1. Attach contracts
+    const [fpc, token] = await Promise.all([
+      attachContract(fpcAddress, "fpc", node, wallet),
+      attachContract(tokenAddress, "token", node, wallet),
+    ]);
+
+    // 2. Query gas fees from node and compute fjAmount
+    const gasFees = await node.getCurrentMinFees();
+    const fjAmount =
+      BigInt(daGasLimit) * gasFees.feePerDaGas + BigInt(l2GasLimit) * gasFees.feePerL2Gas;
+
+    // 3. Fetch quote
+    const quote = await fetchQuote(attestationBaseUrl, user, tokenAddress, fjAmount);
+
+    // 4. Parse quote fields for contract calls
+    const aaPaymentAmount = BigInt(quote.aa_payment_amount);
+    const validUntil = BigInt(quote.valid_until);
+    const sigBytes = Array.from(Buffer.from(quote.signature.replace(/^0x/, ""), "hex"));
+
+    // 5. Build transfer call + auth witness
+    const nonce = Fr.random();
+    const transferCall = await token.methods
+      .transfer_private_to_private(user, operator, aaPaymentAmount, nonce)
+      .getFunctionCall();
+    const transferAuthwit = await wallet.createAuthWit(user, {
+      caller: fpcAddress,
+      call: transferCall,
+    });
+
+    // 6. Build fee_entrypoint call
+    const feeEntrypointCall = await fpc.methods
+      .fee_entrypoint(tokenAddress, nonce, fjAmount, aaPaymentAmount, validUntil, sigBytes)
+      .getFunctionCall();
+
+    // 7. Assemble payment method with embedded gas settings
+    const gasSettings = new GasSettings(
+      new Gas(daGasLimit, l2GasLimit),
+      new Gas(0, 0),
+      gasFees,
+      GasFees.empty(),
+    );
+
+    const paymentMethod: FeePaymentMethod = {
+      getAsset: async () => ProtocolContractAddress.FeeJuice,
+      getExecutionPayload: async () =>
+        new ExecutionPayload([feeEntrypointCall], [transferAuthwit], [], [], fpcAddress),
+      getFeePayer: async () => fpcAddress,
+      getGasSettings: () => gasSettings,
+    };
+
+    return {
+      fee: { paymentMethod },
+      nonce,
+      quote,
+    };
+  }
+}

--- a/sdk/test/payment-method.test.ts
+++ b/sdk/test/payment-method.test.ts
@@ -1,0 +1,248 @@
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
+import { Gas, GasFees, GasSettings } from "@aztec/stdlib/gas";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FpcClient } from "../src/payment-method";
+
+vi.mock("../src/internal/contracts", () => ({
+  requireDefaultArtifact: vi.fn(() => ({ name: "MockArtifact" })),
+}));
+
+vi.mock("@aztec/aztec.js/contracts", () => {
+  const contractInstance = {
+    address: AztecAddress.fromString(
+      "0x24a735808258519dc1637f1833202ea2dc7c829a0a82c73f61bbd195fce4105b",
+    ),
+    methods: {
+      transfer_private_to_private: vi.fn(() => ({
+        getFunctionCall: vi.fn(async () => ({ fn: "transfer" })),
+      })),
+      fee_entrypoint: vi.fn(() => ({
+        getFunctionCall: vi.fn(async () => ({ fn: "fee_entrypoint" })),
+      })),
+    },
+  };
+
+  return {
+    Contract: {
+      at: vi.fn(() => contractInstance),
+    },
+    __contractInstance: contractInstance,
+  };
+});
+
+const USER = AztecAddress.fromString(
+  "0x226762b1e122bd46054de3fd21a19f0500ebe072aeac35fe0bb82d43b85f94fd",
+);
+const TOKEN_ADDRESS = AztecAddress.fromString(
+  "0x10600e2f256b6500de5a79367d70b4c7d8121c408a2127dbcba995a1abc0d6f8",
+);
+const OPERATOR = AztecAddress.fromString(
+  "0x18a15b90bea06cea7cbd06b3940533952aa9e5f94c157000c727321644d07af8",
+);
+const FPC_ADDRESS = AztecAddress.fromString(
+  "0x24a735808258519dc1637f1833202ea2dc7c829a0a82c73f61bbd195fce4105b",
+);
+
+const FEE_PER_DA_GAS = 2n;
+const FEE_PER_L2_GAS = 3n;
+const MOCK_GAS_FEES = new GasFees(FEE_PER_DA_GAS, FEE_PER_L2_GAS);
+const DA_GAS_LIMIT = 1_000_000;
+const L2_GAS_LIMIT = 1_000_000;
+const EXPECTED_FJ_AMOUNT =
+  BigInt(DA_GAS_LIMIT) * FEE_PER_DA_GAS + BigInt(L2_GAS_LIMIT) * FEE_PER_L2_GAS;
+
+const QUOTE_RESPONSE = {
+  accepted_asset: TOKEN_ADDRESS.toString(),
+  fj_amount: EXPECTED_FJ_AMOUNT.toString(),
+  aa_payment_amount: "500",
+  valid_until: "9999",
+  signature: "ab".repeat(64),
+};
+
+function createMockNode() {
+  return {
+    getCurrentMinFees: vi.fn(async () => MOCK_GAS_FEES),
+    getContract: vi.fn(async () => ({ address: FPC_ADDRESS })),
+  };
+}
+
+function createMockWallet() {
+  return {
+    createAuthWit: vi.fn(async () => ({ witness: "ok" })),
+    registerContract: vi.fn(async () => undefined),
+  };
+}
+
+function mockFetchOk(body: unknown) {
+  return vi.fn(async () => ({
+    ok: true,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }));
+}
+
+function createClient(nodeOverride?: ReturnType<typeof createMockNode>) {
+  return new FpcClient({
+    fpcAddress: FPC_ADDRESS,
+    operator: OPERATOR,
+    node: (nodeOverride ?? createMockNode()) as never,
+    attestationBaseUrl: "https://example.com/v2",
+    daGasLimit: DA_GAS_LIMIT,
+    l2GasLimit: L2_GAS_LIMIT,
+  });
+}
+
+describe("FpcClient", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("builds payment method with correct fee payer, asset, and gas settings", async () => {
+    const wallet = createMockWallet();
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+
+    const client = createClient();
+    const result = await client.createPaymentMethod({
+      wallet: wallet as never,
+      user: USER,
+      tokenAddress: TOKEN_ADDRESS,
+    });
+
+    expect(await result.fee.paymentMethod.getAsset()).toBe(ProtocolContractAddress.FeeJuice);
+    expect(await result.fee.paymentMethod.getFeePayer()).toBe(FPC_ADDRESS);
+    expect(result.fee.paymentMethod.getGasSettings()).toEqual(
+      new GasSettings(
+        new Gas(DA_GAS_LIMIT, L2_GAS_LIMIT),
+        new Gas(0, 0),
+        MOCK_GAS_FEES,
+        GasFees.empty(),
+      ),
+    );
+  });
+
+  it("computes fjAmount from node gas fees and gas limits", async () => {
+    const wallet = createMockWallet();
+    const node = createMockNode();
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+
+    const client = createClient(node);
+    const result = await client.createPaymentMethod({
+      wallet: wallet as never,
+      user: USER,
+      tokenAddress: TOKEN_ADDRESS,
+    });
+
+    expect(result.quote.fj_amount).toBe(EXPECTED_FJ_AMOUNT.toString());
+    expect(node.getCurrentMinFees).toHaveBeenCalledTimes(1);
+  });
+
+  it("constructs correct quote URL", async () => {
+    const wallet = createMockWallet();
+    const mockFetch = mockFetchOk(QUOTE_RESPONSE);
+    globalThis.fetch = mockFetch as never;
+
+    const client = createClient();
+    await client.createPaymentMethod({
+      wallet: wallet as never,
+      user: USER,
+      tokenAddress: TOKEN_ADDRESS,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const calledUrl = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(calledUrl.pathname).toBe("/v2/quote");
+    expect(calledUrl.searchParams.get("user")).toBe(USER.toString());
+    expect(calledUrl.searchParams.get("accepted_asset")).toBe(TOKEN_ADDRESS.toString());
+    expect(calledUrl.searchParams.get("fj_amount")).toBe(EXPECTED_FJ_AMOUNT.toString());
+  });
+
+  it("returns full quote response", async () => {
+    const wallet = createMockWallet();
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+
+    const client = createClient();
+    const result = await client.createPaymentMethod({
+      wallet: wallet as never,
+      user: USER,
+      tokenAddress: TOKEN_ADDRESS,
+    });
+
+    expect(result.quote).toEqual(QUOTE_RESPONSE);
+  });
+
+  it("calls wallet.createAuthWit with correct args", async () => {
+    const wallet = createMockWallet();
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+
+    const client = createClient();
+    await client.createPaymentMethod({
+      wallet: wallet as never,
+      user: USER,
+      tokenAddress: TOKEN_ADDRESS,
+    });
+
+    expect(wallet.createAuthWit).toHaveBeenCalledTimes(1);
+    expect(wallet.createAuthWit).toHaveBeenCalledWith(USER, {
+      caller: FPC_ADDRESS,
+      call: { fn: "transfer" },
+    });
+  });
+
+  it("registers contracts with wallet before use", async () => {
+    const wallet = createMockWallet();
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+
+    const client = createClient();
+    await client.createPaymentMethod({
+      wallet: wallet as never,
+      user: USER,
+      tokenAddress: TOKEN_ADDRESS,
+    });
+
+    expect(wallet.registerContract).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates fetch errors", async () => {
+    const wallet = createMockWallet();
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    })) as never;
+
+    const client = createClient();
+    await expect(
+      client.createPaymentMethod({
+        wallet: wallet as never,
+        user: USER,
+        tokenAddress: TOKEN_ADDRESS,
+      }),
+    ).rejects.toThrow("Quote request failed (500)");
+  });
+
+  it("throws when contract not found on node", async () => {
+    const wallet = createMockWallet();
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+
+    const node = createMockNode();
+    node.getContract.mockResolvedValue(null);
+
+    const client = createClient(node);
+    await expect(
+      client.createPaymentMethod({
+        wallet: wallet as never,
+        user: USER,
+        tokenAddress: TOKEN_ADDRESS,
+      }),
+    ).rejects.toThrow("contract not found on node");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `FpcClient` class to SDK that returns `InteractionFeeOptions` ready to plug into `.send({ fee })`
- Handles quote fetching, gas computation, authwit creation, and fee_entrypoint assembly
- `tokenAddress` is a per-call input to support multiple tokens
- Migrate `scripts/same-token-transfer` and `scripts/always-revert` to use the new SDK
- Remove duplicated local helpers (quote fetching, signature decoding, payment method building) from each script
- Add `@aztec-fpc/sdk` dependency to `scripts/package.json`
- Update `Dockerfile.smoke` to copy and build the SDK package
- Add 8 unit tests for `FpcClient`