### PR TITLE
refactor: extract common setup helper for smoke-test bootstrap scripts

### DIFF
--- a/scripts/always-revert/cli.ts
+++ b/scripts/always-revert/cli.ts
@@ -10,6 +10,7 @@
  */
 
 import path from "node:path";
+import { Fr } from "@aztec/aztec.js/fields";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -22,7 +23,7 @@ export type CliArgs = {
   nodeUrl: string;
   attestationUrl: string;
   manifestPath: string;
-  operatorSecretKey: string;
+  operatorSecretKey: Fr;
   proverEnabled: boolean;
   messageTimeoutSeconds: number;
   iterations: number;
@@ -214,7 +215,7 @@ export function parseCliArgs(argv: string[]): CliParseResult {
       nodeUrl: parseHttpUrl(nodeUrl, "--node-url"),
       attestationUrl: parseHttpUrl(attestationUrl, "--attestation-url"),
       manifestPath: path.resolve(manifestPath),
-      operatorSecretKey: parseHex32(operatorSecretKey, "--operator-secret-key"),
+      operatorSecretKey: Fr.fromHexString(parseHex32(operatorSecretKey, "--operator-secret-key")),
       proverEnabled,
       messageTimeoutSeconds: parseNonNegativeInt(messageTimeoutSeconds, "--message-timeout"),
       iterations: parsePositiveInt(iterations, "--iterations"),

--- a/scripts/always-revert/setup.ts
+++ b/scripts/always-revert/setup.ts
@@ -7,28 +7,15 @@
  * is needed.
  */
 
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import type { ContractArtifact } from "@aztec/aztec.js/abi";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { Contract } from "@aztec/aztec.js/contracts";
+import type { AztecAddress } from "@aztec/aztec.js/addresses";
+import type { Contract } from "@aztec/aztec.js/contracts";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
-import { Fr } from "@aztec/aztec.js/fields";
-import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
-import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
-import { SPONSORED_FPC_SALT } from "@aztec/constants";
-import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
-import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
-import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
-import type { NoirCompiledContract } from "@aztec/stdlib/noir";
-import { EmbeddedWallet } from "@aztec/wallets/embedded";
-import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import type { AztecNode } from "@aztec/aztec.js/node";
+import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { FpcClient } from "@aztec-fpc/sdk";
-import pino from "pino";
-import { deriveAccount } from "../common/script-credentials.ts";
-import { type CliArgs, CliError } from "./cli.ts";
-
-const pinoLogger = pino();
+import { setup as commonSetup } from "../common/setup-helpers.ts";
+import type { CliArgs } from "./cli.ts";
 
 // ---------------------------------------------------------------------------
 // TestContext — everything tests need
@@ -36,7 +23,7 @@ const pinoLogger = pino();
 
 export type TestContext = {
   args: CliArgs;
-  node: ReturnType<typeof createAztecNodeClient>;
+  node: AztecNode;
   wallet: EmbeddedWallet;
   operator: AztecAddress;
   fpcClient: FpcClient;
@@ -49,138 +36,32 @@ export type TestContext = {
 };
 
 // ---------------------------------------------------------------------------
-// Private helpers
-// ---------------------------------------------------------------------------
-
-function loadArtifact(artifactPath: string): ContractArtifact {
-  const raw = readFileSync(artifactPath, "utf8");
-  const parsed = JSON.parse(raw) as NoirCompiledContract;
-  try {
-    return loadContractArtifact(parsed);
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      err.message.includes("Contract's public bytecode has not been transpiled")
-    ) {
-      return loadContractArtifactForPublic(parsed);
-    }
-    throw err;
-  }
-}
-
-function resolveFpcArtifactPath(repoRoot: string): string {
-  for (const name of ["fpc-FPCMultiAsset.json", "fpc-FPC.json"]) {
-    const p = path.join(repoRoot, "target", name);
-    if (existsSync(p)) return p;
-  }
-  throw new Error("FPC artifact not found in target/");
-}
-
-async function registerAndGet(
-  node: ReturnType<typeof createAztecNodeClient>,
-  wallet: EmbeddedWallet,
-  address: AztecAddress,
-  artifact: ContractArtifact,
-) {
-  const instance = await node.getContract(address);
-  if (!instance) {
-    throw new Error(`Contract not found on node: ${address.toString()}`);
-  }
-  await wallet.registerContract(instance, artifact);
-  return Contract.at(address, artifact, wallet);
-}
-
-// ---------------------------------------------------------------------------
 // setup()
 // ---------------------------------------------------------------------------
 
 export async function setup(args: CliArgs): Promise<TestContext> {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
+  const { node, wallet, operator, contracts, sponsoredFpcAddress } = await commonSetup(
+    args,
+    repoRoot,
+    "always-revert",
+  );
 
-  pinoLogger.info("[always-revert] starting");
-  pinoLogger.info(`[always-revert] node_url=${args.nodeUrl}`);
-  pinoLogger.info(`[always-revert] manifest=${args.manifestPath}`);
+  const { token, fpc, counter, faucet } = contracts;
 
-  // 1. Read manifest
-  if (!existsSync(args.manifestPath)) {
-    throw new CliError(`Manifest not found: ${args.manifestPath}`);
-  }
-  const manifest = JSON.parse(readFileSync(args.manifestPath, "utf8")) as DevnetDeployManifest;
-
-  if (!manifest.contracts.faucet) {
-    throw new Error("Manifest missing contracts.faucet (required for always-revert)");
-  }
-  if (!manifest.contracts.counter) {
+  if (!counter) {
     throw new Error("Manifest missing contracts.counter (required for always-revert)");
   }
-  const fpcAddress = AztecAddress.fromString(manifest.contracts.fpc);
-  const tokenAddress = AztecAddress.fromString(manifest.contracts.accepted_asset);
-  const faucetAddress = AztecAddress.fromString(manifest.contracts.faucet);
-  const counterAddress = AztecAddress.fromString(manifest.contracts.counter);
+  if (!faucet) {
+    throw new Error("Manifest missing contracts.faucet (required for always-revert)");
+  }
 
-  pinoLogger.info(
-    `[always-revert] manifest loaded. fpc=${manifest.contracts.fpc} token=${manifest.contracts.accepted_asset} faucet=${manifest.contracts.faucet}`,
-  );
-
-  // 2. Connect to node
-  const node = createAztecNodeClient(args.nodeUrl);
-  await waitForNode(node);
-  const wallet = await EmbeddedWallet.create(node, {
-    ephemeral: true,
-    pxeConfig: { proverEnabled: args.proverEnabled },
-  });
-
-  // 3. Setup operator account
-  const operatorSecretFr = Fr.fromHexString(args.operatorSecretKey);
-  const operatorAccount = await deriveAccount(operatorSecretFr, wallet);
-  const operator = operatorAccount.address;
-
-  pinoLogger.info(`[always-revert] operator=${operator.toString()}`);
-
-  // 4. Register deployed contracts (faucet + counter for non-FPC operations)
-  const tokenArtifact = loadArtifact(path.join(repoRoot, "target", "token_contract-Token.json"));
-  const fpcArtifact = loadArtifact(resolveFpcArtifactPath(repoRoot));
-  const faucetArtifact = loadArtifact(path.join(repoRoot, "target", "faucet-Faucet.json"));
-  const counterArtifact = loadArtifact(path.join(repoRoot, "target", "mock_counter-Counter.json"));
-
-  const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
-  await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
-  const faucet = await registerAndGet(node, wallet, faucetAddress, faucetArtifact);
-  const counter = await registerAndGet(node, wallet, counterAddress, counterArtifact);
-
-  // Register the canonical SponsoredFPC contract (address derived from artifact + salt)
-  const sponsoredFpcInstance = await getContractInstanceFromInstantiationParams(
-    SponsoredFPCContractArtifact,
-    { salt: new Fr(SPONSORED_FPC_SALT) },
-  );
-  await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
-  const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcInstance.address);
-
-  // 5. Create FpcClient
   const fpcClient = new FpcClient({
-    fpcAddress,
+    fpcAddress: fpc.address,
     operator,
     node,
     attestationBaseUrl: args.attestationUrl,
   });
-
-  // 6. Wait for topup service to fund FPC with FeeJuice
-  pinoLogger.info("[always-revert] waiting for FPC FeeJuice balance > 0 (via topup service)");
-
-  const FJ_POLL_MS = 2_000;
-  const FJ_TIMEOUT_MS = args.messageTimeoutSeconds * 1_000;
-  const fjDeadline = Date.now() + FJ_TIMEOUT_MS;
-  let fjBalance = 0n;
-  while (Date.now() <= fjDeadline) {
-    fjBalance = await getFeeJuiceBalance(fpcAddress, node);
-    if (fjBalance > 0n) break;
-    await new Promise((resolve) => setTimeout(resolve, FJ_POLL_MS));
-  }
-  if (fjBalance === 0n) {
-    throw new Error(`Timed out waiting for FPC FeeJuice balance on ${fpcAddress.toString()}`);
-  }
-
-  pinoLogger.info(`[always-revert] FPC FeeJuice balance=${fjBalance}`);
 
   return {
     args,
@@ -188,11 +69,11 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     wallet,
     operator,
     fpcClient,
-    fpcAddress,
-    tokenAddress,
+    fpcAddress: fpc.address,
+    tokenAddress: token.address,
     token,
     faucet,
     counter,
-    sponsoredFeePayment,
+    sponsoredFeePayment: new SponsoredFeePaymentMethod(sponsoredFpcAddress),
   };
 }

--- a/scripts/always-revert/test-always-revert.ts
+++ b/scripts/always-revert/test-always-revert.ts
@@ -96,7 +96,7 @@ export async function testAlwaysRevert(ctx: TestContext): Promise<void> {
   const operatorStartBalance = BigInt(operatorStartBalanceRaw.toString());
 
   // Assert: drip landed in public, then shield moved it all to private
-  const userBal = new PrivateBalanceTracker(token, user, "User", 0n);
+  const userBal = await PrivateBalanceTracker.create(token, ctx.wallet, userData.secret, "User");
   await userBal.change(shieldAmount);
 
   pinoLogger.info(`${LOG_PREFIX} PASS: faucet drip + shield succeeded`);
@@ -107,9 +107,10 @@ export async function testAlwaysRevert(ctx: TestContext): Promise<void> {
 
   pinoLogger.info(`${LOG_PREFIX} starting ${iterations} always_revert iteration(s)`);
 
-  const operatorBal = new PrivateBalanceTracker(
+  const operatorBal = await PrivateBalanceTracker.create(
     token,
-    operator,
+    ctx.wallet,
+    args.operatorSecretKey,
     "Operator",
     operatorStartBalance,
     "atLeast",

--- a/scripts/cold-start/cli.ts
+++ b/scripts/cold-start/cli.ts
@@ -10,6 +10,7 @@
  */
 
 import path from "node:path";
+import { Fr } from "@aztec/aztec.js/fields";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -23,7 +24,7 @@ export type CliArgs = {
   l1RpcUrl: string;
   attestationUrl: string;
   manifestPath: string;
-  operatorSecretKey: string;
+  operatorSecretKey: Fr;
   l1DeployerKey: string | null;
   userL1PrivateKey: string | null;
   claimAmount: bigint;
@@ -247,7 +248,7 @@ export function parseCliArgs(argv: string[]): CliParseResult {
       l1RpcUrl: parseHttpUrl(l1RpcUrl, "--l1-rpc-url"),
       attestationUrl: parseHttpUrl(attestationUrl, "--attestation-url"),
       manifestPath: path.resolve(manifestPath),
-      operatorSecretKey: parseHex32(operatorSecretKey, "--operator-secret-key"),
+      operatorSecretKey: Fr.fromHexString(parseHex32(operatorSecretKey, "--operator-secret-key")),
       l1DeployerKey: l1DeployerKey ? parseHex32(l1DeployerKey, "--l1-deployer-key") : null,
       userL1PrivateKey: userL1PrivateKey
         ? parseHex32(userL1PrivateKey, "--user-l1-private-key")

--- a/scripts/cold-start/setup.ts
+++ b/scripts/cold-start/setup.ts
@@ -6,32 +6,23 @@
  * so each test can bridge its own tokens independently.
  */
 
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import type { ContractArtifact } from "@aztec/aztec.js/abi";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { Contract } from "@aztec/aztec.js/contracts";
+import type { AztecAddress } from "@aztec/aztec.js/addresses";
+import type { Contract } from "@aztec/aztec.js/contracts";
 import { L1ToL2TokenPortalManager } from "@aztec/aztec.js/ethereum";
-import { Fr } from "@aztec/aztec.js/fields";
-import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
-import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
-import { SPONSORED_FPC_SALT } from "@aztec/constants";
+import type { AztecNode } from "@aztec/aztec.js/node";
 import { createExtendedL1Client } from "@aztec/ethereum/client";
 import type { ExtendedViemWalletClient } from "@aztec/ethereum/types";
 import { EthAddress } from "@aztec/foundation/eth-address";
 import { createLogger } from "@aztec/foundation/log";
 import { TestERC20Abi } from "@aztec/l1-artifacts";
-import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
-import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
-import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
-import type { NoirCompiledContract } from "@aztec/stdlib/noir";
-import { EmbeddedWallet } from "@aztec/wallets/embedded";
-import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
 import { type Chain, extractChain, type GetContractReturnType, getContract, type Hex } from "viem";
 import * as viemChains from "viem/chains";
-import { deriveAccount, resolveScriptAccounts } from "../common/script-credentials.ts";
-import { type CliArgs, CliError } from "./cli.ts";
+import { resolveScriptAccounts } from "../common/script-credentials.ts";
+import { setup as commonSetup } from "../common/setup-helpers.ts";
+import type { CliArgs } from "./cli.ts";
 
 const pinoLogger = pino();
 
@@ -41,7 +32,7 @@ const pinoLogger = pino();
 
 export type TestContext = {
   args: CliArgs;
-  node: ReturnType<typeof createAztecNodeClient>;
+  node: AztecNode;
   wallet: EmbeddedWallet;
   operator: AztecAddress;
   token: Contract;
@@ -56,97 +47,30 @@ export type TestContext = {
 };
 
 // ---------------------------------------------------------------------------
-// Private helpers
-// ---------------------------------------------------------------------------
-
-function loadArtifact(artifactPath: string): ContractArtifact {
-  const raw = readFileSync(artifactPath, "utf8");
-  const parsed = JSON.parse(raw) as NoirCompiledContract;
-  try {
-    return loadContractArtifact(parsed);
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      err.message.includes("Contract's public bytecode has not been transpiled")
-    ) {
-      return loadContractArtifactForPublic(parsed);
-    }
-    throw err;
-  }
-}
-
-function resolveFpcArtifactPath(repoRoot: string): string {
-  for (const name of ["fpc-FPCMultiAsset.json", "fpc-FPC.json"]) {
-    const p = path.join(repoRoot, "target", name);
-    if (existsSync(p)) return p;
-  }
-  throw new Error("FPC artifact not found in target/");
-}
-
-async function registerAndGet(
-  node: ReturnType<typeof createAztecNodeClient>,
-  wallet: EmbeddedWallet,
-  address: AztecAddress,
-  artifact: ContractArtifact,
-  secretKey?: Fr,
-) {
-  const instance = await node.getContract(address);
-  if (!instance) {
-    throw new Error(`Contract not found on node: ${address.toString()}`);
-  }
-  await wallet.registerContract(instance, artifact, secretKey);
-  return Contract.at(address, artifact, wallet);
-}
-
-// ---------------------------------------------------------------------------
 // setup()
 // ---------------------------------------------------------------------------
 
 export async function setup(args: CliArgs): Promise<TestContext> {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
+  const { manifest, node, wallet, operator, contracts, sponsoredFpcAddress } = await commonSetup(
+    args,
+    repoRoot,
+    "cold-start-smoke",
+  );
 
-  pinoLogger.info("[cold-start-smoke] starting");
-  pinoLogger.info(`[cold-start-smoke] node_url=${args.nodeUrl}`);
-  pinoLogger.info(`[cold-start-smoke] l1_rpc_url=${args.l1RpcUrl}`);
-  pinoLogger.info(`[cold-start-smoke] attestation_url=${args.attestationUrl}`);
-  pinoLogger.info(`[cold-start-smoke] manifest=${args.manifestPath}`);
+  const { token, fpc, counter, bridge } = contracts;
 
-  // 1. Read manifest
-  if (!existsSync(args.manifestPath)) {
-    throw new CliError(`Manifest not found: ${args.manifestPath}`);
-  }
-  const manifest = JSON.parse(readFileSync(args.manifestPath, "utf8")) as DevnetDeployManifest;
-
-  if (!manifest.contracts.bridge) {
-    throw new Error("Manifest missing contracts.bridge");
-  }
-  if (!manifest.contracts.counter) {
+  if (!counter) {
     throw new Error("Manifest missing contracts.counter");
+  }
+  if (!bridge) {
+    throw new Error("Manifest missing contracts.bridge");
   }
   if (!manifest.l1_contracts) {
     throw new Error("Manifest missing l1_contracts");
   }
 
-  const fpcAddress = AztecAddress.fromString(manifest.contracts.fpc);
-  const tokenAddress = AztecAddress.fromString(manifest.contracts.accepted_asset);
-  const bridgeAddress = AztecAddress.fromString(manifest.contracts.bridge);
-  const counterAddress = AztecAddress.fromString(manifest.contracts.counter);
-  const l1PortalAddress = manifest.l1_contracts.token_portal;
-  const l1Erc20Address = manifest.l1_contracts.erc20;
-
-  pinoLogger.info(
-    `[cold-start-smoke] manifest loaded. fpc=${manifest.contracts.fpc} token=${manifest.contracts.accepted_asset} bridge=${manifest.contracts.bridge}`,
-  );
-
-  // 2. Connect to node
-  const node = createAztecNodeClient(args.nodeUrl);
-  await waitForNode(node);
-  const wallet = await EmbeddedWallet.create(node, {
-    ephemeral: true,
-    pxeConfig: { proverEnabled: args.proverEnabled },
-  });
-
-  // 3. Setup accounts
+  // Setup L1 accounts
   let l1PrivateKey: Hex;
   if (args.userL1PrivateKey) {
     l1PrivateKey = args.userL1PrivateKey as Hex;
@@ -155,50 +79,9 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     ({ l1PrivateKey } = await resolveScriptAccounts(args.nodeUrl, args.l1RpcUrl, wallet, 0));
   }
 
-  const operatorSecretFr = Fr.fromHexString(args.operatorSecretKey);
-  const operatorAccount = await deriveAccount(operatorSecretFr, wallet);
-  const operator = operatorAccount.address;
-
-  pinoLogger.info(`[cold-start-smoke] accounts ready. operator=${operator.toString()}`);
-
-  // 4. Register deployed contracts
-  const tokenArtifact = loadArtifact(path.join(repoRoot, "target", "token_contract-Token.json"));
-  const bridgeArtifact = loadArtifact(
-    path.join(repoRoot, "target", "token_bridge_contract-TokenBridge.json"),
-  );
-  const fpcArtifact = loadArtifact(resolveFpcArtifactPath(repoRoot));
-  const counterArtifact = loadArtifact(path.join(repoRoot, "target", "mock_counter-Counter.json"));
-
-  const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
-  await registerAndGet(node, wallet, fpcAddress, fpcArtifact, Fr.ZERO);
-  await registerAndGet(node, wallet, bridgeAddress, bridgeArtifact);
-  const counter = await registerAndGet(node, wallet, counterAddress, counterArtifact);
-
-  // Register the canonical SponsoredFPC contract (address derived from artifact + salt)
-  const sponsoredFpcInstance = await getContractInstanceFromInstantiationParams(
-    SponsoredFPCContractArtifact,
-    { salt: new Fr(SPONSORED_FPC_SALT) },
-  );
-  await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
-  const sponsoredFpcAddress = sponsoredFpcInstance.address;
-
-  // 5. Wait for the topup service to fund the FPC with FeeJuice
-  pinoLogger.info("[cold-start-smoke] waiting for FPC FeeJuice balance (funded by topup service)");
-
-  const FEE_JUICE_POLL_MS = 2_000;
-  const feeJuiceDeadline = Date.now() + args.messageTimeoutSeconds * 1_000;
-  let fpcFeeJuiceBalance = 0n;
-  while (Date.now() < feeJuiceDeadline) {
-    fpcFeeJuiceBalance = await getFeeJuiceBalance(fpcAddress, node);
-    if (fpcFeeJuiceBalance > 0n) break;
-    await new Promise((resolve) => setTimeout(resolve, FEE_JUICE_POLL_MS));
-  }
-  if (fpcFeeJuiceBalance === 0n) {
-    throw new Error(
-      `FPC FeeJuice balance is still 0 after ${args.messageTimeoutSeconds}s — is the topup service running?`,
-    );
-  }
-  pinoLogger.info(`[cold-start-smoke] FPC FeeJuice balance=${fpcFeeJuiceBalance}`);
+  // Setup L1 infrastructure
+  const l1PortalAddress = manifest.l1_contracts.token_portal;
+  const l1Erc20Address = manifest.l1_contracts.erc20;
 
   const nodeInfo = await node.getNodeInfo();
   const l1Chain = extractChain({
@@ -233,9 +116,9 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     operator,
     token,
     counter,
-    fpcAddress,
-    tokenAddress,
-    bridgeAddress,
+    fpcAddress: fpc.address,
+    tokenAddress: token.address,
+    bridgeAddress: bridge.address,
     sponsoredFpcAddress,
     l1WalletClient,
     l1Erc20,

--- a/scripts/cold-start/test-happy-path.ts
+++ b/scripts/cold-start/test-happy-path.ts
@@ -47,8 +47,20 @@ export async function testHappyPath(ctx: TestContext): Promise<void> {
   const user = userData.address;
 
   // Balance trackers — accumulate expected private balances across phases
-  const userBalance = new PrivateBalanceTracker(token, user, "User", 0n);
-  const operatorBalance = new PrivateBalanceTracker(token, operator, "Operator", 0n, "atLeast");
+  const userBalance = await PrivateBalanceTracker.create(
+    token,
+    ctx.wallet,
+    userData.secret,
+    "User",
+  );
+  const operatorBalance = await PrivateBalanceTracker.create(
+    token,
+    ctx.wallet,
+    args.operatorSecretKey,
+    "Operator",
+    0n,
+    "atLeast",
+  );
 
   // Shared FpcClient for all FPC-sponsored phases
   const fpcClient = new FpcClient({
@@ -181,14 +193,14 @@ export async function testHappyPath(ctx: TestContext): Promise<void> {
 
   pinoLogger.info("[cold-start-smoke] transferring tokens to recipient via sponsored FPC");
 
-  const sponsoredRecipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
   const sponsoredTransferAmount = args.aaPaymentAmount;
-  const sponsoredRecipientBalance = new PrivateBalanceTracker(
+  const sponsoredRecipientBalance = await PrivateBalanceTracker.create(
     token,
-    sponsoredRecipient,
+    ctx.wallet,
+    Fr.random(),
     "Sponsored recipient",
-    0n,
   );
+  const sponsoredRecipient = sponsoredRecipientBalance.address;
 
   await token.methods
     .transfer_private_to_private(user, sponsoredRecipient, sponsoredTransferAmount, 0)
@@ -213,9 +225,14 @@ export async function testHappyPath(ctx: TestContext): Promise<void> {
 
   pinoLogger.info("[cold-start-smoke] transferring tokens to recipient via FPC");
 
-  const recipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
   const transferAmount = args.aaPaymentAmount;
-  const recipientBalance = new PrivateBalanceTracker(token, recipient, "Recipient", 0n);
+  const recipientBalance = await PrivateBalanceTracker.create(
+    token,
+    ctx.wallet,
+    Fr.random(),
+    "Recipient",
+  );
+  const recipient = recipientBalance.address;
 
   const transferMethod = token.methods.transfer_private_to_private(
     user,

--- a/scripts/common/balance-tracker.ts
+++ b/scripts/common/balance-tracker.ts
@@ -1,5 +1,7 @@
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import type { Contract } from "@aztec/aztec.js/contracts";
+import { Fr } from "@aztec/aztec.js/fields";
+import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -9,7 +11,7 @@ abstract class BalanceTracker {
     protected readonly token: Contract,
     readonly address: AztecAddress,
     protected readonly label: string,
-    protected expected: bigint,
+    protected expected = 0n,
     protected readonly mode: "exact" | "atLeast" = "exact",
   ) {}
 
@@ -37,6 +39,28 @@ abstract class BalanceTracker {
 
 export class PrivateBalanceTracker extends BalanceTracker {
   protected balanceKind = "private_balance";
+
+  private constructor(
+    token: Contract,
+    address: AztecAddress,
+    label: string,
+    expected = 0n,
+    mode: "exact" | "atLeast" = "exact",
+  ) {
+    super(token, address, label, expected, mode);
+  }
+
+  static async create(
+    token: Contract,
+    wallet: EmbeddedWallet,
+    secretKey: Fr,
+    label: string,
+    expected = 0n,
+    mode: "exact" | "atLeast" = "exact",
+  ): Promise<PrivateBalanceTracker> {
+    const account = await wallet.createSchnorrAccount(secretKey, Fr.ZERO);
+    return new PrivateBalanceTracker(token, account.address, label, expected, mode);
+  }
 
   protected async fetchBalance(): Promise<bigint> {
     const { result } = await this.token.methods

--- a/scripts/common/setup-helpers.ts
+++ b/scripts/common/setup-helpers.ts
@@ -1,0 +1,243 @@
+/**
+ * Shared setup helpers for smoke-test bootstrap scripts.
+ *
+ * Extracts the duplicated artifact-loading, contract-registration, node
+ * connection, SponsoredFPC registration, and FeeJuice
+ * polling logic that was copy-pasted across cold-start, always-revert, and
+ * same-token-transfer setup modules.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { ContractArtifact } from "@aztec/aztec.js/abi";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { Contract } from "@aztec/aztec.js/contracts";
+import { Fr } from "@aztec/aztec.js/fields";
+import { type AztecNode, createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import { SPONSORED_FPC_SALT } from "@aztec/constants";
+import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
+import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
+import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
+import type { NoirCompiledContract } from "@aztec/stdlib/noir";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import pino from "pino";
+
+const pinoLogger = pino();
+
+// ---------------------------------------------------------------------------
+// Contract registration
+// ---------------------------------------------------------------------------
+
+export async function registerAndGet(
+  node: AztecNode,
+  wallet: EmbeddedWallet,
+  addressHex: string,
+  artifactPath: string,
+  secretKey?: Fr,
+) {
+  const address = AztecAddress.fromString(addressHex);
+  const instance = await node.getContract(address);
+  if (!instance) {
+    throw new Error(`Contract not found on node: ${addressHex}`);
+  }
+  const raw = readFileSync(artifactPath, "utf8");
+  const parsed = JSON.parse(raw) as NoirCompiledContract;
+  let artifact: ContractArtifact;
+  try {
+    artifact = loadContractArtifact(parsed);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.includes("Contract's public bytecode has not been transpiled")
+    ) {
+      artifact = loadContractArtifactForPublic(parsed);
+    } else {
+      throw err;
+    }
+  }
+  await wallet.registerContract(instance, artifact, secretKey);
+  return Contract.at(address, artifact, wallet);
+}
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+export function readManifest(manifestPath: string): DevnetDeployManifest {
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Manifest not found: ${manifestPath}`);
+  }
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as DevnetDeployManifest;
+}
+
+// ---------------------------------------------------------------------------
+// Node + wallet
+// ---------------------------------------------------------------------------
+
+export async function connectAndCreateWallet(nodeUrl: string, proverEnabled: boolean) {
+  const node = createAztecNodeClient(nodeUrl);
+  await waitForNode(node);
+  const wallet = await EmbeddedWallet.create(node, {
+    ephemeral: true,
+    pxeConfig: { proverEnabled },
+  });
+  return { node, wallet };
+}
+
+// ---------------------------------------------------------------------------
+// Core contract registration (token + FPC + counter)
+// ---------------------------------------------------------------------------
+
+export type CoreContracts = {
+  token: Contract;
+  fpc: Contract;
+  counter?: Contract;
+  faucet?: Contract;
+  bridge?: Contract;
+};
+
+export async function registerCoreContracts(
+  repoRoot: string,
+  manifest: DevnetDeployManifest,
+  node: AztecNode,
+  wallet: EmbeddedWallet,
+): Promise<CoreContracts> {
+  const target = path.join(repoRoot, "target");
+
+  const token = await registerAndGet(
+    node,
+    wallet,
+    manifest.contracts.accepted_asset,
+    path.join(target, "token_contract-Token.json"),
+  );
+  const fpc = await registerAndGet(
+    node,
+    wallet,
+    manifest.contracts.fpc,
+    path.join(target, "fpc-FPCMultiAsset.json"),
+    Fr.ZERO,
+  );
+
+  const counter = manifest.contracts.counter
+    ? await registerAndGet(
+        node,
+        wallet,
+        manifest.contracts.counter,
+        path.join(target, "mock_counter-Counter.json"),
+      )
+    : undefined;
+
+  const faucet = manifest.contracts.faucet
+    ? await registerAndGet(
+        node,
+        wallet,
+        manifest.contracts.faucet,
+        path.join(target, "faucet-Faucet.json"),
+      )
+    : undefined;
+
+  const bridge = manifest.contracts.bridge
+    ? await registerAndGet(
+        node,
+        wallet,
+        manifest.contracts.bridge,
+        path.join(target, "token_bridge_contract-TokenBridge.json"),
+      )
+    : undefined;
+
+  return { token, fpc, counter, faucet, bridge };
+}
+
+// ---------------------------------------------------------------------------
+// SponsoredFPC registration
+// ---------------------------------------------------------------------------
+
+export async function registerSponsoredFpc(wallet: EmbeddedWallet) {
+  const sponsoredFpcInstance = await getContractInstanceFromInstantiationParams(
+    SponsoredFPCContractArtifact,
+    { salt: new Fr(SPONSORED_FPC_SALT) },
+  );
+  await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
+  return sponsoredFpcInstance.address;
+}
+
+// ---------------------------------------------------------------------------
+// FeeJuice balance polling
+// ---------------------------------------------------------------------------
+
+export async function waitForFpcFeeJuice(
+  fpcAddress: AztecAddress,
+  node: AztecNode,
+  timeoutSeconds: number,
+  label: string,
+): Promise<bigint> {
+  pinoLogger.info(`[${label}] waiting for FPC FeeJuice balance > 0 (via topup service)`);
+
+  const POLL_MS = 2_000;
+  const deadline = Date.now() + timeoutSeconds * 1_000;
+  let balance = 0n;
+  while (Date.now() < deadline) {
+    balance = await getFeeJuiceBalance(fpcAddress, node);
+    if (balance > 0n) break;
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+  if (balance === 0n) {
+    throw new Error(
+      `FPC FeeJuice balance is still 0 after ${timeoutSeconds}s — is the topup service running?`,
+    );
+  }
+
+  pinoLogger.info(`[${label}] FPC FeeJuice balance=${balance}`);
+  return balance;
+}
+
+// ---------------------------------------------------------------------------
+// Common setup
+// ---------------------------------------------------------------------------
+
+export type SetupArgs = {
+  nodeUrl: string;
+  manifestPath: string;
+  proverEnabled: boolean;
+  messageTimeoutSeconds: number;
+};
+
+export type SetupResult = {
+  manifest: DevnetDeployManifest;
+  node: AztecNode;
+  wallet: EmbeddedWallet;
+  operator: AztecAddress;
+  contracts: CoreContracts;
+  sponsoredFpcAddress: AztecAddress;
+};
+
+export async function setup(
+  args: SetupArgs,
+  repoRoot: string,
+  label: string,
+): Promise<SetupResult> {
+  pinoLogger.info(`[${label}] starting`);
+  pinoLogger.info(`[${label}] node_url=${args.nodeUrl}`);
+  pinoLogger.info(`[${label}] manifest=${args.manifestPath}`);
+
+  const manifest = readManifest(args.manifestPath);
+
+  pinoLogger.info(
+    `[${label}] manifest loaded. fpc=${manifest.contracts.fpc} token=${manifest.contracts.accepted_asset}`,
+  );
+
+  const { node, wallet } = await connectAndCreateWallet(args.nodeUrl, args.proverEnabled);
+
+  const operator = AztecAddress.fromString(manifest.operator.address);
+  pinoLogger.info(`[${label}] operator=${operator.toString()}`);
+
+  const contracts = await registerCoreContracts(repoRoot, manifest, node, wallet);
+
+  const sponsoredFpcAddress = await registerSponsoredFpc(wallet);
+
+  await waitForFpcFeeJuice(contracts.fpc.address, node, args.messageTimeoutSeconds, label);
+
+  return { manifest, node, wallet, operator, contracts, sponsoredFpcAddress };
+}

--- a/scripts/same-token-transfer/cli.ts
+++ b/scripts/same-token-transfer/cli.ts
@@ -10,6 +10,7 @@
  */
 
 import path from "node:path";
+import { Fr } from "@aztec/aztec.js/fields";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -22,7 +23,7 @@ export type CliArgs = {
   nodeUrl: string;
   attestationUrl: string;
   manifestPath: string;
-  operatorSecretKey: string;
+  operatorSecretKey: Fr;
   proverEnabled: boolean;
   aaPaymentAmount: bigint;
   messageTimeoutSeconds: number;
@@ -206,7 +207,7 @@ export function parseCliArgs(argv: string[]): CliParseResult {
       nodeUrl: parseHttpUrl(nodeUrl, "--node-url"),
       attestationUrl: parseHttpUrl(attestationUrl, "--attestation-url"),
       manifestPath: path.resolve(manifestPath),
-      operatorSecretKey: parseHex32(operatorSecretKey, "--operator-secret-key"),
+      operatorSecretKey: Fr.fromHexString(parseHex32(operatorSecretKey, "--operator-secret-key")),
       proverEnabled,
       aaPaymentAmount: parsePositiveBigInt(aaPaymentAmount, "--aa-payment-amount"),
       messageTimeoutSeconds: parseNonNegativeInt(messageTimeoutSeconds, "--message-timeout"),

--- a/scripts/same-token-transfer/setup.ts
+++ b/scripts/same-token-transfer/setup.ts
@@ -7,28 +7,15 @@
  * is needed.
  */
 
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import type { ContractArtifact } from "@aztec/aztec.js/abi";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { Contract } from "@aztec/aztec.js/contracts";
+import type { AztecAddress } from "@aztec/aztec.js/addresses";
+import type { Contract } from "@aztec/aztec.js/contracts";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
-import { Fr } from "@aztec/aztec.js/fields";
-import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
-import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
-import { SPONSORED_FPC_SALT } from "@aztec/constants";
-import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
-import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
-import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
-import type { NoirCompiledContract } from "@aztec/stdlib/noir";
-import { EmbeddedWallet } from "@aztec/wallets/embedded";
-import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
+import type { AztecNode } from "@aztec/aztec.js/node";
+import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { FpcClient } from "@aztec-fpc/sdk";
-import pino from "pino";
-import { deriveAccount } from "../common/script-credentials.ts";
-import { type CliArgs, CliError } from "./cli.ts";
-
-const pinoLogger = pino();
+import { setup as commonSetup } from "../common/setup-helpers.ts";
+import type { CliArgs } from "./cli.ts";
 
 // ---------------------------------------------------------------------------
 // TestContext — everything tests need
@@ -36,7 +23,7 @@ const pinoLogger = pino();
 
 export type TestContext = {
   args: CliArgs;
-  node: ReturnType<typeof createAztecNodeClient>;
+  node: AztecNode;
   wallet: EmbeddedWallet;
   operator: AztecAddress;
   fpcClient: FpcClient;
@@ -49,138 +36,32 @@ export type TestContext = {
 };
 
 // ---------------------------------------------------------------------------
-// Private helpers
-// ---------------------------------------------------------------------------
-
-function loadArtifact(artifactPath: string): ContractArtifact {
-  const raw = readFileSync(artifactPath, "utf8");
-  const parsed = JSON.parse(raw) as NoirCompiledContract;
-  try {
-    return loadContractArtifact(parsed);
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      err.message.includes("Contract's public bytecode has not been transpiled")
-    ) {
-      return loadContractArtifactForPublic(parsed);
-    }
-    throw err;
-  }
-}
-
-function resolveFpcArtifactPath(repoRoot: string): string {
-  for (const name of ["fpc-FPCMultiAsset.json", "fpc-FPC.json"]) {
-    const p = path.join(repoRoot, "target", name);
-    if (existsSync(p)) return p;
-  }
-  throw new Error("FPC artifact not found in target/");
-}
-
-async function registerAndGet(
-  node: ReturnType<typeof createAztecNodeClient>,
-  wallet: EmbeddedWallet,
-  address: AztecAddress,
-  artifact: ContractArtifact,
-) {
-  const instance = await node.getContract(address);
-  if (!instance) {
-    throw new Error(`Contract not found on node: ${address.toString()}`);
-  }
-  await wallet.registerContract(instance, artifact);
-  return Contract.at(address, artifact, wallet);
-}
-
-// ---------------------------------------------------------------------------
 // setup()
 // ---------------------------------------------------------------------------
 
 export async function setup(args: CliArgs): Promise<TestContext> {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
+  const { node, wallet, operator, contracts, sponsoredFpcAddress } = await commonSetup(
+    args,
+    repoRoot,
+    "same-token-transfer",
+  );
 
-  pinoLogger.info("[same-token-transfer] starting");
-  pinoLogger.info(`[same-token-transfer] node_url=${args.nodeUrl}`);
-  pinoLogger.info(`[same-token-transfer] manifest=${args.manifestPath}`);
+  const { token, fpc, counter, faucet } = contracts;
 
-  // 1. Read manifest
-  if (!existsSync(args.manifestPath)) {
-    throw new CliError(`Manifest not found: ${args.manifestPath}`);
-  }
-  const manifest = JSON.parse(readFileSync(args.manifestPath, "utf8")) as DevnetDeployManifest;
-
-  if (!manifest.contracts.faucet) {
-    throw new Error("Manifest missing contracts.faucet (required for same-token-transfer)");
-  }
-  if (!manifest.contracts.counter) {
+  if (!counter) {
     throw new Error("Manifest missing contracts.counter (required for same-token-transfer)");
   }
-  const fpcAddress = AztecAddress.fromString(manifest.contracts.fpc);
-  const tokenAddress = AztecAddress.fromString(manifest.contracts.accepted_asset);
-  const faucetAddress = AztecAddress.fromString(manifest.contracts.faucet);
-  const counterAddress = AztecAddress.fromString(manifest.contracts.counter);
+  if (!faucet) {
+    throw new Error("Manifest missing contracts.faucet (required for same-token-transfer)");
+  }
 
-  pinoLogger.info(
-    `[same-token-transfer] manifest loaded. fpc=${manifest.contracts.fpc} token=${manifest.contracts.accepted_asset} faucet=${manifest.contracts.faucet}`,
-  );
-
-  // 2. Connect to node
-  const node = createAztecNodeClient(args.nodeUrl);
-  await waitForNode(node);
-  const wallet = await EmbeddedWallet.create(node, {
-    ephemeral: true,
-    pxeConfig: { proverEnabled: args.proverEnabled },
-  });
-
-  // 3. Setup operator account
-  const operatorSecretFr = Fr.fromHexString(args.operatorSecretKey);
-  const operatorAccount = await deriveAccount(operatorSecretFr, wallet);
-  const operator = operatorAccount.address;
-
-  pinoLogger.info(`[same-token-transfer] operator=${operator.toString()}`);
-
-  // 4. Register deployed contracts (faucet + counter for non-FPC operations)
-  const tokenArtifact = loadArtifact(path.join(repoRoot, "target", "token_contract-Token.json"));
-  const fpcArtifact = loadArtifact(resolveFpcArtifactPath(repoRoot));
-  const faucetArtifact = loadArtifact(path.join(repoRoot, "target", "faucet-Faucet.json"));
-  const counterArtifact = loadArtifact(path.join(repoRoot, "target", "mock_counter-Counter.json"));
-
-  const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
-  await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
-  const faucet = await registerAndGet(node, wallet, faucetAddress, faucetArtifact);
-  const counter = await registerAndGet(node, wallet, counterAddress, counterArtifact);
-
-  // Register the canonical SponsoredFPC contract (address derived from artifact + salt)
-  const sponsoredFpcInstance = await getContractInstanceFromInstantiationParams(
-    SponsoredFPCContractArtifact,
-    { salt: new Fr(SPONSORED_FPC_SALT) },
-  );
-  await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
-  const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcInstance.address);
-
-  // 5. Create FpcClient
   const fpcClient = new FpcClient({
-    fpcAddress,
+    fpcAddress: fpc.address,
     operator,
     node,
     attestationBaseUrl: args.attestationUrl,
   });
-
-  // 6. Wait for topup service to fund FPC with FeeJuice
-  pinoLogger.info("[same-token-transfer] waiting for FPC FeeJuice balance > 0 (via topup service)");
-
-  const FJ_POLL_MS = 2_000;
-  const FJ_TIMEOUT_MS = args.messageTimeoutSeconds * 1_000;
-  const fjDeadline = Date.now() + FJ_TIMEOUT_MS;
-  let fjBalance = 0n;
-  while (Date.now() <= fjDeadline) {
-    fjBalance = await getFeeJuiceBalance(fpcAddress, node);
-    if (fjBalance > 0n) break;
-    await new Promise((resolve) => setTimeout(resolve, FJ_POLL_MS));
-  }
-  if (fjBalance === 0n) {
-    throw new Error(`Timed out waiting for FPC FeeJuice balance on ${fpcAddress.toString()}`);
-  }
-
-  pinoLogger.info(`[same-token-transfer] FPC FeeJuice balance=${fjBalance}`);
 
   return {
     args,
@@ -188,11 +69,11 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     wallet,
     operator,
     fpcClient,
-    fpcAddress,
-    tokenAddress,
+    fpcAddress: fpc.address,
+    tokenAddress: token.address,
     token,
     faucet,
     counter,
-    sponsoredFeePayment,
+    sponsoredFeePayment: new SponsoredFeePaymentMethod(sponsoredFpcAddress),
   };
 }

--- a/scripts/same-token-transfer/test-same-token-transfer.ts
+++ b/scripts/same-token-transfer/test-same-token-transfer.ts
@@ -81,17 +81,23 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
   const operatorStartBalance = BigInt(operatorStartBalanceRaw.toString());
 
   // Assert: drip landed in public, then shield moved half to private
-  const userPrivBal = new PrivateBalanceTracker(token, user, "User", 0n);
+  const userPrivBal = await PrivateBalanceTracker.create(
+    token,
+    ctx.wallet,
+    userData.secret,
+    "User",
+  );
   await userPrivBal.change(shieldAmount);
 
-  const userPubBal = new PublicBalanceTracker(token, user, "User", 0n);
+  const userPubBal = new PublicBalanceTracker(token, user, "User");
   await userPubBal.change(dripAmount - shieldAmount);
 
   pinoLogger.info(`${LOG_PREFIX} PASS: faucet drip + shield succeeded`);
 
-  const operatorPrivBal = new PrivateBalanceTracker(
+  const operatorPrivBal = await PrivateBalanceTracker.create(
     token,
-    operator,
+    ctx.wallet,
+    args.operatorSecretKey,
     "Operator",
     operatorStartBalance,
     "atLeast",
@@ -101,9 +107,14 @@ export async function testSameTokenTransfer(ctx: TestContext): Promise<void> {
   // Phase 3: Transfer tokens to a fresh recipient via FPC fee_entrypoint
   // =========================================================================
 
-  const recipient = (await deriveAccount(Fr.random(), ctx.wallet)).address;
-  const recipientPrivBal = new PrivateBalanceTracker(token, recipient, "Recipient", 0n);
-  const recipientPubBal = new PublicBalanceTracker(token, recipient, "Recipient", 0n);
+  const recipientPrivBal = await PrivateBalanceTracker.create(
+    token,
+    ctx.wallet,
+    Fr.random(),
+    "Recipient",
+  );
+  const recipient = recipientPrivBal.address;
+  const recipientPubBal = new PublicBalanceTracker(token, recipient, "Recipient");
 
   pinoLogger.info(`${LOG_PREFIX} transferring tokens to recipient via FPC`);
 

--- a/scripts/services/fpc-full-lifecycle-e2e.ts
+++ b/scripts/services/fpc-full-lifecycle-e2e.ts
@@ -1,29 +1,21 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { BatchCall, Contract, type TxSendResultMined } from "@aztec/aztec.js/contracts";
+import { BatchCall, type Contract, type TxSendResultMined } from "@aztec/aztec.js/contracts";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
 import { Fr } from "@aztec/aztec.js/fields";
-import { type AztecNode, createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import type { AztecNode } from "@aztec/aztec.js/node";
 import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
-import { SPONSORED_FPC_SALT } from "@aztec/constants";
 import { Schnorr } from "@aztec/foundation/crypto/schnorr";
-import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
-import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
 import { computeInnerAuthWitHash } from "@aztec/stdlib/auth-witness";
-import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
 import { Gas, GasFees } from "@aztec/stdlib/gas";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
-import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { ExecutionPayload, type TxReceipt } from "@aztec/stdlib/tx";
-import { EmbeddedWallet } from "@aztec/wallets/embedded";
-import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
-import { sleep } from "../common/managed-process.ts";
+import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { deriveAccount } from "../common/script-credentials.ts";
+import { setup as commonSetup } from "../common/setup-helpers.ts";
 
 type FullE2EConfig = {
   nodeUrl: string;
@@ -67,10 +59,6 @@ const HEX_32_BYTE_PATTERN = /^0x[0-9a-fA-F]{64}$/;
 const MAX_QUOTE_VALIDITY_SECONDS = 3600;
 const QUOTE_DOMAIN_SEPARATOR = Fr.fromHexString("0x465043");
 
-const tokenArtifactPath = "token_contract-Token.json";
-const fpcArtifactPath = "fpc-FPCMultiAsset.json";
-const faucetArtifactPath = "faucet-Faucet.json";
-
 function readEnvPositiveInteger(name: string, fallback: number): number {
   const value = process.env[name];
   if (value === undefined) return fallback;
@@ -97,55 +85,6 @@ function assertPrivateKeyHex(value: string, fieldName: string): void {
 
 function ceilDiv(numerator: bigint, denominator: bigint): bigint {
   return (numerator + denominator - 1n) / denominator;
-}
-
-function loadArtifact(artifactPath: string): ContractArtifact {
-  const raw = readFileSync(artifactPath, "utf8");
-  const parsed = JSON.parse(raw) as NoirCompiledContract;
-  try {
-    return loadContractArtifact(parsed);
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes("Contract's public bytecode has not been transpiled")
-    ) {
-      return loadContractArtifactForPublic(parsed);
-    }
-    throw error;
-  }
-}
-
-async function registerAndGet(
-  node: AztecNode,
-  wallet: EmbeddedWallet,
-  address: AztecAddress,
-  artifact: ContractArtifact,
-) {
-  const instance = await node.getContract(address);
-  if (!instance) {
-    throw new Error(`Contract not found on node: ${address.toString()}`);
-  }
-  await wallet.registerContract(instance, artifact);
-  return Contract.at(address, artifact, wallet);
-}
-
-async function waitForPositiveFeeJuiceBalance(
-  node: AztecNode,
-  feePayerAddress: AztecAddress,
-  timeoutMs: number,
-  pollMs: number,
-): Promise<bigint> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    const balance = await getFeeJuiceBalance(feePayerAddress, node);
-    if (balance > 0n) {
-      return balance;
-    }
-    await sleep(pollMs);
-  }
-  throw new Error(
-    `Timed out waiting for positive Fee Juice balance on ${feePayerAddress.toString()}`,
-  );
 }
 
 function getFinalRate(config: FullE2EConfig): {
@@ -279,54 +218,29 @@ function getConfig(): FullE2EConfig {
 async function setupFromManifest(config: FullE2EConfig): Promise<DeploymentRuntimeResult> {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
 
-  // Read pre-deployed contract addresses from manifest.
-  if (!existsSync(config.manifestPath)) {
-    throw new Error(`Manifest not found: ${config.manifestPath}`);
+  const { node, wallet, operator, contracts, sponsoredFpcAddress } = await commonSetup(
+    {
+      nodeUrl: config.nodeUrl,
+      manifestPath: config.manifestPath,
+      proverEnabled: config.pxeProverEnabled,
+      messageTimeoutSeconds: Math.ceil(config.feeJuiceTimeoutMs / 1_000),
+    },
+    repoRoot,
+    "fpc-full-lifecycle-e2e",
+  );
+
+  const { token, fpc, faucet } = contracts;
+  if (!faucet) {
+    throw new Error("Manifest missing contracts.faucet (required for fpc-full-lifecycle-e2e)");
   }
-  const manifest = JSON.parse(readFileSync(config.manifestPath, "utf8")) as DevnetDeployManifest;
-  if (!manifest.contracts.faucet) {
-    throw new Error(`Faucet contract not found in manifest: ${config.manifestPath}`);
-  }
 
-  const fpcAddress = AztecAddress.fromString(manifest.contracts.fpc);
-  const tokenAddress = AztecAddress.fromString(manifest.contracts.accepted_asset);
-  const faucetAddress = AztecAddress.fromString(manifest.contracts.faucet);
-
-  // Connect to node and create wallet.
-  const node = createAztecNodeClient(config.nodeUrl);
-  await waitForNode(node);
-  const wallet = await EmbeddedWallet.create(node, {
-    ephemeral: true,
-    pxeConfig: { proverEnabled: config.pxeProverEnabled },
-  });
-
-  // Derive operator account and ensure it is deployed on-chain.
-  const operatorSecretFr = Fr.fromHexString(config.operatorSecretKey);
-  const operatorData = await deriveAccount(operatorSecretFr, wallet);
-  const operator = operatorData.address;
-  const operatorSecretHex = config.operatorSecretKey;
+  const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcAddress);
 
   // Derive fresh user and otherUser for negative scenarios.
   const userData = await deriveAccount(Fr.random(), wallet);
   const otherUserData = await deriveAccount(Fr.random(), wallet);
   const user = userData.address;
   const otherUser = otherUserData.address;
-
-  const tokenArtifact = loadArtifact(path.join(repoRoot, "target", tokenArtifactPath));
-  const fpcArtifact = loadArtifact(path.join(repoRoot, "target", fpcArtifactPath));
-  const faucetArtifact = loadArtifact(path.join(repoRoot, "target", faucetArtifactPath));
-
-  const token = await registerAndGet(node, wallet, tokenAddress, tokenArtifact);
-  const fpc = await registerAndGet(node, wallet, fpcAddress, fpcArtifact);
-  const faucet = await registerAndGet(node, wallet, faucetAddress, faucetArtifact);
-
-  // Register the canonical SponsoredFPC contract.
-  const sponsoredFpcInstance = await getContractInstanceFromInstantiationParams(
-    SponsoredFPCContractArtifact,
-    { salt: new Fr(SPONSORED_FPC_SALT) },
-  );
-  await wallet.registerContract(sponsoredFpcInstance, SponsoredFPCContractArtifact);
-  const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcInstance.address);
 
   // Deploy user and otherUser accounts via SponsoredFPC (batched).
   const deployBatch = new BatchCall(wallet, [
@@ -337,18 +251,19 @@ async function setupFromManifest(config: FullE2EConfig): Promise<DeploymentRunti
     from: AztecAddress.ZERO,
     fee: { paymentMethod: sponsoredFeePayment },
   });
+
   // Fund user via faucet drip + shield (batched via SponsoredFPC).
   const { result: faucetConfig } = await faucet.methods.get_config().simulate({ from: user });
   const dripAmount = BigInt(faucetConfig.drip_amount.toString());
-  const shieldAmount = dripAmount;
   const dripBatch = new BatchCall(wallet, [
     faucet.methods.drip(user),
-    token.methods.transfer_public_to_private(user, user, shieldAmount, Fr.random()),
+    token.methods.transfer_public_to_private(user, user, dripAmount, Fr.random()),
   ]);
   await dripBatch.send({
     from: user,
     fee: { paymentMethod: sponsoredFeePayment },
   });
+
   const minFees = await node.getCurrentMinFees();
   const gasLimits = new Gas(config.daGasLimit, config.l2GasLimit);
   const maxFeesPerGas = new GasFees(minFees.feePerDaGas, minFees.feePerL2Gas);
@@ -356,7 +271,7 @@ async function setupFromManifest(config: FullE2EConfig): Promise<DeploymentRunti
   return {
     repoRoot,
     operator,
-    operatorSecretHex,
+    operatorSecretHex: config.operatorSecretKey,
     user,
     otherUser,
     wallet,
@@ -425,13 +340,6 @@ describe("fpc full lifecycle e2e", () => {
     config = getConfig();
     result = await setupFromManifest(config);
     node = result.node;
-
-    await waitForPositiveFeeJuiceBalance(
-      node,
-      result.fpc.address,
-      config.feeJuiceTimeoutMs,
-      config.feeJuicePollMs,
-    );
   });
 
   it("rejects insufficient fee juice", async () => {

--- a/scripts/services/fpc-services-smoke.ts
+++ b/scripts/services/fpc-services-smoke.ts
@@ -1,15 +1,12 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
-
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
 import { Fr } from "@aztec/aztec.js/fields";
 import { type AztecNode, createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
-import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
 import { Schnorr, SchnorrSignature } from "@aztec/foundation/crypto/schnorr";
 import { Point } from "@aztec/foundation/curves/grumpkin";
-import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
 import { sleep } from "../common/managed-process.ts";
+import { readManifest, waitForFpcFeeJuice } from "../common/setup-helpers.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -109,23 +106,6 @@ async function waitForHealth(url: string, timeoutMs: number): Promise<Response> 
     await sleep(500);
   }
   throw new Error(`Timed out waiting for health at ${url}. Last error: ${lastError}`);
-}
-
-async function waitForPositiveFeeJuiceBalance(
-  node: AztecNode,
-  fpcAddress: AztecAddress,
-  timeoutMs: number,
-  pollMs: number,
-): Promise<bigint> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    const balance = await getFeeJuiceBalance(fpcAddress, node);
-    if (balance > 0n) {
-      return balance;
-    }
-    await sleep(pollMs);
-  }
-  throw new Error(`Timed out waiting for Fee Juice balance on ${fpcAddress}`);
 }
 
 async function getCurrentChainUnixSeconds(node: AztecNode): Promise<bigint> {
@@ -334,10 +314,7 @@ async function verifyQuoteSignature(
 // ---------------------------------------------------------------------------
 
 async function setupFromConfig(config: SmokeConfig): Promise<SmokeRuntimeResult> {
-  if (!existsSync(config.manifestPath)) {
-    throw new Error(`Manifest not found: ${config.manifestPath}`);
-  }
-  const manifest = JSON.parse(readFileSync(config.manifestPath, "utf8")) as DevnetDeployManifest;
+  const manifest = readManifest(config.manifestPath);
 
   const fpcAddress = AztecAddress.fromString(manifest.contracts.fpc);
   const tokenAddress = AztecAddress.fromString(manifest.contracts.accepted_asset);
@@ -352,8 +329,7 @@ async function setupFromConfig(config: SmokeConfig): Promise<SmokeRuntimeResult>
     false,
   );
 
-  const fjTimeoutMs = config.messageTimeoutSeconds * 1_000;
-  await waitForPositiveFeeJuiceBalance(node, fpcAddress, fjTimeoutMs, 2_000);
+  await waitForFpcFeeJuice(fpcAddress, node, config.messageTimeoutSeconds, "fpc-services-smoke");
 
   const minFees = await node.getCurrentMinFees();
   const quoteFjAmount =


### PR DESCRIPTION
## Summary
- New `scripts/common/setup-helpers.ts` with shared `setup()` that runs manifest reading, node connection, wallet creation, operator address from manifest, contract registration, SponsoredFPC registration, and FeeJuice polling
- `registerAndGet()` takes raw address hex + artifact path and handles `AztecAddress.fromString` / artifact loading internally
- `registerCoreContracts()` registers token + FPC (hardcoded `Fr.ZERO` secret key), with counter, faucet, and bridge conditionally registered based on manifest presence
- Rewrote `always-revert/setup.ts`, `same-token-transfer/setup.ts`, `cold-start/setup.ts` to call common `setup()` and only add test-specific logic (FpcClient, L1 infrastructure)
- Rewrote `fpc-full-lifecycle-e2e.ts` `setupFromManifest` to use common `setup()`, removing duplicated artifact loading, contract registration, and FeeJuice polling
- Replaced `ReturnType<typeof createAztecNodeClient>` with `AztecNode` throughout
- Net -204 lines