### PR TITLE
refactor: extract L1 infrastructure setup into common helper

### DIFF
--- a/scripts/cold-start/setup.ts
+++ b/scripts/cold-start/setup.ts
@@ -9,19 +9,14 @@
 import path from "node:path";
 import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import type { Contract } from "@aztec/aztec.js/contracts";
-import { L1ToL2TokenPortalManager } from "@aztec/aztec.js/ethereum";
+import type { L1ToL2TokenPortalManager } from "@aztec/aztec.js/ethereum";
 import type { AztecNode } from "@aztec/aztec.js/node";
-import { createExtendedL1Client } from "@aztec/ethereum/client";
 import type { ExtendedViemWalletClient } from "@aztec/ethereum/types";
-import { EthAddress } from "@aztec/foundation/eth-address";
-import { createLogger } from "@aztec/foundation/log";
-import { TestERC20Abi } from "@aztec/l1-artifacts";
 import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
-import { type Chain, extractChain, type GetContractReturnType, getContract, type Hex } from "viem";
-import * as viemChains from "viem/chains";
+import type { GetContractReturnType, Hex } from "viem";
 import { resolveScriptAccounts } from "../common/script-credentials.ts";
-import { setup as commonSetup } from "../common/setup-helpers.ts";
+import { setup as commonSetup, setupL1Infrastructure } from "../common/setup-helpers.ts";
 import type { CliArgs } from "./cli.ts";
 
 const pinoLogger = pino();
@@ -79,35 +74,20 @@ export async function setup(args: CliArgs): Promise<TestContext> {
     ({ l1PrivateKey } = await resolveScriptAccounts(args.nodeUrl, args.l1RpcUrl, wallet, 0));
   }
 
-  // Setup L1 infrastructure
-  const l1PortalAddress = manifest.l1_contracts.token_portal;
-  const l1Erc20Address = manifest.l1_contracts.erc20;
-
-  const nodeInfo = await node.getNodeInfo();
-  const l1Chain = extractChain({
-    chains: Object.values(viemChains) as readonly Chain[],
-    id: nodeInfo.l1ChainId,
-  });
-  const l1WalletClient = createExtendedL1Client([args.l1RpcUrl], l1PrivateKey, l1Chain);
-
   if (!args.l1DeployerKey) {
     throw new Error("Missing --l1-deployer-key or FPC_L1_DEPLOYER_KEY");
   }
-  const l1MintClient = createExtendedL1Client([args.l1RpcUrl], args.l1DeployerKey, l1Chain);
 
-  const l1Erc20 = getContract({
-    address: l1Erc20Address as Hex,
-    abi: TestERC20Abi,
-    client: l1MintClient,
+  // Setup L1 infrastructure
+  const { l1WalletClient, l1Erc20, portalManager } = await setupL1Infrastructure({
+    l1RpcUrl: args.l1RpcUrl,
+    l1PrivateKey,
+    l1DeployerKey: args.l1DeployerKey,
+    l1PortalAddress: manifest.l1_contracts.token_portal,
+    l1Erc20Address: manifest.l1_contracts.erc20,
+    node,
+    loggerName: "cold-start:bridge",
   });
-
-  const portalManager = new L1ToL2TokenPortalManager(
-    EthAddress.fromString(l1PortalAddress),
-    EthAddress.fromString(l1Erc20Address),
-    undefined,
-    l1WalletClient,
-    createLogger("cold-start:bridge"),
-  );
 
   return {
     args,

--- a/scripts/common/setup-helpers.ts
+++ b/scripts/common/setup-helpers.ts
@@ -12,10 +12,16 @@ import path from "node:path";
 import type { ContractArtifact } from "@aztec/aztec.js/abi";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Contract } from "@aztec/aztec.js/contracts";
+import { L1ToL2TokenPortalManager } from "@aztec/aztec.js/ethereum";
 import { Fr } from "@aztec/aztec.js/fields";
 import { type AztecNode, createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
 import { SPONSORED_FPC_SALT } from "@aztec/constants";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
+import type { ExtendedViemWalletClient } from "@aztec/ethereum/types";
+import { EthAddress } from "@aztec/foundation/eth-address";
+import { createLogger } from "@aztec/foundation/log";
+import { TestERC20Abi } from "@aztec/l1-artifacts";
 import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
 import { loadContractArtifact, loadContractArtifactForPublic } from "@aztec/stdlib/abi";
 import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
@@ -23,6 +29,8 @@ import type { NoirCompiledContract } from "@aztec/stdlib/noir";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import type { DevnetDeployManifest } from "@aztec-fpc/contract-deployment/src/devnet-manifest.ts";
 import pino from "pino";
+import { type Chain, extractChain, type GetContractReturnType, getContract, type Hex } from "viem";
+import * as viemChains from "viem/chains";
 
 const pinoLogger = pino();
 
@@ -191,6 +199,53 @@ export async function waitForFpcFeeJuice(
 
   pinoLogger.info(`[${label}] FPC FeeJuice balance=${balance}`);
   return balance;
+}
+
+// ---------------------------------------------------------------------------
+// L1 infrastructure
+// ---------------------------------------------------------------------------
+
+export type L1InfraArgs = {
+  l1RpcUrl: string;
+  l1PrivateKey: Hex;
+  l1DeployerKey: string;
+  l1PortalAddress: string;
+  l1Erc20Address: string;
+  node: AztecNode;
+  loggerName: string;
+};
+
+export type L1Infra = {
+  l1WalletClient: ExtendedViemWalletClient;
+  l1Erc20: GetContractReturnType;
+  portalManager: L1ToL2TokenPortalManager;
+};
+
+export async function setupL1Infrastructure(args: L1InfraArgs): Promise<L1Infra> {
+  const nodeInfo = await args.node.getNodeInfo();
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as readonly Chain[],
+    id: nodeInfo.l1ChainId,
+  });
+
+  const l1WalletClient = createExtendedL1Client([args.l1RpcUrl], args.l1PrivateKey, l1Chain);
+  const l1MintClient = createExtendedL1Client([args.l1RpcUrl], args.l1DeployerKey, l1Chain);
+
+  const l1Erc20 = getContract({
+    address: args.l1Erc20Address as Hex,
+    abi: TestERC20Abi,
+    client: l1MintClient,
+  });
+
+  const portalManager = new L1ToL2TokenPortalManager(
+    EthAddress.fromString(args.l1PortalAddress),
+    EthAddress.fromString(args.l1Erc20Address),
+    undefined,
+    l1WalletClient,
+    createLogger(args.loggerName),
+  );
+
+  return { l1WalletClient, l1Erc20, portalManager };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Moved L1 chain extraction, client creation, ERC20 contract setup, and portal manager instantiation from `cold-start/setup.ts` into a reusable `setupL1Infrastructure()` helper in `scripts/common/setup-helpers.ts`
- Exported `L1InfraArgs` and `L1Infra` types for the helper's input/output
- Simplified `cold-start/setup.ts` to call the new helper, trimming imports to type-only where possible