### PR TITLE
refactor: replace createWalletClient with createExtendedL1Client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
         "@aztec/accounts": "4.1.0-nightly.20260312.2",
         "@aztec/aztec.js": "4.1.0-nightly.20260312.2",
         "@aztec/bb.js": "4.1.0-nightly.20260312.2",
+        "@aztec/ethereum": "4.1.0-nightly.20260312.2",
         "@aztec/foundation": "4.1.0-nightly.20260312.2",
         "@aztec/noir-acvm_js": "4.1.0-nightly.20260312.2",
         "@aztec/noir-noirc_abi": "4.1.0-nightly.20260312.2",
@@ -87,7 +88,7 @@
         "fastify": "^4.28.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
-        "viem": "^2.18.0",
+        "viem": "npm:@aztec/viem@2.38.2",
         "yaml": "^2.4.5",
         "zod": "^3.23.8",
       },
@@ -108,7 +109,7 @@
         "@aztec/wallets": "4.1.0-nightly.20260312.2",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
-        "viem": "^2.18.0",
+        "viem": "npm:@aztec/viem@2.38.2",
         "yaml": "^2.4.5",
         "zod": "^3.23.8",
       },
@@ -663,7 +664,7 @@
 
     "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
-    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+    "abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -981,7 +982,7 @@
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
-    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+    "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1129,7 +1130,7 @@
 
     "ordered-binary": ["ordered-binary@1.6.1", "", {}, "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w=="],
 
-    "ox": ["ox@0.14.0", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw=="],
+    "ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -1387,7 +1388,7 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "viem": ["viem@2.47.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.0", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-jU5e1E1s5E5M1y+YrELDnNar/34U8NXfVcRfxtVETigs2gS1vvW2ngnBoQUGBwLnNr0kNv+NUu4m10OqHByoFw=="],
+    "viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
 
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
@@ -1437,21 +1438,7 @@
 
     "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.4.1", "", { "dependencies": { "fast-xml-builder": "^1.0.0", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A=="],
 
-    "@aztec-fpc/contract-deployment/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
-
-    "@aztec-fpc/scripts/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
-
-    "@aztec/aztec.js/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
-
-    "@aztec/ethereum/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
-
     "@aztec/foundation/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
-
-    "@aztec/pxe/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
-
-    "@aztec/stdlib/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
-
-    "@aztec/telemetry-client/viem": ["@aztec/viem@2.38.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.6.0", "", {}, "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ=="],
 
@@ -1509,13 +1496,13 @@
 
     "command-line-usage/typical": ["typical@5.2.0", "", {}, "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="],
 
-    "execa/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
-
     "fast-json-stringify/ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "fastify/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "gaxios/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -1575,67 +1562,11 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@aztec-fpc/contract-deployment/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec-fpc/contract-deployment/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec-fpc/contract-deployment/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec-fpc/contract-deployment/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
-
-    "@aztec-fpc/scripts/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec-fpc/scripts/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec-fpc/scripts/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec-fpc/scripts/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
-
-    "@aztec/aztec.js/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec/aztec.js/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec/aztec.js/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec/aztec.js/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
-
-    "@aztec/ethereum/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec/ethereum/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec/ethereum/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec/ethereum/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
-
     "@aztec/foundation/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
     "@aztec/foundation/pino/process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "@aztec/foundation/pino/thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
-
-    "@aztec/pxe/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec/pxe/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec/pxe/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec/pxe/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
-
-    "@aztec/stdlib/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec/stdlib/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec/stdlib/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec/stdlib/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
-
-    "@aztec/telemetry-client/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@aztec/telemetry-client/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@aztec/telemetry-client/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "@aztec/telemetry-client/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
 
     "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.27.0", "", {}, "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg=="],
 
@@ -1732,20 +1663,6 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
-
-    "@aztec-fpc/contract-deployment/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
-
-    "@aztec-fpc/scripts/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
-
-    "@aztec/aztec.js/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
-
-    "@aztec/ethereum/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
-
-    "@aztec/pxe/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
-
-    "@aztec/stdlib/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
-
-    "@aztec/telemetry-client/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "command-line-usage/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -24,8 +24,7 @@ import { deriveKeys, deriveSigningKey } from "@aztec/stdlib/keys";
 import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
-import type { Chain, Hex } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { type Chain, extractChain, type Hex } from "viem";
 import * as viemChains from "viem/chains";
 import { deployContract } from "./deploy-utils.js";
 import { writeDevnetDeployManifest } from "./devnet-manifest.js";
@@ -492,43 +491,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function isChain(value: unknown): value is Chain {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as {
-    id?: unknown;
-    name?: unknown;
-    nativeCurrency?: unknown;
-    rpcUrls?: unknown;
-  };
-  return (
-    typeof candidate.id === "number" &&
-    typeof candidate.name === "string" &&
-    typeof candidate.nativeCurrency === "object" &&
-    typeof candidate.rpcUrls === "object"
-  );
-}
-
-function resolveL1Chain(chainId: number, l1RpcUrl: string): Chain {
-  const known = Object.values(viemChains)
-    .filter(isChain)
-    .find((chain) => chain.id === chainId);
-  if (!known) {
-    throw new CliError(
-      `Unsupported L1 chain ID ${chainId}. No matching chain found in viem/chains.`,
-    );
-  }
-  return {
-    ...known,
-    rpcUrls: {
-      ...known.rpcUrls,
-      default: { http: [l1RpcUrl] },
-      public: { http: [l1RpcUrl] },
-    },
-  };
-}
-
 function isJsonRpcFailure(payload: unknown): payload is JsonRpcFailure {
   if (!payload || typeof payload !== "object") {
     return false;
@@ -959,18 +921,17 @@ async function deployTestTokenEcosystem(opts: {
 }): Promise<TestTokenEcosystem> {
   pinoLogger.info("[deploy-fpc-devnet] deploying L1 + L2 bridge contracts");
 
-  const l1Account = privateKeyToAccount(opts.l1DeployerKey as Hex);
   const l1WalletClient = createExtendedL1Client(
     [opts.l1RpcUrl],
-    l1Account,
-    resolveL1Chain(opts.l1ChainId, opts.l1RpcUrl),
+    opts.l1DeployerKey as Hex,
+    extractChain({ chains: Object.values(viemChains) as readonly Chain[], id: opts.l1ChainId }),
   );
 
   // 1. Deploy L1 TestERC20
   const l1Erc20Hash = await l1WalletClient.deployContract({
     abi: TestERC20Abi,
     bytecode: TestERC20Bytecode as Hex,
-    args: ["TestToken", "TST", l1Account.address],
+    args: ["TestToken", "TST", l1WalletClient.account.address],
   });
   const l1Erc20Receipt = await l1WalletClient.waitForTransactionReceipt({ hash: l1Erc20Hash });
   if (!l1Erc20Receipt.contractAddress) {
@@ -1063,7 +1024,7 @@ async function deployTestTokenEcosystem(opts: {
     address: l1Erc20Address as Hex,
     abi: TestERC20Abi,
     functionName: "mint",
-    args: [l1Account.address, faucetConfig.initialSupply],
+    args: [l1WalletClient.account.address, faucetConfig.initialSupply],
   });
   await l1WalletClient.waitForTransactionReceipt({ hash: l1MintHash });
 

--- a/profiling/benchmarks/fpc.benchmark.ts
+++ b/profiling/benchmarks/fpc.benchmark.ts
@@ -55,14 +55,10 @@ import {
   AVM_MAX_PROCESSABLE_L2_GAS,
   MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT,
 } from '@aztec/constants';
+import { createExtendedL1Client } from '@aztec/ethereum/client';
 import { createPXE, getPXEConfig } from '@aztec/pxe/server';
-import {
-  createWalletClient,
-  defineChain,
-  http,
-  publicActions,
-} from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
+import { extractChain, type Chain } from 'viem';
+import * as viemChains from 'viem/chains';
 import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync, rmSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -159,19 +155,8 @@ function constructorHasAcceptedAsset(fpcArtifact: any): boolean {
 
 async function createL1Client(node: any) {
   const nodeInfo = await node.getNodeInfo();
-  const chain = defineChain({
-    id: nodeInfo.l1ChainId,
-    name: 'Local L1',
-    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-    rpcUrls: { default: { http: [L1_RPC_URL] } },
-  });
-  const account = privateKeyToAccount(ANVIL_PRIVATE_KEY as `0x${string}`);
-  const walletClient = createWalletClient({
-    account,
-    chain,
-    transport: http(L1_RPC_URL),
-  });
-  return walletClient.extend(publicActions);
+  const chain = extractChain({ chains: Object.values(viemChains) as readonly Chain[], id: nodeInfo.l1ChainId });
+  return createExtendedL1Client([L1_RPC_URL], ANVIL_PRIVATE_KEY, chain);
 }
 
 async function mineL1Blocks(l1Client: any, count: number) {

--- a/profiling/package.json
+++ b/profiling/package.json
@@ -7,6 +7,7 @@
     "@aztec/accounts": "4.1.0-nightly.20260312.2",
     "@aztec/aztec.js": "4.1.0-nightly.20260312.2",
     "@aztec/constants": "4.1.0-nightly.20260312.2",
+    "@aztec/ethereum": "4.1.0-nightly.20260312.2",
     "@aztec/foundation": "4.1.0-nightly.20260312.2",
     "@aztec/protocol-contracts": "4.1.0-nightly.20260312.2",
     "@aztec/pxe": "4.1.0-nightly.20260312.2",
@@ -14,6 +15,6 @@
     "@aztec/wallet-sdk": "4.1.0-nightly.20260312.2",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
-    "viem": "^2.31.0"
+    "viem": "npm:@aztec/viem@2.38.2"
   }
 }

--- a/scripts/cold-start/setup.ts
+++ b/scripts/cold-start/setup.ts
@@ -28,16 +28,8 @@ import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
 import pino from "pino";
-import {
-  createWalletClient,
-  fallback,
-  type GetContractReturnType,
-  getContract,
-  type Hex,
-  http,
-  publicActions,
-} from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { type Chain, extractChain, type GetContractReturnType, getContract, type Hex } from "viem";
+import * as viemChains from "viem/chains";
 import { deriveAccount, resolveScriptAccounts } from "../common/script-credentials.ts";
 import { type CliArgs, CliError } from "./cli.ts";
 
@@ -201,16 +193,16 @@ export async function setup(args: CliArgs): Promise<TestContext> {
   }
   pinoLogger.info(`[cold-start-smoke] FPC FeeJuice balance=${fpcFeeJuiceBalance}`);
 
-  const l1Account = privateKeyToAccount(l1PrivateKey as Hex);
-  const l1WalletClient = createExtendedL1Client([args.l1RpcUrl], l1Account);
+  const nodeInfo = await node.getNodeInfo();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: nodeInfo.l1ChainId,
+  });
+  const l1WalletClient = createExtendedL1Client([args.l1RpcUrl], l1PrivateKey as Hex, l1Chain);
 
   // 6. Set up L1 clients for token bridging (tests bridge their own tokens)
   const l1MintKey = (args.l1DeployerKey ?? l1PrivateKey) as Hex;
-  const l1MintAccount = privateKeyToAccount(l1MintKey);
-  const l1MintClient = createWalletClient({
-    account: l1MintAccount,
-    transport: fallback([http(args.l1RpcUrl)]),
-  }).extend(publicActions);
+  const l1MintClient = createExtendedL1Client([args.l1RpcUrl], l1MintKey, l1Chain);
 
   const l1Erc20 = getContract({
     address: l1Erc20Address as Hex,

--- a/scripts/common/script-credentials.ts
+++ b/scripts/common/script-credentials.ts
@@ -18,12 +18,14 @@ import { type Fq, Fr } from "@aztec/aztec.js/fields";
 import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import type { AccountManager } from "@aztec/aztec.js/wallet";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import { createLogger } from "@aztec/foundation/log";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
 import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
-import { createWalletClient, fallback, type Hex, http, publicActions } from "viem";
+import { type Chain, extractChain, type Hex } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import * as viemChains from "viem/chains";
 
 const pinoLogger = pino();
 
@@ -82,10 +84,12 @@ export async function resolveScriptAccounts(
   const node = createAztecNodeClient(nodeUrl);
 
   // Set up L1 portal for bridging FeeJuice.
-  const l1WalletClient = createWalletClient({
-    account: l1Account,
-    transport: fallback([http(l1RpcUrl)]),
-  }).extend(publicActions);
+  const nodeInfo = await node.getNodeInfo();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: nodeInfo.l1ChainId,
+  });
+  const l1WalletClient = createExtendedL1Client([l1RpcUrl], l1Key, l1Chain);
   const portal = await L1FeeJuicePortalManager.new(
     node,
     l1WalletClient,

--- a/scripts/contract/devnet-postdeploy-smoke.ts
+++ b/scripts/contract/devnet-postdeploy-smoke.ts
@@ -130,11 +130,16 @@ type AztecDeps = {
   ExecutionPayload: new (...args: unknown[]) => unknown;
   EmbeddedWallet: { create: (node: NodeLike) => Promise<WalletLike> };
   createPublicClient: (config: { transport: unknown }) => L1PublicClientLike;
-  createWalletClient: (config: { account: unknown; transport: unknown }) => L1WalletClientLike;
+  createExtendedL1Client: (
+    rpcUrls: string[],
+    account: unknown,
+    chain?: unknown,
+  ) => L1WalletClientLike & L1PublicClientLike;
   decodeEventLog: (config: { abi: unknown; data: string; topics: string[] }) => unknown;
   http: (url: string) => unknown;
   parseAbi: (abi: string[]) => unknown;
-  privateKeyToAccount: (privateKey: string) => unknown;
+  extractChain: (args: { chains: unknown[]; id: number }) => unknown;
+  viemChains: unknown[];
 };
 
 class CliError extends Error {
@@ -497,8 +502,9 @@ async function loadDeps(): Promise<AztecDeps> {
     keysApi,
     txApi,
     embeddedApi,
+    ethereumClientApi,
     viemApi,
-    viemAccountsApi,
+    viemChainsApi,
   ] = await Promise.all([
     importWithWorkspaceFallback("@aztec/aztec.js/node"),
     importWithWorkspaceFallback("@aztec/aztec.js/messaging"),
@@ -514,8 +520,9 @@ async function loadDeps(): Promise<AztecDeps> {
     importWithWorkspaceFallback("@aztec/stdlib/keys"),
     importWithWorkspaceFallback("@aztec/stdlib/tx"),
     importWithWorkspaceFallback("@aztec/wallets/embedded"),
+    importWithWorkspaceFallback("@aztec/ethereum/client"),
     importWithWorkspaceFallback("viem"),
-    importWithWorkspaceFallback("viem/accounts"),
+    importWithWorkspaceFallback("viem/chains"),
   ]);
 
   const deps: AztecDeps = {
@@ -541,11 +548,13 @@ async function loadDeps(): Promise<AztecDeps> {
     ExecutionPayload: txApi.ExecutionPayload as AztecDeps["ExecutionPayload"],
     EmbeddedWallet: embeddedApi.EmbeddedWallet as AztecDeps["EmbeddedWallet"],
     createPublicClient: viemApi.createPublicClient as AztecDeps["createPublicClient"],
-    createWalletClient: viemApi.createWalletClient as AztecDeps["createWalletClient"],
+    createExtendedL1Client:
+      ethereumClientApi.createExtendedL1Client as AztecDeps["createExtendedL1Client"],
     decodeEventLog: viemApi.decodeEventLog as AztecDeps["decodeEventLog"],
     http: viemApi.http as AztecDeps["http"],
     parseAbi: viemApi.parseAbi as AztecDeps["parseAbi"],
-    privateKeyToAccount: viemAccountsApi.privateKeyToAccount as AztecDeps["privateKeyToAccount"],
+    extractChain: viemApi.extractChain as AztecDeps["extractChain"],
+    viemChains: Object.values(viemChainsApi),
   };
 
   const requiredFunctions: Array<[string, unknown]> = [
@@ -557,11 +566,10 @@ async function loadDeps(): Promise<AztecDeps> {
     ["computeSecretHash", deps.computeSecretHash],
     ["deriveSigningKey", deps.deriveSigningKey],
     ["createPublicClient", deps.createPublicClient],
-    ["createWalletClient", deps.createWalletClient],
+    ["createExtendedL1Client", deps.createExtendedL1Client],
     ["decodeEventLog", deps.decodeEventLog],
     ["http", deps.http],
     ["parseAbi", deps.parseAbi],
-    ["privateKeyToAccount", deps.privateKeyToAccount],
   ];
   for (const [name, value] of requiredFunctions) {
     if (typeof value !== "function") {
@@ -943,10 +951,12 @@ async function runSmoke(args: CliArgs): Promise<void> {
     );
   }
 
-  const l1WalletClient = deps.createWalletClient({
-    account: deps.privateKeyToAccount(l1OperatorPrivateKeyHex),
-    transport: deps.http(args.l1RpcUrl),
-  });
+  const l1Chain = deps.extractChain({ chains: deps.viemChains, id: l1ChainId });
+  const l1WalletClient = deps.createExtendedL1Client(
+    [args.l1RpcUrl],
+    l1OperatorPrivateKeyHex,
+    l1Chain,
+  );
 
   const tokenArtifact = loadArtifact(
     deps,

--- a/scripts/services/fpc-services-smoke.ts
+++ b/scripts/services/fpc-services-smoke.ts
@@ -13,6 +13,7 @@ import type { Contract } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import { Schnorr, SchnorrSignature } from "@aztec/foundation/crypto/schnorr";
 import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
 import { Gas } from "@aztec/stdlib/gas";
@@ -21,8 +22,9 @@ import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { deployContract } from "@aztec-fpc/contract-deployment/src/deploy-utils.ts";
 import { FpcClient } from "@aztec-fpc/sdk";
-import { createPublicClient, createWalletClient, type Hex, http, parseAbi } from "viem";
+import { type Chain, createPublicClient, extractChain, type Hex, http, parseAbi } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import * as viemChains from "viem/chains";
 import {
   installManagedProcessSignalHandlers,
   type ManagedProcess,
@@ -231,10 +233,12 @@ async function tryMintL1FeeJuice(
 
   const { tokenAddress } = await getFeeJuiceL1Addresses(node);
   const account = privateKeyToAccount(l1PrivateKey);
-  const walletClient = createWalletClient({
-    account,
-    transport: http(l1RpcUrl),
+  const nodeInfo = await node.getNodeInfo();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: nodeInfo.l1ChainId,
   });
+  const walletClient = createExtendedL1Client([l1RpcUrl], l1PrivateKey, l1Chain);
   const publicClient = createPublicClient({
     transport: http(l1RpcUrl),
   });

--- a/scripts/services/fund-l1-fee-juice.ts
+++ b/scripts/services/fund-l1-fee-juice.ts
@@ -1,8 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import pino from "pino";
-import { type Address, createPublicClient, createWalletClient, http, isAddress } from "viem";
+import { type Address, type Chain, createPublicClient, extractChain, http, isAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import * as viemChains from "viem/chains";
 
 const pinoLogger = pino();
 
@@ -535,11 +537,13 @@ async function tryDirectMint(params: {
   amount: bigint;
 }): Promise<boolean> {
   const funder = privateKeyToAccount(params.funderPrivateKey);
-  const walletClient = createWalletClient({
-    account: funder,
-    transport: http(params.l1RpcUrl),
-  });
   const publicClient = createPublicClient({ transport: http(params.l1RpcUrl) });
+  const l1ChainId = await publicClient.getChainId();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: l1ChainId,
+  });
+  const walletClient = createExtendedL1Client([params.l1RpcUrl], params.funderPrivateKey, l1Chain);
 
   try {
     const { hash } = await sendWithManagedNonce({
@@ -547,7 +551,6 @@ async function tryDirectMint(params: {
       accountAddress: funder.address,
       send: (nonce) =>
         walletClient.writeContract({
-          chain: null,
           address: params.tokenAddress,
           abi: ERC20_MINT_ABI,
           functionName: "mint",
@@ -580,11 +583,13 @@ async function mintViaFeeAssetHandler(params: {
   targetBalanceWei: bigint;
 }): Promise<void> {
   const funder = privateKeyToAccount(params.funderPrivateKey);
-  const walletClient = createWalletClient({
-    account: funder,
-    transport: http(params.l1RpcUrl),
-  });
   const publicClient = createPublicClient({ transport: http(params.l1RpcUrl) });
+  const l1ChainId = await publicClient.getChainId();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: l1ChainId,
+  });
+  const walletClient = createExtendedL1Client([params.l1RpcUrl], params.funderPrivateKey, l1Chain);
 
   const mintAmount = await publicClient.readContract({
     address: params.handlerAddress,
@@ -612,7 +617,6 @@ async function mintViaFeeAssetHandler(params: {
       initialNonce: nextNonce,
       send: (nonce) =>
         walletClient.writeContract({
-          chain: null,
           address: params.handlerAddress,
           abi: FEE_ASSET_HANDLER_ABI,
           functionName: "mint",

--- a/services/attestation/package.json
+++ b/services/attestation/package.json
@@ -20,11 +20,12 @@
     "@aztec/noir-acvm_js": "4.1.0-nightly.20260312.2",
     "@aztec/pxe": "4.1.0-nightly.20260312.2",
     "@aztec/stdlib": "4.1.0-nightly.20260312.2",
+    "@aztec/ethereum": "4.1.0-nightly.20260312.2",
     "@aztec/wallets": "4.1.0-nightly.20260312.2",
     "fastify": "^4.28.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
-    "viem": "^2.18.0",
+    "viem": "npm:@aztec/viem@2.38.2",
     "yaml": "^2.4.5",
     "zod": "^3.23.8",
     "@aztec-fpc/contract-deployment": "workspace:*"

--- a/services/attestation/test/fee-entrypoint-local-smoke.ts
+++ b/services/attestation/test/fee-entrypoint-local-smoke.ts
@@ -12,6 +12,7 @@ import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { FeeJuiceContract, ProtocolContractAddress } from "@aztec/aztec.js/protocol";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import { Schnorr } from "@aztec/foundation/crypto/schnorr";
 import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
 import { Gas, GasFees, GasSettings } from "@aztec/stdlib/gas";
@@ -22,14 +23,16 @@ import { ExecutionPayload } from "@aztec/stdlib/tx";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { deployContract } from "@aztec-fpc/contract-deployment/src/deploy-utils.ts";
 import {
+  type Chain,
   createPublicClient,
-  createWalletClient,
   decodeEventLog,
+  extractChain,
   type Hex,
   http,
   parseAbi,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import * as viemChains from "viem/chains";
 import { resolveScriptAccounts } from "../../../scripts/common/script-credentials.ts";
 
 const QUOTE_DOMAIN_SEPARATOR = Fr.fromHexString("0x465043");
@@ -200,7 +203,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 type PublicClient = ReturnType<typeof createPublicClient>;
-type WalletClient = ReturnType<typeof createWalletClient>;
+type WalletClient = ReturnType<typeof createExtendedL1Client>;
 type L1Receipt = Awaited<ReturnType<PublicClient["waitForTransactionReceipt"]>>;
 
 interface FeeJuiceBridgeContracts {
@@ -241,17 +244,20 @@ async function resolveFeeJuiceBridgeContracts(
   };
 }
 
-function createL1Clients(config: SmokeConfig): L1Clients {
+async function createL1Clients(config: SmokeConfig): Promise<L1Clients> {
   const account = privateKeyToAccount(config.l1PrivateKey);
+  const publicClient = createPublicClient({
+    transport: http(config.l1RpcUrl),
+  });
+  const l1ChainId = await publicClient.getChainId();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: l1ChainId,
+  });
   return {
     accountAddress: account.address,
-    walletClient: createWalletClient({
-      account,
-      transport: http(config.l1RpcUrl),
-    }),
-    publicClient: createPublicClient({
-      transport: http(config.l1RpcUrl),
-    }),
+    walletClient: createExtendedL1Client([config.l1RpcUrl], config.l1PrivateKey, l1Chain),
+    publicClient,
   };
 }
 
@@ -385,7 +391,7 @@ async function topUpFpcFeeJuice(
   topupWei: bigint,
 ): Promise<bigint> {
   const contracts = await resolveFeeJuiceBridgeContracts(node, fpcAddress);
-  const { accountAddress, walletClient, publicClient } = createL1Clients(config);
+  const { accountAddress, walletClient, publicClient } = await createL1Clients(config);
   const bridgeAmount = await resolveBridgeAmount(
     publicClient,
     contracts.feeJuiceTokenAddress,

--- a/services/topup/package.json
+++ b/services/topup/package.json
@@ -25,7 +25,7 @@
     "@aztec/wallets": "4.1.0-nightly.20260312.2",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
-    "viem": "^2.18.0",
+    "viem": "npm:@aztec/viem@2.38.2",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"
   },

--- a/services/topup/src/bridge.ts
+++ b/services/topup/src/bridge.ts
@@ -9,17 +9,9 @@ const pinoLogger = pino();
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import { L1FeeJuicePortalManager, type L2AmountClaim } from "@aztec/aztec.js/ethereum";
 import type { AztecNode } from "@aztec/aztec.js/node";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import { createLogger, type Logger } from "@aztec/foundation/log";
-import {
-  type Chain,
-  createWalletClient,
-  defineChain,
-  fallback,
-  type Hex,
-  http,
-  publicActions,
-} from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { type Chain, extractChain, type Hex } from "viem";
 import * as viemChains from "viem/chains";
 
 export interface BridgeResult {
@@ -63,68 +55,18 @@ function isNonceConflictError(error: unknown): boolean {
 }
 
 export interface BridgeDeps {
-  createWalletClient: typeof createWalletClient;
-  defineChain: typeof defineChain;
-  http: typeof http;
-  privateKeyToAccount: typeof privateKeyToAccount;
+  createExtendedL1Client: typeof createExtendedL1Client;
   createPortalManager: CreatePortalManager;
   createLogger: () => Logger;
-  knownChains: Chain[];
+  chains: readonly Chain[];
 }
 
 const DEFAULT_BRIDGE_DEPS: BridgeDeps = {
-  createWalletClient,
-  defineChain,
-  http,
-  privateKeyToAccount,
+  createExtendedL1Client,
   createPortalManager,
   createLogger: makeBridgeLogger,
-  knownChains: Object.values(viemChains).filter(isChain),
+  chains: Object.values(viemChains),
 };
-
-function isChain(value: unknown): value is Chain {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const candidate = value as {
-    id?: unknown;
-    name?: unknown;
-    nativeCurrency?: unknown;
-    rpcUrls?: unknown;
-  };
-
-  return (
-    typeof candidate.id === "number" &&
-    typeof candidate.name === "string" &&
-    typeof candidate.nativeCurrency === "object" &&
-    typeof candidate.rpcUrls === "object"
-  );
-}
-
-function resolveL1Chain(chainId: number, rpcUrl: string, deps: BridgeDeps): Chain {
-  const known = deps.knownChains.find((chain) => chain.id === chainId);
-  if (known) {
-    return {
-      ...known,
-      rpcUrls: {
-        ...known.rpcUrls,
-        default: { http: [rpcUrl] },
-        public: { http: [rpcUrl] },
-      },
-    };
-  }
-
-  return deps.defineChain({
-    id: chainId,
-    name: `L1 Chain ${chainId}`,
-    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-    rpcUrls: {
-      default: { http: [rpcUrl] },
-      public: { http: [rpcUrl] },
-    },
-  });
-}
 
 /**
  * Bridge `amount` wei of Fee Juice from L1 to the FPC's L2 address.
@@ -146,20 +88,18 @@ export async function bridgeFeeJuice(
   }
 
   const deps: BridgeDeps = { ...DEFAULT_BRIDGE_DEPS, ...depsOverride };
-  const chain = resolveL1Chain(l1ChainId, l1RpcUrl, deps);
-  const account = deps.privateKeyToAccount(privateKey as Hex);
+  const chain = extractChain({ chains: deps.chains as readonly Chain[], id: l1ChainId });
   const logger = deps.createLogger();
   let lastError: unknown;
   let claim: L2AmountClaim | undefined;
 
   for (let attempt = 1; attempt <= MAX_NONCE_RETRY_ATTEMPTS; attempt += 1) {
     try {
-      const walletClient = deps.createWalletClient({
-        account,
+      const extendedClient = deps.createExtendedL1Client(
+        [l1RpcUrl],
+        privateKey as Hex,
         chain,
-        transport: fallback([deps.http(l1RpcUrl)]),
-      });
-      const extendedClient = walletClient.extend(publicActions) as ExtendedWalletClient;
+      ) as ExtendedWalletClient;
       const portalManager = await deps.createPortalManager(node, extendedClient, logger);
       claim = await portalManager.bridgeTokensPublic(fpcL2Address, amount);
       break;

--- a/services/topup/src/fund-claimer-l2.ts
+++ b/services/topup/src/fund-claimer-l2.ts
@@ -15,12 +15,11 @@ import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { FeeJuiceContract } from "@aztec/aztec.js/protocol";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import { createLogger } from "@aztec/foundation/log";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
-import type { Chain, Hex } from "viem";
-import { createPublicClient, createWalletClient, defineChain, http, publicActions } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { type Chain, createPublicClient, extractChain, http } from "viem";
 import * as viemChains from "viem/chains";
 
 const LOG_PREFIX = "[fund-claimer-l2]";
@@ -307,49 +306,6 @@ function deriveAddressFromSecret(secretKey: string): Promise<AztecAddress> {
   return getSchnorrAccountContractAddress(secret, Fr.ZERO);
 }
 
-function isChain(value: unknown): value is Chain {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as {
-    id?: unknown;
-    name?: unknown;
-    nativeCurrency?: unknown;
-    rpcUrls?: unknown;
-  };
-  return (
-    typeof candidate.id === "number" &&
-    typeof candidate.name === "string" &&
-    typeof candidate.nativeCurrency === "object" &&
-    typeof candidate.rpcUrls === "object"
-  );
-}
-
-function resolveL1Chain(chainId: number, l1RpcUrl: string): Chain {
-  const known = Object.values(viemChains)
-    .filter(isChain)
-    .find((chain) => chain.id === chainId);
-  if (known) {
-    return {
-      ...known,
-      rpcUrls: {
-        ...known.rpcUrls,
-        default: { http: [l1RpcUrl] },
-        public: { http: [l1RpcUrl] },
-      },
-    };
-  }
-  return defineChain({
-    id: chainId,
-    name: `L1 Chain ${chainId}`,
-    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-    rpcUrls: {
-      default: { http: [l1RpcUrl] },
-      public: { http: [l1RpcUrl] },
-    },
-  });
-}
-
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -488,13 +444,11 @@ async function assertL1ChainIdMatchesRpc(l1RpcUrl: string, l1ChainId: number): P
 }
 
 function createL1WalletClient(l1RpcUrl: string, l1ChainId: number, l1PrivateKey: string) {
-  const l1Chain = resolveL1Chain(l1ChainId, l1RpcUrl);
-  const l1Account = privateKeyToAccount(l1PrivateKey as Hex);
-  return createWalletClient({
-    account: l1Account,
-    chain: l1Chain,
-    transport: http(l1RpcUrl),
-  }).extend(publicActions);
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: l1ChainId,
+  });
+  return createExtendedL1Client([l1RpcUrl], l1PrivateKey, l1Chain);
 }
 
 async function setupBridgePortal(

--- a/services/topup/test/bridge.test.ts
+++ b/services/topup/test/bridge.test.ts
@@ -3,9 +3,9 @@ import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import type { AztecNode } from "@aztec/aztec.js/node";
+import type { createExtendedL1Client } from "@aztec/ethereum/client";
 import { createLogger } from "@aztec/foundation/log";
-import type { Chain, createWalletClient, defineChain, http } from "viem";
-import type { privateKeyToAccount } from "viem/accounts";
+import type { Chain } from "viem";
 import type { BridgeDeps } from "../src/bridge.js";
 import { bridgeFeeJuice } from "../src/bridge.js";
 
@@ -21,16 +21,7 @@ function makeNode(): AztecNode {
 
 function makeDeps(overrides: Partial<BridgeDeps> = {}): BridgeDeps {
   return {
-    createWalletClient: (() =>
-      ({
-        extend: () => ({}),
-      }) as never) as typeof createWalletClient,
-    defineChain: ((chain) => chain) as typeof defineChain,
-    http: ((_url) => ({}) as never) as typeof http,
-    privateKeyToAccount: (() =>
-      ({
-        address: `0x${"11".repeat(20)}`,
-      }) as never) as typeof privateKeyToAccount,
+    createExtendedL1Client: (() => ({})) as never as typeof createExtendedL1Client,
     createPortalManager: async () =>
       ({
         bridgeTokensPublic: (_to: AztecAddress, amount: bigint) =>
@@ -43,7 +34,7 @@ function makeDeps(overrides: Partial<BridgeDeps> = {}): BridgeDeps {
           }),
       }) as never,
     createLogger: () => createLogger("topup:test"),
-    knownChains: [
+    chains: [
       {
         id: 31337,
         name: "Anvil",
@@ -65,11 +56,9 @@ describe("bridge", () => {
     let capturedAmount: bigint | undefined;
 
     const deps = makeDeps({
-      createWalletClient: ((args: { chain: { id: number } }) => {
-        capturedChainId = args.chain.id;
-        return {
-          extend: () => ({}),
-        };
+      createExtendedL1Client: ((_rpcUrls: string[], _account: unknown, chain?: { id: number }) => {
+        capturedChainId = chain?.id;
+        return {};
       }) as never,
       createPortalManager: async () =>
         ({


### PR DESCRIPTION
## Summary
- Replace all `createWalletClient` from viem with `createExtendedL1Client` from `@aztec/ethereum/client`
- Pass private keys directly instead of calling `privateKeyToAccount` first
- Resolve L1 chain via `extractChain` from viem at every call site (from node info, L1 RPC query, or manifest)
- Remove `resolveL1Chain` wrappers — call `extractChain` inline
- Stop overriding rpc urls on resolved chains — use viem chain definitions as-is
- Remove `isChain` type guards, `defineChain` fallbacks, and `privateKeyToAccount` from dependency injection interfaces
- Update bridge test mocks to match simplified `BridgeDeps` interface