### PR TITLE
refactor(contract-deployment): accept DeployMethod + extraCalls in deployContract

### DIFF
--- a/contract-deployment/src/deploy-utils.ts
+++ b/contract-deployment/src/deploy-utils.ts
@@ -8,12 +8,16 @@
  * already published before each attempt.
  */
 
+import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import {
-  Contract,
+  BatchCall,
+  type Contract,
+  type ContractFunctionInteraction,
+  type DeployMethod,
   type DeployOptions,
   getContractClassFromArtifact,
 } from "@aztec/aztec.js/contracts";
-import type { PublicKeys } from "@aztec/stdlib/keys";
+import type { Wallet } from "@aztec/aztec.js/wallet";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -21,27 +25,22 @@ const pinoLogger = pino();
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 3000;
 
-type DeployParams = Parameters<typeof Contract.deploy>;
-
 /**
  * Deploy a contract with automatic retry on class publication races.
  *
- * @param wallet   - Wallet instance to deploy with
- * @param artifact - Contract artifact
- * @param args     - Constructor arguments
- * @param sendOptions - Options forwarded to `.send()` (`from`, `fee`, etc.)
- * @param constructorName - Optional non-default constructor name
- * @param publicKeys - Optional public keys embedded in the contract instance
- *                     (defaults to PublicKeys.default() when omitted)
+ * @param wallet       - Wallet instance to deploy with
+ * @param artifact     - Contract artifact
+ * @param deployMethod - Pre-built deploy method (from Contract.deploy or Contract.deployWithPublicKeys)
+ * @param sendOptions  - Options forwarded to `.send()` (`from`, `fee`, etc.)
+ * @param extraCalls   - Optional extra calls to batch with the deploy via BatchCall
  */
 export async function deployContract(
-  wallet: DeployParams[0],
-  artifact: DeployParams[1],
-  args: DeployParams[2],
+  wallet: Wallet,
+  artifact: ContractArtifact,
+  deployMethod: DeployMethod<Contract>,
   sendOptions: DeployOptions,
-  constructorName?: DeployParams[3],
-  publicKeys?: PublicKeys,
-) {
+  extraCalls?: ContractFunctionInteraction[],
+): Promise<void> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const opts = { ...sendOptions };
@@ -53,11 +52,14 @@ export async function deployContract(
         opts.skipClassPublication = true;
       }
 
-      const deployMethod = publicKeys
-        ? Contract.deployWithPublicKeys(publicKeys, wallet, artifact, args, constructorName)
-        : Contract.deploy(wallet, artifact, args, constructorName);
-      const { contract } = await deployMethod.send(opts);
-      return contract;
+      if (extraCalls && extraCalls.length > 0) {
+        const batch = new BatchCall(wallet, [deployMethod, ...extraCalls]);
+        await batch.send(opts);
+        return;
+      }
+
+      await deployMethod.send(opts);
+      return;
     } catch (error) {
       if (isClassPublicationRace(error) && attempt < MAX_RETRIES) {
         pinoLogger.info(

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { getSchnorrAccountContractAddress } from "@aztec/accounts/schnorr";
 import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { BatchCall, Contract, type DeployOptions } from "@aztec/aztec.js/contracts";
+import { Contract, type DeployOptions } from "@aztec/aztec.js/contracts";
 import { L1ToL2TokenPortalManager } from "@aztec/aztec.js/ethereum";
 import { Fr } from "@aztec/aztec.js/fields";
 import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
@@ -1035,19 +1035,17 @@ async function deployTestTokenEcosystem(opts: {
 
   // ── Phase 2: L2 batch 1 — bridge deploy + set_config (4 units) ────
   const bridgeContract = Contract.at(bridgeAddress, bridgeArtifact, opts.wallet);
-  const bridgeBatch = new BatchCall(opts.wallet, [
-    bridgeDeploy,
+  await deployContract(opts.wallet, bridgeArtifact, bridgeDeploy, opts.deployOpts, [
     bridgeContract.methods.set_config(tokenAddress, EthAddress.fromString(l1TokenPortalAddress)),
   ]);
-  await bridgeBatch.send(opts.deployOpts);
   pinoLogger.info("[deploy-fpc-devnet] L2 batch 1 completed (bridge deploy + set_config)");
 
   // ── Phase 3: L2 batch 2 — token deploy ─────────────────────────────
-  await tokenDeploy.send(opts.deployOpts);
+  await deployContract(opts.wallet, opts.tokenArtifact, tokenDeploy, opts.deployOpts);
   pinoLogger.info("[deploy-fpc-devnet] L2 batch 2 completed (token deploy)");
 
   // ── Phase 4: L2 batch 3 — counter deploy ───────────────────────────
-  await counterDeploy.send(opts.deployOpts);
+  await deployContract(opts.wallet, counterArtifact, counterDeploy, opts.deployOpts);
   pinoLogger.info("[deploy-fpc-devnet] L2 batch 3 completed (counter deploy)");
 
   // ── Phase 5: Wait for L1→L2 message ───────────────────────────────
@@ -1058,8 +1056,7 @@ async function deployTestTokenEcosystem(opts: {
   pinoLogger.info("[deploy-fpc-devnet] L1→L2 message ready");
 
   // ── Phase 6: L2 batch 4 — faucet deploy + claim_public (4 units) ──
-  const faucetBatch = new BatchCall(opts.wallet, [
-    faucetDeploy,
+  await deployContract(opts.wallet, faucetArtifact, faucetDeploy, opts.deployOpts, [
     bridgeContract.methods.claim_public(
       faucetAddress,
       faucetBridgeClaim.claimAmount,
@@ -1067,7 +1064,6 @@ async function deployTestTokenEcosystem(opts: {
       faucetBridgeClaim.messageLeafIndex,
     ),
   ]);
-  await faucetBatch.send(opts.deployOpts);
   pinoLogger.info(
     `[deploy-fpc-devnet] L2 batch 4 completed (faucet deploy + claim_public, ${faucetConfig.initialSupply} tokens)`,
   );
@@ -1263,15 +1259,13 @@ async function main(): Promise<void> {
   const fpcArtifact = loadArtifact(fpcSelection.artifactPath);
 
   const { publicKeys: fpcPublicKeys } = await deriveKeys(Fr.ZERO);
-  const fpcContract = await deployContract(
-    wallet,
-    fpcArtifact,
-    [operatorAddress, operatorIdentity.pubkeyX, operatorIdentity.pubkeyY],
-    deployOpts,
-    undefined,
-    fpcPublicKeys,
-  );
-  const fpcAddress = fpcContract.address.toString();
+  const fpcDeployMethod = Contract.deployWithPublicKeys(fpcPublicKeys, wallet, fpcArtifact, [
+    operatorAddress,
+    operatorIdentity.pubkeyX,
+    operatorIdentity.pubkeyY,
+  ]);
+  const fpcAddress = (await fpcDeployMethod.getInstance()).address.toString();
+  await deployContract(wallet, fpcArtifact, fpcDeployMethod, deployOpts);
   pinoLogger.info(`[deploy-fpc-devnet] fpc deployed. address=${fpcAddress}`);
 
   const manifest = writeDevnetDeployManifest(args.out, {


### PR DESCRIPTION
## Summary
- Refactored `deployContract` to accept a pre-built `DeployMethod<Contract>` instead of raw params (artifact, args, constructorName, publicKeys)
- Added optional `extraCalls` parameter — when non-empty, batches the deploy with extra calls via `BatchCall`
- Changed return type to `void` since callers extract addresses via `getInstance()`
- Replaced all direct `BatchCall` / `.send()` usage in `deployTestTokenEcosystem` with `deployContract`, giving every L2 deploy the class-publication-race retry logic
- Updated FPC deploy site to construct `DeployMethod` externally
- Removed `BatchCall` import from `index.ts` (no longer used directly)