### PR TITLE
refactor: focus same-token-transfer test on transfer phases with public balance tracking

### DIFF
--- a/scripts/common/balance-tracker.ts
+++ b/scripts/common/balance-tracker.ts
@@ -4,32 +4,55 @@ import pino from "pino";
 
 const pinoLogger = pino();
 
-export class PrivateBalanceTracker {
+abstract class BalanceTracker {
   constructor(
-    private readonly token: Contract,
+    protected readonly token: Contract,
     readonly address: AztecAddress,
-    private readonly label: string,
-    private expected: bigint,
-    private readonly mode: "exact" | "atLeast" = "exact",
+    protected readonly label: string,
+    protected expected: bigint,
+    protected readonly mode: "exact" | "atLeast" = "exact",
   ) {}
+
+  protected abstract balanceKind: string;
+
+  protected abstract fetchBalance(): Promise<bigint>;
 
   async change(delta: bigint): Promise<void> {
     this.expected += delta;
-    const { result } = await this.token.methods
-      .balance_of_private(this.address)
-      .simulate({ from: this.address });
-    const actual = BigInt(result.toString());
+    const actual = await this.fetchBalance();
     const expectStr = this.mode === "atLeast" ? `>=${this.expected}` : `${this.expected}`;
-    pinoLogger.info(`${this.label}: private_balance=${actual} expected=${expectStr}`);
+    pinoLogger.info(`${this.label}: ${this.balanceKind}=${actual} expected=${expectStr}`);
     if (this.mode === "exact" && actual !== this.expected) {
       throw new Error(
-        `${this.label} private balance mismatch: expected=${this.expected} got=${actual}`,
+        `${this.label} ${this.balanceKind} mismatch: expected=${this.expected} got=${actual}`,
       );
     }
     if (this.mode === "atLeast" && actual < this.expected) {
       throw new Error(
-        `${this.label} private balance too low: expected>=${this.expected} got=${actual}`,
+        `${this.label} ${this.balanceKind} too low: expected>=${this.expected} got=${actual}`,
       );
     }
+  }
+}
+
+export class PrivateBalanceTracker extends BalanceTracker {
+  protected balanceKind = "private_balance";
+
+  protected async fetchBalance(): Promise<bigint> {
+    const { result } = await this.token.methods
+      .balance_of_private(this.address)
+      .simulate({ from: this.address });
+    return BigInt(result.toString());
+  }
+}
+
+export class PublicBalanceTracker extends BalanceTracker {
+  protected balanceKind = "public_balance";
+
+  protected async fetchBalance(): Promise<bigint> {
+    const { result } = await this.token.methods
+      .balance_of_public(this.address)
+      .simulate({ from: this.address });
+    return BigInt(result.toString());
   }
 }

--- a/scripts/same-token-transfer/test-same-token-transfer.ts
+++ b/scripts/same-token-transfer/test-same-token-transfer.ts
@@ -1,19 +1,20 @@
 /**
- * Same-token-transfer test: faucet drip -> shield -> counter -> sponsored transfer -> FPC transfer.
+ * Same-token-transfer test: faucet drip -> partial shield -> private transfer -> public transfer
+ * -> batch cross-domain transfers.
  *
  * Exercises the full lifecycle from zero to FPC usage without any L1 bridging:
  * 1. Deploy user account via SponsoredFPC
- * 2. Faucet drip + shield tokens (batched in one tx via SponsoredFPC)
- * 3. Increment counter via FPC fee_entrypoint
- * 4. Transfer tokens to a fresh recipient via SponsoredFPC
- * 5. Transfer tokens to a fresh recipient, fee paid by our FPC fee_entrypoint
+ * 2. Faucet drip + shield half of tokens (batched in one tx via SponsoredFPC)
+ * 3. Transfer tokens to a fresh recipient, fee paid by our FPC fee_entrypoint
+ * 4. Transfer public tokens to recipient, fee paid by our FPC fee_entrypoint
+ * 5. Batch: transfer_public_to_private + transfer_private_to_public, fee paid by our FPC fee_entrypoint
  */
 
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { BatchCall } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import pino from "pino";
-import { PrivateBalanceTracker } from "../common/balance-tracker.ts";
+import { PrivateBalanceTracker, PublicBalanceTracker } from "../common/balance-tracker.ts";
 import { type AccountData, deriveAccount } from "../common/script-credentials.ts";
 import type { TestContext } from "./setup.ts";
 
@@ -26,8 +27,7 @@ const LOG_PREFIX = "[same-token-transfer]";
 // ---------------------------------------------------------------------------
 
 export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
-  const { args, operator, fpcClient, tokenAddress, token, faucet, counter, sponsoredFeePayment } =
-    ctx;
+  const { args, operator, fpcClient, tokenAddress, token, faucet, sponsoredFeePayment } = ctx;
 
   const { aaPaymentAmount } = args;
 
@@ -57,10 +57,10 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
   pinoLogger.info(`${LOG_PREFIX} PASS: user account deployed via SponsoredFPC`);
 
   // =========================================================================
-  // Phase 2: Faucet drip + shield tokens (batched in one tx via SponsoredFPC)
+  // Phase 2: Faucet drip + shield half of tokens (batched in one tx via SponsoredFPC)
   // =========================================================================
 
-  const shieldAmount = dripAmount;
+  const shieldAmount = dripAmount / 2n;
   pinoLogger.info(`${LOG_PREFIX} batching faucet drip + shield (${shieldAmount} tokens)`);
 
   const batch = new BatchCall(ctx.wallet, [
@@ -80,19 +80,16 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
     .simulate({ from: operator });
   const operatorStartBalance = BigInt(operatorStartBalanceRaw.toString());
 
-  // Assert: drip landed in public, then shield moved it all to private
-  const userBal = new PrivateBalanceTracker(token, user, "User", 0n);
-  await userBal.change(shieldAmount);
+  // Assert: drip landed in public, then shield moved half to private
+  const userPrivBal = new PrivateBalanceTracker(token, user, "User", 0n);
+  await userPrivBal.change(shieldAmount);
+
+  const userPubBal = new PublicBalanceTracker(token, user, "User", 0n);
+  await userPubBal.change(dripAmount - shieldAmount);
 
   pinoLogger.info(`${LOG_PREFIX} PASS: faucet drip + shield succeeded`);
 
-  // =========================================================================
-  // Phase 3: Increment counter via FPC fee_entrypoint
-  // =========================================================================
-
-  pinoLogger.info(`${LOG_PREFIX} incrementing counter via FPC`);
-
-  const operatorBal = new PrivateBalanceTracker(
+  const operatorPrivBal = new PrivateBalanceTracker(
     token,
     operator,
     "Operator",
@@ -100,88 +97,28 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
     "atLeast",
   );
 
-  const { result: counterBeforeRaw } = await counter.methods
-    .get_counter(user)
-    .simulate({ from: user });
-  const counterBefore = BigInt(counterBeforeRaw.toString());
-
-  const counterSim = await counter.methods.increment(user).simulate({
-    from: user,
-    fee: { estimateGas: true },
-  });
-  const counterFpc = await fpcClient.createPaymentMethod({
-    wallet: ctx.wallet,
-    user,
-    tokenAddress,
-    estimatedGas: counterSim.estimatedGas,
-  });
-  const counterFeePayment = BigInt(counterFpc.quote.aa_payment_amount);
-
-  await counter.methods.increment(user).send({
-    from: user,
-    fee: counterFpc.fee,
-  });
-
-  const { result: counterAfterRaw } = await counter.methods
-    .get_counter(user)
-    .simulate({ from: user });
-  const counterAfter = BigInt(counterAfterRaw.toString());
-
-  if (counterAfter !== counterBefore + 1n) {
-    throw new Error(`Counter mismatch: expected=${counterBefore + 1n} got=${counterAfter}`);
-  }
-
-  await userBal.change(-counterFeePayment);
-  await operatorBal.change(counterFeePayment);
-
-  pinoLogger.info(`${LOG_PREFIX} PASS: counter increment via FPC succeeded`);
-
   // =========================================================================
-  // Phase 4: Transfer tokens to a fresh recipient via SponsoredFPC
+  // Phase 3: Transfer tokens to a fresh recipient via FPC fee_entrypoint
   // =========================================================================
 
-  const sponsoredRecipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
-  const sponsoredTransferAmount = aaPaymentAmount;
-
-  pinoLogger.info(
-    `${LOG_PREFIX} transferring ${sponsoredTransferAmount} tokens to sponsored recipient via SponsoredFPC`,
-  );
-
-  await token.methods
-    .transfer_private_to_private(user, sponsoredRecipient, sponsoredTransferAmount, 0)
-    .send({
-      from: user,
-      fee: {
-        paymentMethod: sponsoredFeePayment,
-      },
-    });
-
-  const sponsoredRecipientBal = new PrivateBalanceTracker(
-    token,
-    sponsoredRecipient,
-    "Sponsored recipient",
-    0n,
-  );
-  await sponsoredRecipientBal.change(sponsoredTransferAmount);
-  await userBal.change(-sponsoredTransferAmount);
-
-  pinoLogger.info(`${LOG_PREFIX} PASS: sponsored transfer succeeded`);
-
-  // =========================================================================
-  // Phase 5: Transfer tokens to a fresh recipient via FPC fee_entrypoint
-  // =========================================================================
+  const recipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
+  const recipientPrivBal = new PrivateBalanceTracker(token, recipient, "Recipient", 0n);
+  const recipientPubBal = new PublicBalanceTracker(token, recipient, "Recipient", 0n);
 
   pinoLogger.info(`${LOG_PREFIX} transferring tokens to recipient via FPC`);
 
-  const recipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
-  const transferAmount = aaPaymentAmount;
+  const privTransferAmount = aaPaymentAmount;
 
-  const transferSim = await token.methods
-    .transfer_private_to_private(user, recipient, transferAmount, 0)
-    .simulate({
-      from: user,
-      fee: { estimateGas: true },
-    });
+  const transferCall = token.methods.transfer_private_to_private(
+    user,
+    recipient,
+    privTransferAmount,
+    Fr.random(),
+  );
+  const transferSim = await transferCall.simulate({
+    from: user,
+    fee: { estimateGas: true },
+  });
   const transferFpc = await fpcClient.createPaymentMethod({
     wallet: ctx.wallet,
     user,
@@ -190,16 +127,117 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
   });
   const transferFeePayment = BigInt(transferFpc.quote.aa_payment_amount);
 
-  await token.methods.transfer_private_to_private(user, recipient, transferAmount, 0).send({
+  await transferCall.send({
     from: user,
     fee: transferFpc.fee,
   });
 
-  const recipientBal = new PrivateBalanceTracker(token, recipient, "Recipient", 0n);
-  await recipientBal.change(transferAmount);
-  await userBal.change(-transferAmount - transferFeePayment);
-
-  await operatorBal.change(transferFeePayment);
+  await recipientPrivBal.change(privTransferAmount);
+  await userPrivBal.change(-privTransferAmount - transferFeePayment);
+  await operatorPrivBal.change(transferFeePayment);
 
   pinoLogger.info(`${LOG_PREFIX} PASS: token transfer via FPC succeeded`);
+
+  // =========================================================================
+  // Phase 4: Transfer public tokens to recipient via FPC fee_entrypoint
+  // =========================================================================
+
+  pinoLogger.info(`${LOG_PREFIX} transferring public tokens to recipient via FPC`);
+
+  const pubTransferAmount = aaPaymentAmount;
+
+  const publicTransferCall = token.methods.transfer_public_to_public(
+    user,
+    recipient,
+    pubTransferAmount,
+    Fr.random(),
+  );
+  const publicTransferSim = await publicTransferCall.simulate({
+    from: user,
+    fee: { estimateGas: true },
+  });
+  const publicTransferFpc = await fpcClient.createPaymentMethod({
+    wallet: ctx.wallet,
+    user,
+    tokenAddress,
+    estimatedGas: publicTransferSim.estimatedGas,
+  });
+  const publicTransferFeePayment = BigInt(publicTransferFpc.quote.aa_payment_amount);
+
+  await publicTransferCall.send({
+    from: user,
+    fee: publicTransferFpc.fee,
+  });
+
+  await recipientPubBal.change(pubTransferAmount);
+  await userPubBal.change(-pubTransferAmount);
+  await userPrivBal.change(-publicTransferFeePayment);
+  await operatorPrivBal.change(publicTransferFeePayment);
+
+  pinoLogger.info(`${LOG_PREFIX} PASS: public-to-public transfer via FPC succeeded`);
+
+  // =========================================================================
+  // Phase 5: Batch transfer_public_to_private + transfer_private_to_public
+  //          via FPC fee_entrypoint
+  // =========================================================================
+
+  const batchTransferAmount = aaPaymentAmount;
+
+  pinoLogger.info(
+    `${LOG_PREFIX} batching public_to_private + private_to_public (${batchTransferAmount} tokens each) via FPC`,
+  );
+
+  const pubToPrivCall = token.methods.transfer_public_to_private(
+    user,
+    recipient,
+    batchTransferAmount,
+    Fr.random(),
+  );
+  const privToPubCall = token.methods.transfer_private_to_public(
+    user,
+    recipient,
+    batchTransferAmount,
+    Fr.random(),
+  );
+
+  const { estimatedGas: pubToPrivGas } = await pubToPrivCall.simulate({
+    from: user,
+    fee: { estimateGas: true },
+  });
+  const { estimatedGas: privToPubGas } = await privToPubCall.simulate({
+    from: user,
+    fee: { estimateGas: true },
+  });
+
+  if (!pubToPrivGas || !privToPubGas) {
+    throw new Error("Gas estimation failed for batch transfer calls");
+  }
+
+  const batchEstimatedGas = {
+    gasLimits: pubToPrivGas.gasLimits.add(privToPubGas.gasLimits),
+    teardownGasLimits: pubToPrivGas.teardownGasLimits.add(privToPubGas.teardownGasLimits),
+  };
+  const batchTransferFpc = await fpcClient.createPaymentMethod({
+    wallet: ctx.wallet,
+    user,
+    tokenAddress,
+    estimatedGas: batchEstimatedGas,
+  });
+  const batchTransferFeePayment = BigInt(batchTransferFpc.quote.aa_payment_amount);
+
+  const batchTransferCall = new BatchCall(ctx.wallet, [pubToPrivCall, privToPubCall]);
+  await batchTransferCall.send({
+    from: user,
+    fee: batchTransferFpc.fee,
+  });
+
+  await recipientPrivBal.change(batchTransferAmount);
+  await recipientPubBal.change(batchTransferAmount);
+  await userPubBal.change(-batchTransferAmount);
+  await userPrivBal.change(-batchTransferAmount - batchTransferFeePayment);
+  await operatorPrivBal.change(batchTransferFeePayment);
+
+  pinoLogger.info(
+    `${LOG_PREFIX} PASS: batch public_to_private + private_to_public via FPC succeeded`,
+  );
 }


### PR DESCRIPTION
## Summary
- Extract abstract `BalanceTracker` base class with `PrivateBalanceTracker` and `PublicBalanceTracker` subclasses
- Shield only half the faucet drip to exercise both public and private balances
- Remove counter increment and sponsored transfer phases to focus on token transfers
- Add `transfer_public_to_public` phase via FPC
- Add batch `transfer_public_to_private` + `transfer_private_to_public` phase via FPC with aggregated gas estimation
- Reuse a single recipient across transfer phases with cumulative balance tracking
- Deduplicate method calls by storing contract call before simulate/send