### PR TITLE
refactor: remove secret key material from manifest, flatten deployer_address

### DIFF
--- a/contract-deployment/src/devnet-manifest.ts
+++ b/contract-deployment/src/devnet-manifest.ts
@@ -9,8 +9,6 @@ const TX_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/;
 const ZERO_TX_HASH_PATTERN = /^0x0{64}$/i;
 const DECIMAL_UINT_PATTERN = /^(0|[1-9][0-9]*)$/;
 const HEX_FIELD_PATTERN = /^0x[0-9a-fA-F]+$/;
-const HEX_32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
-
 export type FpcArtifactName = "FPC" | "FPCMultiAsset";
 
 export type DevnetDeployManifest = {
@@ -40,19 +38,7 @@ export type DevnetDeployManifest = {
     };
     sponsored_fpc_address?: string;
   };
-  deployment_accounts: {
-    l2_deployer: {
-      alias: string;
-      address: string;
-      private_key?: string;
-      private_key_ref?: string;
-    };
-    l1_topup_operator?: {
-      address: string;
-      private_key?: string;
-      private_key_ref?: string;
-    };
-  };
+  deployer_address: string;
   contracts: {
     accepted_asset: string;
     fpc: string;
@@ -212,28 +198,6 @@ function parseTxHashOrNull(value: unknown, fieldPath: string): string | null {
   return value;
 }
 
-function parseKeyMaterial(
-  root: Record<string, unknown>,
-  context: string,
-): { privateKey?: string; privateKeyRef?: string } {
-  const privateKey = optionalString(root, "private_key", context);
-  const privateKeyRef = optionalString(root, "private_key_ref", context);
-
-  if (!privateKey && !privateKeyRef) {
-    throw new ManifestValidationError(
-      `Invalid ${context}: must include private_key or private_key_ref`,
-    );
-  }
-
-  if (privateKey && !HEX_32_PATTERN.test(privateKey)) {
-    throw new ManifestValidationError(
-      `Invalid ${context}.private_key: expected 32-byte 0x-prefixed hex`,
-    );
-  }
-
-  return { privateKey, privateKeyRef };
-}
-
 function hasOwn(root: Record<string, unknown>, key: string): boolean {
   return Object.hasOwn(root, key);
 }
@@ -368,48 +332,10 @@ function parseManifest(input: unknown): DevnetDeployManifest {
     ),
   };
 
-  const deploymentAccountsRaw = requireObject(input, "deployment_accounts", "manifest");
-  const l2DeployerRaw = requireObject(
-    deploymentAccountsRaw,
-    "l2_deployer",
-    "manifest.deployment_accounts",
+  const deployerAddress = parseAztecAddress(
+    requireString(input, "deployer_address", "manifest"),
+    "manifest.deployer_address",
   );
-  const l2DeployerKeyMaterial = parseKeyMaterial(
-    l2DeployerRaw,
-    "manifest.deployment_accounts.l2_deployer",
-  );
-  const l2Deployer: DevnetDeployManifest["deployment_accounts"]["l2_deployer"] = {
-    alias: requireString(l2DeployerRaw, "alias", "manifest.deployment_accounts.l2_deployer"),
-    address: parseAztecAddress(
-      requireString(l2DeployerRaw, "address", "manifest.deployment_accounts.l2_deployer"),
-      "manifest.deployment_accounts.l2_deployer.address",
-    ),
-    ...(l2DeployerKeyMaterial.privateKey ? { private_key: l2DeployerKeyMaterial.privateKey } : {}),
-    ...(l2DeployerKeyMaterial.privateKeyRef
-      ? { private_key_ref: l2DeployerKeyMaterial.privateKeyRef }
-      : {}),
-  };
-
-  let l1TopupOperator: DevnetDeployManifest["deployment_accounts"]["l1_topup_operator"];
-  if (hasOwn(deploymentAccountsRaw, "l1_topup_operator")) {
-    const l1TopupRaw = requireObject(
-      deploymentAccountsRaw,
-      "l1_topup_operator",
-      "manifest.deployment_accounts",
-    );
-    const l1KeyMaterial = parseKeyMaterial(
-      l1TopupRaw,
-      "manifest.deployment_accounts.l1_topup_operator",
-    );
-    l1TopupOperator = {
-      address: parseEthAddress(
-        requireString(l1TopupRaw, "address", "manifest.deployment_accounts.l1_topup_operator"),
-        "manifest.deployment_accounts.l1_topup_operator.address",
-      ),
-      ...(l1KeyMaterial.privateKey ? { private_key: l1KeyMaterial.privateKey } : {}),
-      ...(l1KeyMaterial.privateKeyRef ? { private_key_ref: l1KeyMaterial.privateKeyRef } : {}),
-    };
-  }
 
   const contractsRaw = requireObject(input, "contracts", "manifest");
   const faucetAddressRaw = hasOwn(contractsRaw, "faucet")
@@ -578,10 +504,7 @@ function parseManifest(input: unknown): DevnetDeployManifest {
           }
         : {}),
     },
-    deployment_accounts: {
-      l2_deployer: l2Deployer,
-      ...(l1TopupOperator ? { l1_topup_operator: l1TopupOperator } : {}),
-    },
+    deployer_address: deployerAddress,
     contracts,
     ...(l1Contracts ? { l1_contracts: l1Contracts } : {}),
     ...(fpcArtifact ? { fpc_artifact: fpcArtifact } : {}),

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -1295,15 +1295,7 @@ async function main(): Promise<void> {
       },
       ...(args.sponsoredFpcAddress ? { sponsored_fpc_address: args.sponsoredFpcAddress } : {}),
     },
-    deployment_accounts: {
-      l2_deployer: {
-        alias: "deployer",
-        address: deployerAddress.toString(),
-        ...(args.deployerSecretKey
-          ? { private_key: args.deployerSecretKey }
-          : { private_key_ref: args.deployerSecretKeyRef }),
-      },
-    },
+    deployer_address: deployerAddress.toString(),
     contracts: {
       accepted_asset: acceptedAssetAddress,
       fpc: fpcAddress,

--- a/deployments/devnet-manifest-v2.json
+++ b/deployments/devnet-manifest-v2.json
@@ -25,13 +25,7 @@
     },
     "sponsored_fpc_address": "0x09a4df73aa47f82531a038d1d51abfc85b27665c4b7ca751e2d4fa9f19caffb2"
   },
-  "deployment_accounts": {
-    "l2_deployer": {
-      "alias": "my-wallet",
-      "address": "0x18a15b90bea06cea7cbd06b3940533952aa9e5f94c157000c727321644d07af8",
-      "private_key": "0x1111111111111111111111111111111111111111111111111111111111111111"
-    }
-  },
+  "deployer_address": "0x18a15b90bea06cea7cbd06b3940533952aa9e5f94c157000c727321644d07af8",
   "contracts": {
     "accepted_asset": "0x10600e2f256b6500de5a79367d70b4c7d8121c408a2127dbcba995a1abc0d6f8",
     "fpc": "0x24a735808258519dc1637f1833202ea2dc7c829a0a82c73f61bbd195fce4105b",

--- a/deployments/testnet/manifest.json
+++ b/deployments/testnet/manifest.json
@@ -24,13 +24,7 @@
       "feeJuice": "0x0000000000000000000000000000000000000000000000000000000000000005"
     }
   },
-  "deployment_accounts": {
-    "l2_deployer": {
-      "alias": "deployer",
-      "address": "0x233a3b27b7a07a3d6c59b7dbe0610191e865740c4ba8749ed43bdf5b85c4aa3e",
-      "private_key": "0x228073e435bcbd64d97f6040e6762ec96906fd0bd3494935df55a3340d9afbfc"
-    }
-  },
+  "deployer_address": "0x233a3b27b7a07a3d6c59b7dbe0610191e865740c4ba8749ed43bdf5b85c4aa3e",
   "contracts": {
     "accepted_asset": "0x1b6a3479389c0890b5b5c12fb8c2c5e415d02b7be653d37a2296c64b6f3a31bf",
     "fpc": "0x244fd9caaea2e4ca4800e3877a3cf984b5c15dbeef0b3dd3aa25ae51a7c44f76",

--- a/scripts/contract/devnet-manifest.ts
+++ b/scripts/contract/devnet-manifest.ts
@@ -36,13 +36,7 @@ function buildSelfCheckFixture() {
       },
       sponsored_fpc_address: "0x09a4df73aa47f82531a038d1d51abfc85b27665c4b7ca751e2d4fa9f19caffb2",
     },
-    deployment_accounts: {
-      l2_deployer: {
-        alias: "my-wallet",
-        address: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        private_key_ref: "secret-manager://devnet/l2-deployer",
-      },
-    },
+    deployer_address: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     contracts: {
       accepted_asset: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       fpc: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -90,15 +84,6 @@ function runSelfCheck(): void {
     const broken = buildSelfCheckFixture() as unknown as Record<string, unknown>;
     const contracts = broken.contracts as Record<string, unknown>;
     delete contracts.fpc;
-    validateDevnetDeployManifest(broken);
-  });
-
-  expectThrow("l2_deployer missing private_key/private_key_ref", () => {
-    const broken = buildSelfCheckFixture() as unknown as Record<string, unknown>;
-    const deploymentAccounts = broken.deployment_accounts as Record<string, unknown>;
-    const l2Deployer = deploymentAccounts.l2_deployer as Record<string, unknown>;
-    delete l2Deployer.private_key;
-    delete l2Deployer.private_key_ref;
     validateDevnetDeployManifest(broken);
   });
 

--- a/scripts/contract/devnet-postdeploy-smoke.ts
+++ b/scripts/contract/devnet-postdeploy-smoke.ts
@@ -667,42 +667,15 @@ function fieldStringToBigInt(value: string, fieldName: string): bigint {
   throw new CliError(`Invalid ${fieldName}: expected decimal or 0x-prefixed field value`);
 }
 
-function resolveOperatorSecretKey(args: CliArgs, manifest: DevnetDeployManifest): string {
+function resolveOperatorSecretKey(args: CliArgs): string {
   if (args.operatorSecretKey) {
     return args.operatorSecretKey;
   }
-  const operatorMatchesDeployer =
-    manifest.operator.address.toLowerCase() ===
-    manifest.deployment_accounts.l2_deployer.address.toLowerCase();
-  if (!operatorMatchesDeployer) {
-    throw new CliError(
-      "Missing operator key. Provide --operator-secret-key because manifest.operator.address differs from manifest.deployment_accounts.l2_deployer.address.",
-    );
-  }
-  if (manifest.deployment_accounts.l2_deployer.private_key) {
-    return manifest.deployment_accounts.l2_deployer.private_key;
-  }
-  if (manifest.deployment_accounts.l2_deployer.private_key_ref) {
-    throw new CliError(
-      "Manifest has only deployment_accounts.l2_deployer.private_key_ref. Provide --operator-secret-key explicitly.",
-    );
-  }
-  throw new CliError("Missing operator key in both CLI/env and manifest.");
+  throw new CliError("Missing operator key. Provide --operator-secret-key.");
 }
 
-function resolveL1OperatorPrivateKey(args: CliArgs, manifest: DevnetDeployManifest): string {
-  if (args.l1OperatorPrivateKey) {
-    return args.l1OperatorPrivateKey;
-  }
-  if (manifest.deployment_accounts.l1_topup_operator?.private_key) {
-    return manifest.deployment_accounts.l1_topup_operator.private_key;
-  }
-  if (manifest.deployment_accounts.l1_topup_operator?.private_key_ref) {
-    throw new CliError(
-      "Manifest has only deployment_accounts.l1_topup_operator.private_key_ref. Provide --l1-operator-private-key explicitly.",
-    );
-  }
-  return DEFAULT_LOCAL_L1_PRIVATE_KEY;
+function resolveL1OperatorPrivateKey(args: CliArgs): string {
+  return args.l1OperatorPrivateKey ?? DEFAULT_LOCAL_L1_PRIVATE_KEY;
 }
 
 function ceilDiv(numerator: bigint, denominator: bigint): bigint {
@@ -894,8 +867,8 @@ async function runSmoke(args: CliArgs): Promise<void> {
   const manifest = parseManifestFromDisk(args.manifestPath);
   const fpcSelection = resolveFpcArtifactSelection(manifest, args);
 
-  const operatorSecretKeyHex = resolveOperatorSecretKey(args, manifest);
-  const l1OperatorPrivateKeyHex = resolveL1OperatorPrivateKey(args, manifest);
+  const operatorSecretKeyHex = resolveOperatorSecretKey(args);
+  const l1OperatorPrivateKeyHex = resolveL1OperatorPrivateKey(args);
   const operatorSecret = deps.Fr.fromHexString(operatorSecretKeyHex);
   const operatorSigningKey = deps.deriveSigningKey(operatorSecret);
 

--- a/scripts/manual-fpc-sponsored-user-tx-devnet.ts
+++ b/scripts/manual-fpc-sponsored-user-tx-devnet.ts
@@ -61,11 +61,6 @@ type Manifest = {
   operator?: {
     address?: string;
   };
-  deployment_accounts?: {
-    l2_deployer?: {
-      private_key?: string;
-    };
-  };
 };
 
 const HEX_32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
@@ -100,7 +95,7 @@ function usage(): string {
     "  --manifest ./deployments/devnet-manifest-v2.json",
     "  --node-url from AZTEC_NODE_URL or manifest.network.node_url",
     "  --quote-base-url http://localhost:3000",
-    "  --operator-secret-key from FPC_OPERATOR_SECRET_KEY | OPERATOR_SECRET_KEY | manifest.deployment_accounts.l2_deployer.private_key",
+    "  --operator-secret-key from FPC_OPERATOR_SECRET_KEY | OPERATOR_SECRET_KEY",
     "  --user-secret-key from FPC_DEVNET_USER_SECRET_KEY | USER_SECRET_KEY | L2_PRIVATE_KEY | operator-secret-key",
     `  --operator-salt ${ZERO_SALT_HEX}`,
     `  --user-salt ${ZERO_SALT_HEX}`,
@@ -320,9 +315,6 @@ function readConfig(argv: string[]): Config {
     );
   }
 
-  if (!operatorSecretKeyRaw) {
-    operatorSecretKeyRaw = manifestRaw.deployment_accounts?.l2_deployer?.private_key ?? null;
-  }
   if (!operatorSecretKeyRaw) {
     throw new Error(
       "Missing operator secret key. Set FPC_OPERATOR_SECRET_KEY or OPERATOR_SECRET_KEY.",

--- a/scripts/services/bootstrap-topup-autoclaim-account.ts
+++ b/scripts/services/bootstrap-topup-autoclaim-account.ts
@@ -40,12 +40,6 @@ type PartialManifest = {
   network?: {
     node_url?: string;
   };
-  deployment_accounts?: {
-    l2_deployer?: {
-      private_key?: string;
-      address?: string;
-    };
-  };
   aztec_required_addresses?: {
     sponsored_fpc_address?: string;
   };
@@ -73,7 +67,7 @@ function usage(): string {
     "Defaults / fallbacks:",
     `  --manifest ${DEFAULT_MANIFEST_PATH}`,
     "  --node-url from AZTEC_NODE_URL or manifest.network.node_url",
-    "  --secret-key from TOPUP_AUTOCLAIM_SECRET_KEY or (if enabled) OPERATOR_SECRET_KEY or manifest.deployment_accounts.l2_deployer.private_key",
+    "  --secret-key from TOPUP_AUTOCLAIM_SECRET_KEY or (if enabled) OPERATOR_SECRET_KEY",
     "  --use-operator-secret-key from TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY (default false)",
     "  --sponsored-fpc-address from TOPUP_AUTOCLAIM_SPONSORED_FPC_ADDRESS / FPC_DEVNET_SPONSORED_FPC_ADDRESS / SPONSORED_FPC_ADDRESS / manifest.aztec_required_addresses.sponsored_fpc_address",
     "  --payment-mode from TOPUP_AUTOCLAIM_BOOTSTRAP_PAYMENT_MODE (default auto)",
@@ -278,17 +272,10 @@ function pickOptional<T>(...values: (T | null | undefined)[]): T | null {
   return null;
 }
 
-function resolveSecretKey(
-  args: CliArgs,
-  manifest: PartialManifest,
-): { secretKey: string; source: string } {
+function resolveSecretKey(args: CliArgs): { secretKey: string; source: string } {
   const operatorSecretKey = parseOptionalSecretKey(
     "OPERATOR_SECRET_KEY",
     parseOptionalEnv("OPERATOR_SECRET_KEY"),
-  );
-  const manifestSecretKey = parseOptionalSecretKey(
-    "manifest.deployment_accounts.l2_deployer.private_key",
-    manifest.deployment_accounts?.l2_deployer?.private_key ?? null,
   );
   const useOperatorSecretKey = args.useOperatorSecretKey ?? false;
 
@@ -301,14 +288,8 @@ function resolveSecretKey(
   if (useOperatorSecretKey && operatorSecretKey) {
     return { secretKey: operatorSecretKey, source: "OPERATOR_SECRET_KEY" };
   }
-  if (manifestSecretKey) {
-    return {
-      secretKey: manifestSecretKey,
-      source: "manifest.deployment_accounts.l2_deployer.private_key",
-    };
-  }
   throw new CliError(
-    "Could not resolve claimer secret key. Set TOPUP_AUTOCLAIM_SECRET_KEY (or pass --secret-key), or enable TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY=1 with OPERATOR_SECRET_KEY set, or include deployment_accounts.l2_deployer.private_key in manifest.",
+    "Could not resolve claimer secret key. Set TOPUP_AUTOCLAIM_SECRET_KEY (or pass --secret-key), or enable TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY=1 with OPERATOR_SECRET_KEY set.",
   );
 }
 
@@ -637,7 +618,7 @@ async function main(): Promise<void> {
     );
   }
   const nodeUrl = parseHttpUrl("node URL", nodeUrlRaw);
-  const resolvedSecretKey = resolveSecretKey(args, manifest);
+  const resolvedSecretKey = resolveSecretKey(args);
   const sponsoredFpcAddress = resolveSponsoredFpcAddress(args, manifest);
   const paymentMode = resolvePaymentMode(args, sponsoredFpcAddress);
   const claimerAddress = await deriveAddress(resolvedSecretKey.secretKey);

--- a/scripts/services/compose-mode.sh
+++ b/scripts/services/compose-mode.sh
@@ -68,19 +68,11 @@ services-devnet)
 
     export TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY="${TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY:-1}"
 
-    if [[ -f "$manifest_path" ]]; then
-      if [[ -n "${TOPUP_AUTOCLAIM_SECRET_KEY:-}" ]]; then
-        echo "[compose-mode] using caller-provided TOPUP_AUTOCLAIM_SECRET_KEY (manifest deployment_accounts.l2_deployer.private_key ignored)"
-      elif [[ "${TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY}" == "1" && -n "${OPERATOR_SECRET_KEY:-}" ]]; then
-        export TOPUP_AUTOCLAIM_SECRET_KEY="$OPERATOR_SECRET_KEY"
-        echo "[compose-mode] using TOPUP_AUTOCLAIM_SECRET_KEY from OPERATOR_SECRET_KEY (.env)"
-      else
-        l2_deployer_private_key="$(jq -r '.deployment_accounts.l2_deployer.private_key // empty' "$manifest_path")"
-        if [[ -n "$l2_deployer_private_key" ]]; then
-          echo "[compose-mode] using TOPUP_AUTOCLAIM_SECRET_KEY from deployment_accounts.l2_deployer.private_key (from $manifest_path)"
-          export TOPUP_AUTOCLAIM_SECRET_KEY="$l2_deployer_private_key"
-        fi
-      fi
+    if [[ -n "${TOPUP_AUTOCLAIM_SECRET_KEY:-}" ]]; then
+      echo "[compose-mode] using caller-provided TOPUP_AUTOCLAIM_SECRET_KEY"
+    elif [[ "${TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY}" == "1" && -n "${OPERATOR_SECRET_KEY:-}" ]]; then
+      export TOPUP_AUTOCLAIM_SECRET_KEY="$OPERATOR_SECRET_KEY"
+      echo "[compose-mode] using TOPUP_AUTOCLAIM_SECRET_KEY from OPERATOR_SECRET_KEY (.env)"
     fi
 
     if [[ "${TOPUP_AUTOCLAIM_ENABLED:-1}" != "0" && "${TOPUP_AUTOCLAIM_BOOTSTRAP_ACCOUNT:-0}" == "1" ]]; then

--- a/scripts/services/fpc-full-lifecycle-e2e.ts
+++ b/scripts/services/fpc-full-lifecycle-e2e.ts
@@ -7,7 +7,7 @@ const pinoLogger = pino();
 
 import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
-import type { Contract } from "@aztec/aztec.js/contracts";
+import { Contract } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
@@ -987,24 +987,29 @@ async function deployContractsAndWriteRuntimeConfig(
   const operatorSecretHex = operatorData.secret.toString();
   assertPrivateKeyHex(operatorSecretHex, "operator secret");
 
-  const token = await deployContract(
+  const tokenDeploy = Contract.deploy(
     wallet,
     tokenArtifact,
     ["SmokeToken", "SMK", 18, operator, operator],
-    { from: operator },
     "constructor_with_minter",
   );
+  const tokenAddress = (await tokenDeploy.getInstance()).address;
+  await deployContract(wallet, tokenArtifact, tokenDeploy, { from: operator });
+  const token = Contract.at(tokenAddress, tokenArtifact, wallet);
 
   const schnorr = new Schnorr();
   const operatorSigningKey = operatorData.signingKey ?? deriveSigningKey(operatorData.secret);
   const operatorPubKey = await schnorr.computePublicKey(operatorSigningKey);
 
-  const fpc = await deployContract(
-    wallet,
-    fpcArtifact,
-    [operator, operatorPubKey.x, operatorPubKey.y, token.address],
-    { from: operator },
-  );
+  const fpcDeploy = Contract.deploy(wallet, fpcArtifact, [
+    operator,
+    operatorPubKey.x,
+    operatorPubKey.y,
+    tokenAddress,
+  ]);
+  const fpcAddress = (await fpcDeploy.getInstance()).address;
+  await deployContract(wallet, fpcArtifact, fpcDeploy, { from: operator });
+  const fpc = Contract.at(fpcAddress, fpcArtifact, wallet);
 
   const minFees = await node.getCurrentMinFees();
   const feePerDaGas = minFees.feePerDaGas;
@@ -1458,24 +1463,31 @@ async function negativeInsufficientFeeJuiceSecondTxRejected(
   const tokenArtifact = loadArtifact(tokenArtifactPath);
   const fpcArtifact = loadArtifact(fpcArtifactPath);
 
-  const isolatedToken = await deployContract(
+  const isolatedTokenDeploy = Contract.deploy(
     result.wallet,
     tokenArtifact,
     ["InsufficientToken", "INS", 18, result.operator, result.operator],
-    { from: result.operator },
     "constructor_with_minter",
   );
+  const isolatedTokenAddress = (await isolatedTokenDeploy.getInstance()).address;
+  await deployContract(result.wallet, tokenArtifact, isolatedTokenDeploy, {
+    from: result.operator,
+  });
+  const isolatedToken = Contract.at(isolatedTokenAddress, tokenArtifact, result.wallet);
 
   const secret = Fr.fromHexString(result.operatorSecretHex);
   const signingKey = deriveSigningKey(secret);
   const schnorr = new Schnorr();
   const operatorPubKey = await schnorr.computePublicKey(signingKey);
-  const isolatedFpc = await deployContract(
-    result.wallet,
-    fpcArtifact,
-    [result.operator, operatorPubKey.x, operatorPubKey.y, isolatedToken.address],
-    { from: result.operator },
-  );
+  const isolatedFpcDeploy = Contract.deploy(result.wallet, fpcArtifact, [
+    result.operator,
+    operatorPubKey.x,
+    operatorPubKey.y,
+    isolatedTokenAddress,
+  ]);
+  const isolatedFpcAddress = (await isolatedFpcDeploy.getInstance()).address;
+  await deployContract(result.wallet, fpcArtifact, isolatedFpcDeploy, { from: result.operator });
+  const isolatedFpc = Contract.at(isolatedFpcAddress, fpcArtifact, result.wallet);
 
   const isolatedCasesRoot = path.join(result.runDir, "insufficient");
   mkdirSync(isolatedCasesRoot, { recursive: true });

--- a/scripts/services/fpc-services-smoke.ts
+++ b/scripts/services/fpc-services-smoke.ts
@@ -9,7 +9,7 @@ const pinoLogger = pino();
 import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
-import type { Contract } from "@aztec/aztec.js/contracts";
+import { Contract } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
@@ -1081,13 +1081,15 @@ async function main() {
     pinoLogger.info(`[services-smoke] operator=${operator.toString()}`);
     pinoLogger.info(`[services-smoke] user=${user.toString()}`);
 
-    const token = await deployContract(
+    const tokenDeploy = Contract.deploy(
       wallet,
       tokenArtifact,
       ["SmokeToken", "SMK", 18, operator, operator],
-      { from: operator },
       "constructor_with_minter",
     );
+    const tokenAddress = (await tokenDeploy.getInstance()).address;
+    await deployContract(wallet, tokenArtifact, tokenDeploy, { from: operator });
+    const token = Contract.at(tokenAddress, tokenArtifact, wallet);
     pinoLogger.info(`[services-smoke] token=${token.address.toString()}`);
 
     // Derive operator signing pubkey for inline Schnorr verification.
@@ -1095,12 +1097,15 @@ async function main() {
     const operatorSigningKey = deriveSigningKey(testAccounts[0].secret);
     const operatorPubKey = await schnorr.computePublicKey(operatorSigningKey);
 
-    const fpc = await deployContract(
-      wallet,
-      fpcArtifact,
-      [operator, operatorPubKey.x, operatorPubKey.y, token.address],
-      { from: operator },
-    );
+    const fpcDeploy = Contract.deploy(wallet, fpcArtifact, [
+      operator,
+      operatorPubKey.x,
+      operatorPubKey.y,
+      token.address,
+    ]);
+    const fpcAddress = (await fpcDeploy.getInstance()).address;
+    await deployContract(wallet, fpcArtifact, fpcDeploy, { from: operator });
+    const fpc = Contract.at(fpcAddress, fpcArtifact, wallet);
     pinoLogger.info(`[services-smoke] fpc=${fpc.address.toString()}`);
 
     pinoLogger.info(

--- a/scripts/services/preflight-topup-autoclaim.ts
+++ b/scripts/services/preflight-topup-autoclaim.ts
@@ -32,12 +32,6 @@ type PartialManifest = {
   network?: {
     node_url?: string;
   };
-  deployment_accounts?: {
-    l2_deployer?: {
-      private_key?: string;
-      address?: string;
-    };
-  };
 };
 
 function usage(): string {
@@ -55,7 +49,7 @@ function usage(): string {
     "Defaults / fallbacks:",
     `  --manifest ${DEFAULT_MANIFEST_PATH}`,
     "  --node-url from AZTEC_NODE_URL or manifest.network.node_url",
-    "  --secret-key from TOPUP_AUTOCLAIM_SECRET_KEY or (if enabled) OPERATOR_SECRET_KEY or manifest.deployment_accounts.l2_deployer.private_key",
+    "  --secret-key from TOPUP_AUTOCLAIM_SECRET_KEY or (if enabled) OPERATOR_SECRET_KEY",
     "  --use-operator-secret-key from TOPUP_AUTOCLAIM_USE_OPERATOR_SECRET_KEY (default false)",
     `  --test-account-index from TOPUP_AUTOCLAIM_TEST_ACCOUNT_INDEX (default ${DEFAULT_TEST_ACCOUNT_INDEX})`,
     "  --auto-claim-enabled from TOPUP_AUTOCLAIM_ENABLED (default true)",
@@ -213,20 +207,14 @@ async function resolveClaimer(params: {
   explicitSecretKey: string | null;
   useOperatorSecretKey: boolean;
   testAccountIndex: number;
-  manifest: PartialManifest;
 }): Promise<{
   address: AztecAddress;
   source: "secret_key" | "test_account";
   detail: string;
 }> {
   const operatorSecretKey = parseOptionalSecretKey(parseOptionalEnv("OPERATOR_SECRET_KEY"));
-  const manifestSecretKey = parseOptionalSecretKey(
-    params.manifest.deployment_accounts?.l2_deployer?.private_key ?? null,
-  );
   const chosenSecretKey =
-    params.explicitSecretKey ??
-    (params.useOperatorSecretKey ? operatorSecretKey : null) ??
-    manifestSecretKey;
+    params.explicitSecretKey ?? (params.useOperatorSecretKey ? operatorSecretKey : null);
 
   if (chosenSecretKey) {
     const secretFr = Fr.fromHexString(chosenSecretKey);
@@ -237,9 +225,7 @@ async function resolveClaimer(params: {
       detail:
         params.explicitSecretKey !== null
           ? "TOPUP_AUTOCLAIM_SECRET_KEY/--secret-key"
-          : params.useOperatorSecretKey && operatorSecretKey
-            ? "OPERATOR_SECRET_KEY (fallback enabled)"
-            : "manifest.deployment_accounts.l2_deployer.private_key",
+          : "OPERATOR_SECRET_KEY (fallback enabled)",
     };
   }
 
@@ -291,7 +277,6 @@ async function main(): Promise<void> {
     explicitSecretKey: args.secretKey,
     useOperatorSecretKey,
     testAccountIndex,
-    manifest,
   });
 
   pinoLogger.info(
@@ -309,16 +294,6 @@ async function main(): Promise<void> {
   pinoLogger.info(
     `${LOG_PREFIX} ok: claimer account is publicly deployed (${claimer.address.toString()})`,
   );
-
-  const manifestDeployerAddress = manifest.deployment_accounts?.l2_deployer?.address ?? null;
-  if (
-    manifestDeployerAddress &&
-    manifestDeployerAddress.toLowerCase() !== claimer.address.toString().toLowerCase()
-  ) {
-    pinoLogger.info(
-      `${LOG_PREFIX} note: claimer differs from manifest deployment_accounts.l2_deployer.address (${manifestDeployerAddress})`,
-    );
-  }
 }
 
 main().catch((error) => {

--- a/services/attestation/test/fee-entrypoint-local-smoke.ts
+++ b/services/attestation/test/fee-entrypoint-local-smoke.ts
@@ -7,6 +7,7 @@ const pinoLogger = pino();
 import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
+import { Contract } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
@@ -520,21 +521,25 @@ async function main() {
   const operatorSigningKey = deriveSigningKey(testAccounts[0].secret);
   const operatorPubKey = await schnorr.computePublicKey(operatorSigningKey);
 
-  const token = await deployContract(
+  const tokenDeploy = Contract.deploy(
     wallet,
     tokenArtifact,
     ["SmokeToken", "SMK", 18, operator, operator],
-    { from: operator },
     "constructor_with_minter",
   );
+  const tokenAddress = (await tokenDeploy.getInstance()).address;
+  await deployContract(wallet, tokenArtifact, tokenDeploy, { from: operator });
+  const token = Contract.at(tokenAddress, tokenArtifact, wallet);
   pinoLogger.info(`[smoke] token=${token.address.toString()}`);
 
-  const fpc = await deployContract(
-    wallet,
-    fpcArtifact,
-    [operator, operatorPubKey.x, operatorPubKey.y],
-    { from: operator },
-  );
+  const fpcDeploy = Contract.deploy(wallet, fpcArtifact, [
+    operator,
+    operatorPubKey.x,
+    operatorPubKey.y,
+  ]);
+  const fpcAddress = (await fpcDeploy.getInstance()).address;
+  await deployContract(wallet, fpcArtifact, fpcDeploy, { from: operator });
+  const fpc = Contract.at(fpcAddress, fpcArtifact, wallet);
   pinoLogger.info(`[smoke] fpc=${fpc.address.toString()}`);
 
   pinoLogger.info(`[smoke] fee_per_da_gas=${feePerDaGas}`);

--- a/services/topup/src/fund-claimer-l2.ts
+++ b/services/topup/src/fund-claimer-l2.ts
@@ -53,12 +53,6 @@ type PartialManifest = {
   network?: {
     node_url?: string;
   };
-  deployment_accounts?: {
-    l2_deployer?: {
-      private_key?: string;
-      address?: string;
-    };
-  };
 };
 
 type BridgeClaim = L2AmountClaim;
@@ -90,8 +84,8 @@ function usage(): string {
     "  --node-url from AZTEC_NODE_URL or manifest.network.node_url",
     "  --l1-rpc-url from L1_RPC_URL",
     "  --l1-private-key from L1_OPERATOR_PRIVATE_KEY",
-    "  --claimer-secret-key from TOPUP_AUTOCLAIM_SECRET_KEY, then OPERATOR_SECRET_KEY, then manifest.deployment_accounts.l2_deployer.private_key",
-    "  --claimer-address from --claimer-address or derived from claimer secret key or manifest.deployment_accounts.l2_deployer.address",
+    "  --claimer-secret-key from TOPUP_AUTOCLAIM_SECRET_KEY, then OPERATOR_SECRET_KEY",
+    "  --claimer-address from --claimer-address or derived from claimer secret key",
     "  --fee-payer-secret-key from TOPUP_AUTOCLAIM_FEE_PAYER_SECRET_KEY, else --claimer-secret-key",
     "",
     "Notes:",
@@ -340,23 +334,12 @@ function requireL1PrivateKey(args: CliArgs): string {
   return args.l1PrivateKey;
 }
 
-function resolveClaimerSecretKey(args: CliArgs, manifest: PartialManifest): string | null {
-  const manifestDeployerKey = parseOptionalHex32(
-    "manifest.deployment_accounts.l2_deployer.private_key",
-    manifest.deployment_accounts?.l2_deployer?.private_key ?? null,
-  );
+function resolveClaimerSecretKey(args: CliArgs): string | null {
   const fallbackOperatorKey = parseOptionalHex32(
     "OPERATOR_SECRET_KEY",
     parseOptionalEnv("OPERATOR_SECRET_KEY"),
   );
-  return args.claimerSecretKey ?? fallbackOperatorKey ?? manifestDeployerKey;
-}
-
-function resolveManifestDeployerAddress(manifest: PartialManifest): string | null {
-  return parseOptionalAztecAddress(
-    "manifest.deployment_accounts.l2_deployer.address",
-    manifest.deployment_accounts?.l2_deployer?.address ?? null,
-  );
+  return args.claimerSecretKey ?? fallbackOperatorKey;
 }
 
 function assertClaimerAddressMatchesDerived(
@@ -375,7 +358,6 @@ function assertClaimerAddressMatchesDerived(
 async function resolveClaimerAddress(
   args: CliArgs,
   claimerSecretKey: string | null,
-  manifestDeployerAddress: string | null,
 ): Promise<AztecAddress> {
   if (claimerSecretKey) {
     const derived = await deriveAddressFromSecret(claimerSecretKey);
@@ -387,11 +369,8 @@ async function resolveClaimerAddress(
   if (args.claimerAddress) {
     return AztecAddress.fromString(args.claimerAddress);
   }
-  if (manifestDeployerAddress) {
-    return AztecAddress.fromString(manifestDeployerAddress);
-  }
   throw new Error(
-    "Could not resolve claimer address. Provide --claimer-address or --claimer-secret-key, or include deployment_accounts.l2_deployer in manifest.",
+    "Could not resolve claimer address. Provide --claimer-address or --claimer-secret-key.",
   );
 }
 
@@ -658,13 +637,8 @@ async function main(): Promise<void> {
   const nodeUrl = resolveNodeUrl(args, manifest);
   const l1RpcUrl = requireL1RpcUrl(args);
   const l1PrivateKey = requireL1PrivateKey(args);
-  const claimerSecretKey = resolveClaimerSecretKey(args, manifest);
-  const manifestDeployerAddress = resolveManifestDeployerAddress(manifest);
-  const claimerAddress = await resolveClaimerAddress(
-    args,
-    claimerSecretKey,
-    manifestDeployerAddress,
-  );
+  const claimerSecretKey = resolveClaimerSecretKey(args);
+  const claimerAddress = await resolveClaimerAddress(args, claimerSecretKey);
   const feePayerSecretKey = resolveFeePayerSecretKey(args, claimerSecretKey);
   logRunConfig(args, nodeUrl, l1RpcUrl, claimerAddress);
 


### PR DESCRIPTION
## Summary
- Replace `deployment_accounts` (containing `private_key`/`private_key_ref`) with flat `deployer_address` field
- Remove `parseKeyMaterial`, `HEX_32_PATTERN`, and all key-parsing logic from manifest validator
- Remove `l1_topup_operator` block entirely
- Simplify `resolveOperatorSecretKey` and `resolveL1OperatorPrivateKey` in smoke test — no manifest fallback
- Remove manifest key fallbacks from fund-claimer-l2, bootstrap-topup-autoclaim, preflight-topup-autoclaim, manual-fpc-sponsored-user-tx-devnet
- Remove jq key extraction from compose-mode.sh
- Update JSON manifests (devnet, testnet) and test fixture