### PR TITLE
feat: add standalone FPC cold-start example script

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -71,11 +71,11 @@ jobs:
       - name: Docs quote schema guard
         run: bun run check:docs:quote-schema
 
-      - name: Typecheck
-        run: bun run typecheck
-
       - name: Build
         run: bun run build
+
+      - name: Typecheck
+        run: bun run typecheck
 
       - name: Test
         run: bun run test:ts

--- a/biome.json
+++ b/biome.json
@@ -15,6 +15,8 @@
       "services/*/src/**/*.ts",
       "services/*/test/**/*.ts",
       "services/*/package.json",
+      "examples/**/*.ts",
+      "examples/package.json",
       "scripts/**/*.ts",
       "scripts/*/package.json",
       "sdk/src/**/*.ts",
@@ -46,7 +48,7 @@
   },
   "overrides": [
     {
-      "includes": ["services/**", "sdk/**", "scripts/**", "contract-deployment/**"],
+      "includes": ["examples/**", "services/**", "sdk/**", "scripts/**", "contract-deployment/**"],
       "linter": {
         "rules": {
           "correctness": {
@@ -75,6 +77,16 @@
       }
     },
     {
+      "includes": ["examples/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["scripts/**", "contract-deployment/**"],
       "linter": {
         "rules": {
@@ -97,7 +109,7 @@
       }
     },
     {
-      "includes": ["services/**", "sdk/**"],
+      "includes": ["examples/**", "services/**", "sdk/**"],
       "linter": {
         "rules": {
           "complexity": {

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,18 @@
         "viem": "npm:@aztec/viem@2.38.2",
       },
     },
+    "examples": {
+      "name": "@aztec-fpc/examples",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aztec-fpc/sdk": "workspace:*",
+        "@aztec/aztec.js": "4.1.0-nightly.20260312.2",
+        "@aztec/ethereum": "4.1.0-nightly.20260312.2",
+        "@aztec/foundation": "4.1.0-nightly.20260312.2",
+        "@aztec/wallets": "4.1.0-nightly.20260312.2",
+        "viem": "npm:@aztec/viem@2.38.2",
+      },
+    },
     "scripts": {
       "name": "@aztec-fpc/scripts",
       "version": "0.1.0",
@@ -202,6 +214,8 @@
     "@aztec-fpc/attestation": ["@aztec-fpc/attestation@workspace:services/attestation"],
 
     "@aztec-fpc/contract-deployment": ["@aztec-fpc/contract-deployment@workspace:contract-deployment"],
+
+    "@aztec-fpc/examples": ["@aztec-fpc/examples@workspace:examples"],
 
     "@aztec-fpc/scripts": ["@aztec-fpc/scripts@workspace:scripts"],
 

--- a/examples/fpc-full-flow.ts
+++ b/examples/fpc-full-flow.ts
@@ -1,0 +1,186 @@
+/**
+ * Minimal standalone example: cold-start + FPC-paid transfer.
+ *
+ * Edit the constants below to match your deployment, then run:
+ *   bunx tsx examples/fpc-full-flow.ts
+ *
+ * Requires: Aztec node, L1 (Anvil), attestation server, topup service.
+ */
+
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { L1ToL2TokenPortalManager } from "@aztec/aztec.js/ethereum";
+import { Fr } from "@aztec/aztec.js/fields";
+import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
+import { EthAddress } from "@aztec/foundation/eth-address";
+import { createLogger } from "@aztec/foundation/log";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import { FpcClient } from "@aztec-fpc/sdk";
+import { type Chain, extractChain } from "viem";
+import * as viemChains from "viem/chains";
+
+// =============================================================================
+// Constants — edit these to match your deployment
+// =============================================================================
+
+// --- L2 user secret ---
+const userSecret = Fr.random();
+
+// --- L1 private keys ---
+// If using your own key or the address runs out of L1 test tokens, mint more with:
+//   cast send 0xf49de848d9c00c4dfb088b2e6ba2dac81e34aa5d \
+//     "mint(address,uint256)()" <YOUR_L1_ADDRESS> 1000000000000000000000000000000000000 \
+//     --rpc-url https://ethereum-sepolia-rpc.publicnode.com \
+//     --private-key 0xcc49e1d22f5ee1618c30446bc2e415c7e504e6409ac690205c7bf12d052ae088
+const L1_USER_KEY = "0x43b45bae4115cda0e584e6aae8edfa023973ddb97409d6688549ffdaf904747c";
+
+// --- Network ---
+const NODE_URL = "https://rpc.testnet.aztec-labs.com/";
+const L1_RPC_URL = "https://ethereum-sepolia-rpc.publicnode.com";
+const ATTESTATION_URL = "https://aztec-fpc-testnet.staging-nethermind.xyz/";
+
+// --- L2 contract addresses ---
+const FPC_ADDRESS = "0x1be2cae678e1eddd712682948119b3fe2c3ff3f381d78ebea06162f21487d60f";
+const TOKEN_ADDRESS = "0x07348d12aae72d1c2ff67cb2bf6b0e54f2ac39484f21cad7247d4e27b4822afb";
+const BRIDGE_ADDRESS = "0x19b200d772d3e9068921e6f5df7530271229e958acc9efc2c637afe64db9763f";
+const OPERATOR_ADDRESS = "0x0aa818ff7e9bb59334e0106eeeacc5ce8d32610d34917b213f305a30a87cf974";
+
+// --- L1 contract addresses (Sepolia) ---
+const L1_PORTAL_ADDRESS = "0x57a426552a472e953ecc1342f25b17cc192326be";
+const L1_ERC20_ADDRESS = "0xf49de848d9c00c4dfb088b2e6ba2dac81e34aa5d";
+
+// --- Amounts ---
+const CLAIM_AMOUNT = 10_000_000_000_000_000n;
+
+// --- PXE ---
+const MESSAGE_TIMEOUT_SECONDS = 300;
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main() {
+  // =========================================================================
+  // Phase 0: Setup — connect to node, derive accounts, create clients
+  // =========================================================================
+  console.log("--- Phase 0: Setup ---");
+
+  console.log("Node URL: ", NODE_URL);
+  console.log("L1 RPC URL: ", L1_RPC_URL);
+  console.log("Attestation URL: ", ATTESTATION_URL);
+
+  console.log("\nL2 contract addresses:");
+  console.log("FPC address: ", FPC_ADDRESS);
+  console.log("Token address: ", TOKEN_ADDRESS);
+  console.log("Bridge address: ", BRIDGE_ADDRESS);
+  console.log("Operator address: ", OPERATOR_ADDRESS);
+
+  console.log("\nL1 contract addresses:");
+  console.log("Portal address: ", L1_PORTAL_ADDRESS);
+  console.log("ERC20 address: ", L1_ERC20_ADDRESS);
+
+  const fpcAddress = AztecAddress.fromString(FPC_ADDRESS);
+  const tokenAddress = AztecAddress.fromString(TOKEN_ADDRESS);
+  const bridgeAddress = AztecAddress.fromString(BRIDGE_ADDRESS);
+  const operatorAddress = AztecAddress.fromString(OPERATOR_ADDRESS);
+
+  console.log("Connecting to Aztec node...");
+  const node = createAztecNodeClient(NODE_URL);
+  await waitForNode(node);
+  const wallet = await EmbeddedWallet.create(node, {
+    ephemeral: true,
+    pxeConfig: { proverEnabled: true },
+  });
+  console.log("Connected.");
+
+  const userAccount = await wallet.createSchnorrAccount(userSecret, Fr.ZERO);
+  const userAddress = userAccount.address;
+  console.log(`Generated user key:     ${userSecret}`);
+  console.log(`Generated user address: ${userAddress}`);
+
+  const nodeInfo = await node.getNodeInfo();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: nodeInfo.l1ChainId,
+  });
+  const l1WalletClient = createExtendedL1Client([L1_RPC_URL], L1_USER_KEY, l1Chain);
+  console.log("L1 client ready.");
+
+  const fpcClient = new FpcClient({
+    fpcAddress,
+    operator: operatorAddress,
+    node,
+    attestationBaseUrl: ATTESTATION_URL,
+  });
+  console.log("FpcClient ready.");
+
+  // =========================================================================
+  // Phase 1: Cold-start — bridge L1->L2, claim + pay FPC fee in one tx
+  // =========================================================================
+  console.log("\n--- Phase 1: Cold-start ---");
+
+  const portalManager = new L1ToL2TokenPortalManager(
+    EthAddress.fromString(L1_PORTAL_ADDRESS),
+    EthAddress.fromString(L1_ERC20_ADDRESS),
+    undefined,
+    l1WalletClient,
+    createLogger("bridge"),
+  );
+
+  const bridgeClaim = await portalManager.bridgeTokensPrivate(userAddress, CLAIM_AMOUNT, false);
+  await waitForL1ToL2MessageReady(node, Fr.fromHexString(bridgeClaim.messageHash as string), {
+    timeoutSeconds: MESSAGE_TIMEOUT_SECONDS,
+  });
+  console.log(`Tokens bridged. message_hash=${bridgeClaim.messageHash}`);
+
+  // Execute cold-start
+  const coldStartResult = await fpcClient.executeColdStart({
+    wallet,
+    userAddress,
+    tokenAddress,
+    bridgeAddress,
+    bridgeClaim,
+  });
+  console.log(`Cold-start confirmed. tx_hash=${coldStartResult.txHash}`);
+  console.log(`  fee=${coldStartResult.txFee} aa_payment=${coldStartResult.aaPaymentAmount}`);
+
+  // =========================================================================
+  // Phase 2: Deploy user account via FPC fee_entrypoint
+  // =========================================================================
+  console.log("\n--- Phase 2: Deploy account via FPC ---");
+
+  const deployMethod = await userAccount.getDeployMethod();
+  const { estimatedGas } = await deployMethod.simulate({
+    from: AztecAddress.ZERO,
+    fee: { estimateGas: true },
+    skipClassPublication: true,
+  });
+  if (!estimatedGas) {
+    throw new Error("Failed to estimate gas for deploy method");
+  }
+
+  const deployPayment = await fpcClient.createPaymentMethod({
+    wallet,
+    user: userAddress,
+    tokenAddress,
+    estimatedGas,
+  });
+
+  await deployMethod.send({
+    from: AztecAddress.ZERO,
+    fee: deployPayment.fee,
+    skipClassPublication: true,
+  });
+  console.log(`Account deployed. aa_payment=${deployPayment.quote.aa_payment_amount}`);
+}
+
+main()
+  .then(() => {
+    console.log("\nDone.");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("FAILED:", err);
+    process.exit(1);
+  });

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aztec-fpc/examples",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@aztec/aztec.js": "4.1.0-nightly.20260312.2",
+    "@aztec/ethereum": "4.1.0-nightly.20260312.2",
+    "@aztec/foundation": "4.1.0-nightly.20260312.2",
+    "@aztec/wallets": "4.1.0-nightly.20260312.2",
+    "viem": "npm:@aztec/viem@2.38.2",
+    "@aztec-fpc/sdk": "workspace:*"
+  }
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "ci": "bun run format && bun run biome:ci && bun run lint && bun run typecheck && bun run test:ts && bun run test:contracts",
     "biome:check": "biome check --write",
     "biome:ci": "biome ci --config-path ./biome.json",
-    "format": "biome format --write package.json tsconfig.base.json services scripts sdk contract-deployment",
-    "lint": "biome lint package.json tsconfig.base.json services scripts sdk contract-deployment",
+    "format": "biome format --write package.json tsconfig.base.json examples services scripts sdk contract-deployment",
+    "lint": "biome lint package.json tsconfig.base.json examples services scripts sdk contract-deployment",
     "check:docs:quote-schema": "bash scripts/check-docs-quote-schema.sh",
     "release:sdk:version:patch": "bash -lc 'cd sdk && npm version patch --no-git-tag-version'",
     "release:sdk:version:minor": "bash -lc 'cd sdk && npm version minor --no-git-tag-version'",
@@ -85,6 +85,7 @@
     "chaos:local": "bash scripts/chaos/fpc-chaos-local.sh"
   },
   "workspaces": [
+    "examples",
     "scripts",
     "services/*",
     "sdk",

--- a/sdk/src/internal/contracts.ts
+++ b/sdk/src/internal/contracts.ts
@@ -12,11 +12,12 @@ import {
 const currentDir =
   typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
-type DefaultArtifactLabel = "token" | "fpc";
+type DefaultArtifactLabel = "token" | "fpc" | "bridge";
 
 const DEFAULT_ARTIFACT_FILENAMES: Record<DefaultArtifactLabel, string> = {
   fpc: "fpc-FPCMultiAsset.json",
   token: "token_contract-Token.json",
+  bridge: "token_bridge_contract-TokenBridge.json",
 };
 
 const defaultArtifactCache: Partial<Record<DefaultArtifactLabel, ContractArtifact>> =

--- a/sdk/src/payment-method.ts
+++ b/sdk/src/payment-method.ts
@@ -93,7 +93,11 @@ export class FpcClient {
     const { wallet, userAddress, tokenAddress, bridgeAddress, bridgeClaim } = input;
     const timeoutMs = input.txWaitTimeoutMs ?? DEFAULT_TX_WAIT_TIMEOUT_MS;
 
-    const fpc = await attachContract(fpcAddress, "fpc", node, wallet);
+    const [fpc, _token, _bridge] = await Promise.all([
+      attachContract(fpcAddress, "fpc", node, wallet),
+      attachContract(tokenAddress, "token", node, wallet),
+      attachContract(bridgeAddress, "bridge", node, wallet),
+    ]);
 
     const gasFees = await node.getCurrentMinFees();
     const fjAmount = computeFjAmount(COLD_START_GAS_LIMITS, gasFees);
@@ -248,7 +252,7 @@ async function waitForTx(txHash: TxHash, node: AztecNode, timeoutMs: number): Pr
 
 async function attachContract(
   address: AztecAddress,
-  label: "fpc" | "token",
+  label: "fpc" | "token" | "bridge",
   node: AztecNode,
   wallet: AccountWallet,
 ): Promise<Contract> {
@@ -257,7 +261,8 @@ async function attachContract(
   if (!instance) {
     throw new Error(`${label} contract not found on node at ${address.toString()}`);
   }
-  await wallet.registerContract(instance, artifact);
+  const secretKey = label === "fpc" ? Fr.ZERO : undefined;
+  await wallet.registerContract(instance, artifact, secretKey);
   return Contract.at(address, artifact, wallet);
 }
 

--- a/services/Dockerfile.common
+++ b/services/Dockerfile.common
@@ -15,6 +15,7 @@ FROM base AS deps
 # Bun workspace resolution requires every member's package.json present
 # before `bun install` will accept the lockfile.
 COPY package.json bun.lock ./
+COPY examples/package.json examples/
 COPY sdk/package.json sdk/
 COPY scripts/package.json scripts/
 COPY services/attestation/package.json services/attestation/


### PR DESCRIPTION
## Summary
- Add `examples/fpc-full-flow.ts` — minimal standalone script demonstrating cold-start (L1 bridge + claim) and account deploy via FPC
- Add `examples/` as a new workspace (`@aztec-fpc/examples`) with its own `package.json` and `tsconfig.json`
- Extend SDK's `attachContract` to support bridge contracts, register token and bridge during `executeColdStart`
- Register FPC contract with `secretKey: Fr.ZERO` in SDK
- Include `examples/` in biome config (format, lint, typecheck) with `noConsole: "off"` override
- Prefill constants with testnet deployment addresses and public RPCs