### PR TITLE
feat: add --pxe-prover-enabled CLI flag and PXE_PROVER_ENABLED env var

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -54,6 +54,8 @@ jobs:
     needs: [changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    env:
+      PXE_PROVER_ENABLED: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -47,6 +47,7 @@ type CliArgs = {
   l1DeployerKey: string | null;
   fpcArtifact: string;
   out: string;
+  proverEnabled: boolean;
   preflightOnly: boolean;
 };
 
@@ -184,6 +185,7 @@ function usage(): string {
     "  --sponsored-fpc-address <addr>   Use sponsored FPC payment mode [env: FPC_SPONSORED_FPC_ADDRESS]",
     "  --accepted-asset <addr>          Reuse existing token [env: FPC_ACCEPTED_ASSET]",
     "  --validate-topup-path            Enforce L1 chain-id matching [env: FPC_VALIDATE_TOPUP_PATH=1]",
+    "  --pxe-prover-enabled <bool>      Enable PXE prover (default: true) [env: PXE_PROVER_ENABLED]",
     "  --preflight-only                 Run checks only, do not deploy [env: FPC_PREFLIGHT_ONLY=1]",
     "",
     "Outputs:",
@@ -251,6 +253,13 @@ function parseAztecAddress(value: string, fieldName: string): string {
   return value;
 }
 
+function parseBooleanFlag(value: string, fieldName: string): boolean {
+  const lower = value.toLowerCase();
+  if (lower === "1" || lower === "true") return true;
+  if (lower === "0" || lower === "false") return false;
+  throw new CliError(`Invalid ${fieldName}: expected "true", "false", "1", or "0", got "${value}"`);
+}
+
 function parseHex32(value: string, fieldName: string): string {
   if (!HEX_32_PATTERN.test(value)) {
     throw new CliError(`Invalid ${fieldName}: expected 32-byte 0x-prefixed hex value`);
@@ -289,6 +298,9 @@ function parseCliArgs(argv: string[]): CliParseResult {
   let dataDir: string = process.env.FPC_DATA_DIR ?? DEVNET_DEFAULT_DATA_DIR;
   let outExplicit = !!process.env.FPC_OUT;
   let out: string = process.env.FPC_OUT ?? path.join(dataDir, "manifest.json");
+  let proverEnabled = process.env.PXE_PROVER_ENABLED
+    ? parseBooleanFlag(process.env.PXE_PROVER_ENABLED, "PXE_PROVER_ENABLED")
+    : true;
   let preflightOnly = process.env.FPC_PREFLIGHT_ONLY === "1";
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -348,6 +360,10 @@ function parseCliArgs(argv: string[]): CliParseResult {
       case "--out":
         out = nextArg(argv, i, arg);
         outExplicit = true;
+        i += 1;
+        break;
+      case "--pxe-prover-enabled":
+        proverEnabled = parseBooleanFlag(nextArg(argv, i, arg), arg);
         i += 1;
         break;
       case "--preflight-only":
@@ -424,6 +440,7 @@ function parseCliArgs(argv: string[]): CliParseResult {
       l1DeployerKey: l1DeployerKey ? parseHex32(l1DeployerKey, "--l1-deployer-key") : null,
       fpcArtifact: parseNonEmptyString(fpcArtifact, "--fpc-artifact"),
       out,
+      proverEnabled,
       preflightOnly,
     },
   };
@@ -1173,7 +1190,7 @@ async function main(): Promise<void> {
   // --- JS API wallet setup for contract deployments ---
   const node = createAztecNodeClient(args.nodeUrl);
   const wallet = await EmbeddedWallet.create(node, {
-    pxeConfig: { proverEnabled: true },
+    pxeConfig: { proverEnabled: args.proverEnabled },
   });
 
   const deployerSecretFr = Fr.fromHexString(args.deployerSecretKey);

--- a/docker-compose.public.yaml
+++ b/docker-compose.public.yaml
@@ -4,13 +4,12 @@ services:
     image: "${DEPLOY_IMAGE:-nethermind/aztec-fpc-contract-deployment:local}"
     volumes:
       - ./deployments/${DEPLOYMENT}:/app/data
-      - deploy-crs-cache:/app/.bb-crs
     environment:
       FPC_ACCEPTED_ASSET: "${FPC_ACCEPTED_ASSET}"
-      PXE_PROVER: "${PXE_PROVER:-wasm}"
       FPC_DEPLOYER_SECRET_KEY: "${FPC_DEPLOYER_SECRET_KEY}"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
       FPC_DATA_DIR: "/app/data"
     env_file:
       - .env.${DEPLOYMENT}
@@ -87,6 +86,7 @@ services:
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY}"
       FPC_L1_USER_KEY: "${FPC_L1_USER_KEY}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     env_file:
       - .env.${DEPLOYMENT}
     depends_on:
@@ -106,6 +106,7 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     env_file:
       - .env.${DEPLOYMENT}
     depends_on:
@@ -125,6 +126,7 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     env_file:
       - .env.${DEPLOYMENT}
     depends_on:
@@ -132,6 +134,3 @@ services:
         condition: service_healthy
       topup:
         condition: service_healthy
-
-volumes:
-  deploy-crs-cache:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,11 +50,10 @@ services:
     image: nethermind/aztec-fpc-contract-deployment:local
     volumes:
       - ./deployments/local:/app/data
-      - deploy-crs-cache:/app/.bb-crs
     environment:
       AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
       L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
-      PXE_PROVER: "${PXE_PROVER:-wasm}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
       FPC_DEPLOYER_SECRET_KEY: "${FPC_DEPLOYER_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
@@ -187,6 +186,7 @@ services:
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     depends_on:
       block-producer:
         condition: service_started
@@ -224,6 +224,7 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     depends_on:
       block-producer:
         condition: service_started
@@ -246,6 +247,7 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     depends_on:
       block-producer:
         condition: service_started
@@ -277,9 +279,6 @@ services:
         condition: service_healthy
       topup:
         condition: service_healthy
-
-volumes:
-  deploy-crs-cache:
 
 configs:
   fpc-config:

--- a/scripts/always-revert/cli.ts
+++ b/scripts/always-revert/cli.ts
@@ -23,6 +23,7 @@ export type CliArgs = {
   attestationUrl: string;
   manifestPath: string;
   operatorSecretKey: string;
+  proverEnabled: boolean;
   messageTimeoutSeconds: number;
   iterations: number;
 };
@@ -60,6 +61,9 @@ export function usage(): string {
     "",
     "Test:",
     "  --iterations <uint>              Number of always-revert iterations (default: 3) [env: FPC_SMOKE_ITERATIONS]",
+    "",
+    "PXE:",
+    "  --pxe-prover-enabled <bool>      Enable PXE prover (default: true) [env: PXE_PROVER_ENABLED]",
     "",
     "  --help, -h                       Show this help",
   ].join("\n");
@@ -120,6 +124,13 @@ function parsePositiveInt(value: string, fieldName: string): number {
   return Number(big);
 }
 
+function parseBooleanFlag(value: string, fieldName: string): boolean {
+  const lower = value.toLowerCase();
+  if (lower === "1" || lower === "true") return true;
+  if (lower === "0" || lower === "false") return false;
+  throw new CliError(`Invalid ${fieldName}: expected "true", "false", "1", or "0", got "${value}"`);
+}
+
 function parseNonNegativeInt(value: string, fieldName: string): number {
   const trimmed = value.trim();
   if (!DECIMAL_UINT_PATTERN.test(trimmed)) {
@@ -142,6 +153,9 @@ export function parseCliArgs(argv: string[]): CliParseResult {
   let manifestPath: string | null = process.env.FPC_COLD_START_MANIFEST ?? null;
   let operatorSecretKey: string | null = process.env.FPC_OPERATOR_SECRET_KEY ?? null;
   let messageTimeoutSeconds: string = process.env.FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS ?? "120";
+  let proverEnabled = process.env.PXE_PROVER_ENABLED
+    ? parseBooleanFlag(process.env.PXE_PROVER_ENABLED, "PXE_PROVER_ENABLED")
+    : true;
   let iterations: string = process.env.FPC_SMOKE_ITERATIONS ?? "3";
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -171,6 +185,10 @@ export function parseCliArgs(argv: string[]): CliParseResult {
         iterations = nextArg(argv, i, arg);
         i += 1;
         break;
+      case "--pxe-prover-enabled":
+        proverEnabled = parseBooleanFlag(nextArg(argv, i, arg), arg);
+        i += 1;
+        break;
       case "--help":
       case "-h":
         pinoLogger.info(usage());
@@ -197,6 +215,7 @@ export function parseCliArgs(argv: string[]): CliParseResult {
       attestationUrl: parseHttpUrl(attestationUrl, "--attestation-url"),
       manifestPath: path.resolve(manifestPath),
       operatorSecretKey: parseHex32(operatorSecretKey, "--operator-secret-key"),
+      proverEnabled,
       messageTimeoutSeconds: parseNonNegativeInt(messageTimeoutSeconds, "--message-timeout"),
       iterations: parsePositiveInt(iterations, "--iterations"),
     },

--- a/scripts/always-revert/setup.ts
+++ b/scripts/always-revert/setup.ts
@@ -126,7 +126,8 @@ export async function setup(args: CliArgs): Promise<TestContext> {
   const node = createAztecNodeClient(args.nodeUrl);
   await waitForNode(node);
   const wallet = await EmbeddedWallet.create(node, {
-    pxeConfig: { proverEnabled: true },
+    ephemeral: true,
+    pxeConfig: { proverEnabled: args.proverEnabled },
   });
 
   // 3. Setup operator account

--- a/scripts/cold-start/cli.ts
+++ b/scripts/cold-start/cli.ts
@@ -29,6 +29,7 @@ export type CliArgs = {
   claimAmount: bigint;
   aaPaymentAmount: bigint;
   quoteTtlSeconds: bigint;
+  proverEnabled: boolean;
   messageTimeoutSeconds: number;
 };
 
@@ -72,6 +73,9 @@ export function usage(): string {
     "Timing:",
     "  --quote-ttl-seconds <uint>       Quote TTL in seconds (default: 3600) [env: FPC_SMOKE_QUOTE_TTL_SECONDS]",
     "  --message-timeout <uint>         L1→L2 message wait timeout seconds (default: 120) [env: FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS]",
+    "",
+    "PXE:",
+    "  --pxe-prover-enabled <bool>      Enable PXE prover (default: true) [env: PXE_PROVER_ENABLED]",
     "",
     "  --help, -h                       Show this help",
   ].join("\n");
@@ -124,6 +128,13 @@ function parsePositiveBigInt(value: string, fieldName: string): bigint {
   return parsed;
 }
 
+function parseBooleanFlag(value: string, fieldName: string): boolean {
+  const lower = value.toLowerCase();
+  if (lower === "1" || lower === "true") return true;
+  if (lower === "0" || lower === "false") return false;
+  throw new CliError(`Invalid ${fieldName}: expected "true", "false", "1", or "0", got "${value}"`);
+}
+
 function parseNonNegativeInt(value: string, fieldName: string): number {
   const trimmed = value.trim();
   if (!DECIMAL_UINT_PATTERN.test(trimmed)) {
@@ -151,6 +162,9 @@ export function parseCliArgs(argv: string[]): CliParseResult {
   let claimAmount: string = process.env.FPC_COLD_START_CLAIM_AMOUNT ?? "10000000000000000";
   let aaPaymentAmount: string = process.env.FPC_COLD_START_AA_PAYMENT_AMOUNT ?? "1000000000";
   let quoteTtlSeconds: string = process.env.FPC_SMOKE_QUOTE_TTL_SECONDS ?? "3600";
+  let proverEnabled = process.env.PXE_PROVER_ENABLED
+    ? parseBooleanFlag(process.env.PXE_PROVER_ENABLED, "PXE_PROVER_ENABLED")
+    : true;
   let messageTimeoutSeconds: string = process.env.FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS ?? "120";
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -200,6 +214,10 @@ export function parseCliArgs(argv: string[]): CliParseResult {
         messageTimeoutSeconds = nextArg(argv, i, arg);
         i += 1;
         break;
+      case "--pxe-prover-enabled":
+        proverEnabled = parseBooleanFlag(nextArg(argv, i, arg), arg);
+        i += 1;
+        break;
       case "--help":
       case "-h":
         pinoLogger.info(usage());
@@ -234,6 +252,7 @@ export function parseCliArgs(argv: string[]): CliParseResult {
       userL1PrivateKey: userL1PrivateKey
         ? parseHex32(userL1PrivateKey, "--user-l1-private-key")
         : null,
+      proverEnabled,
       claimAmount: parsePositiveBigInt(claimAmount, "--claim-amount"),
       aaPaymentAmount: parsePositiveBigInt(aaPaymentAmount, "--aa-payment-amount"),
       quoteTtlSeconds: parsePositiveBigInt(quoteTtlSeconds, "--quote-ttl-seconds"),

--- a/scripts/cold-start/setup.ts
+++ b/scripts/cold-start/setup.ts
@@ -142,7 +142,8 @@ export async function setup(args: CliArgs): Promise<TestContext> {
   const node = createAztecNodeClient(args.nodeUrl);
   await waitForNode(node);
   const wallet = await EmbeddedWallet.create(node, {
-    pxeConfig: { proverEnabled: true },
+    ephemeral: true,
+    pxeConfig: { proverEnabled: args.proverEnabled },
   });
 
   // 3. Setup accounts

--- a/scripts/same-token-transfer/cli.ts
+++ b/scripts/same-token-transfer/cli.ts
@@ -23,6 +23,7 @@ export type CliArgs = {
   attestationUrl: string;
   manifestPath: string;
   operatorSecretKey: string;
+  proverEnabled: boolean;
   aaPaymentAmount: bigint;
   messageTimeoutSeconds: number;
 };
@@ -60,6 +61,9 @@ export function usage(): string {
     "",
     "Timing:",
     "  --message-timeout <uint>         FeeJuice balance wait timeout seconds (default: 120) [env: FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS]",
+    "",
+    "PXE:",
+    "  --pxe-prover-enabled <bool>      Enable PXE prover (default: true) [env: PXE_PROVER_ENABLED]",
     "",
     "  --help, -h                       Show this help",
   ].join("\n");
@@ -112,6 +116,13 @@ function parsePositiveBigInt(value: string, fieldName: string): bigint {
   return parsed;
 }
 
+function parseBooleanFlag(value: string, fieldName: string): boolean {
+  const lower = value.toLowerCase();
+  if (lower === "1" || lower === "true") return true;
+  if (lower === "0" || lower === "false") return false;
+  throw new CliError(`Invalid ${fieldName}: expected "true", "false", "1", or "0", got "${value}"`);
+}
+
 function parseNonNegativeInt(value: string, fieldName: string): number {
   const trimmed = value.trim();
   if (!DECIMAL_UINT_PATTERN.test(trimmed)) {
@@ -134,6 +145,9 @@ export function parseCliArgs(argv: string[]): CliParseResult {
   let manifestPath: string | null = process.env.FPC_COLD_START_MANIFEST ?? null;
   let operatorSecretKey: string | null = process.env.FPC_OPERATOR_SECRET_KEY ?? null;
   let aaPaymentAmount: string = process.env.FPC_COLD_START_AA_PAYMENT_AMOUNT ?? "1000000000";
+  let proverEnabled = process.env.PXE_PROVER_ENABLED
+    ? parseBooleanFlag(process.env.PXE_PROVER_ENABLED, "PXE_PROVER_ENABLED")
+    : true;
   let messageTimeoutSeconds: string = process.env.FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS ?? "120";
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -163,6 +177,10 @@ export function parseCliArgs(argv: string[]): CliParseResult {
         messageTimeoutSeconds = nextArg(argv, i, arg);
         i += 1;
         break;
+      case "--pxe-prover-enabled":
+        proverEnabled = parseBooleanFlag(nextArg(argv, i, arg), arg);
+        i += 1;
+        break;
       case "--help":
       case "-h":
         pinoLogger.info(usage());
@@ -189,6 +207,7 @@ export function parseCliArgs(argv: string[]): CliParseResult {
       attestationUrl: parseHttpUrl(attestationUrl, "--attestation-url"),
       manifestPath: path.resolve(manifestPath),
       operatorSecretKey: parseHex32(operatorSecretKey, "--operator-secret-key"),
+      proverEnabled,
       aaPaymentAmount: parsePositiveBigInt(aaPaymentAmount, "--aa-payment-amount"),
       messageTimeoutSeconds: parseNonNegativeInt(messageTimeoutSeconds, "--message-timeout"),
     },

--- a/scripts/same-token-transfer/setup.ts
+++ b/scripts/same-token-transfer/setup.ts
@@ -126,7 +126,8 @@ export async function setup(args: CliArgs): Promise<TestContext> {
   const node = createAztecNodeClient(args.nodeUrl);
   await waitForNode(node);
   const wallet = await EmbeddedWallet.create(node, {
-    pxeConfig: { proverEnabled: true },
+    ephemeral: true,
+    pxeConfig: { proverEnabled: args.proverEnabled },
   });
 
   // 3. Setup operator account

--- a/services/attestation/Dockerfile
+++ b/services/attestation/Dockerfile
@@ -4,7 +4,7 @@ COPY services/attestation/config.example.yaml services/attestation/
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=1s --timeout=3s --start-period=5s --retries=3 \
     CMD bun -e "await fetch('http://127.0.0.1:3000/health').then(r => { if (!r.ok) throw 1 })"
 
 ENTRYPOINT ["bun", "run", "services/attestation/dist/index.js"]

--- a/services/topup/Dockerfile
+++ b/services/topup/Dockerfile
@@ -2,7 +2,7 @@ FROM common
 
 COPY services/topup/config.example.yaml services/topup/
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=1s --timeout=3s --start-period=10s --retries=3 \
   CMD bun -e "const port=process.env.TOPUP_OPS_PORT || '3001'; const r=await fetch('http://127.0.0.1:'+port+'/health'); if (!r.ok) throw new Error('unhealthy')"
 
 ENTRYPOINT ["bun", "run", "services/topup/dist/index.js"]


### PR DESCRIPTION
## Summary
- Add `parseBooleanFlag` helper and `--pxe-prover-enabled` CLI arg / `PXE_PROVER_ENABLED` env var to contract-deployment and 3 smoke-test scripts (cold-start, always-revert, same-token-transfer)
- Wire `proverEnabled` through `CliArgs` to `EmbeddedWallet.create` in all 4 setup paths (default: `true`)
- Add `ephemeral: true` to `EmbeddedWallet.create` in always-revert and same-token-transfer setup
- Pass `PXE_PROVER_ENABLED` to smoke-test and deploy services in `docker-compose.yaml` and `docker-compose.public.yaml`
- Replace `PXE_PROVER` with `PXE_PROVER_ENABLED` in deploy services, remove `deploy-crs-cache` volumes
- Reduce healthcheck interval from 10s to 1s in attestation and topup Dockerfiles