### PR TITLE
feat: add concurrent FPC E2E test for parallel cold starts and account deployments

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -213,6 +213,32 @@ services:
       topup:
         condition: service_healthy
 
+  e2e-concurrent:
+    image: nethermind/aztec-fpc-smoke:local
+    profiles: ["e2e", "full"]
+    entrypoint: ["bun", "test"]
+    command:
+      - "./scripts/services/fpc-concurrent-e2e.ts"
+    volumes:
+      - ./deployments/local:/app/data:ro
+    environment:
+      AZTEC_NODE_URL: "http://aztec-node:8080"
+      L1_RPC_URL: "http://anvil:8545"
+      FPC_ATTESTATION_URL: "http://attestation:3000"
+      FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_CONCURRENT_N: "${FPC_CONCURRENT_N:-20}"
+      FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+    depends_on:
+      block-producer:
+        condition: service_started
+      deploy:
+        condition: service_completed_successfully
+      attestation:
+        condition: service_healthy
+      topup:
+        condition: service_healthy
+
   smoke-same-token-transfer:
     image: nethermind/aztec-fpc-smoke:local
     profiles: ["smoke", "full"]
@@ -296,6 +322,8 @@ services:
       smoke-cold-start:
         condition: service_completed_successfully
       e2e-fpc:
+        condition: service_completed_successfully
+      e2e-concurrent:
         condition: service_completed_successfully
       smoke-same-token-transfer:
         condition: service_completed_successfully

--- a/scripts/services/fpc-concurrent-e2e.ts
+++ b/scripts/services/fpc-concurrent-e2e.ts
@@ -1,0 +1,303 @@
+import { beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import path from "node:path";
+
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import type { L2AmountClaim } from "@aztec/aztec.js/ethereum";
+import { Fr } from "@aztec/aztec.js/fields";
+import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
+import type { AztecNode } from "@aztec/aztec.js/node";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import { FpcClient } from "@aztec-fpc/sdk";
+import pino from "pino";
+import type { Hex } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+import { type AccountData, deriveAccount } from "../common/script-credentials.ts";
+import {
+  type CoreContracts,
+  setup as commonSetup,
+  registerCoreContracts,
+  setupL1Infrastructure,
+} from "../common/setup-helpers.ts";
+
+const pinoLogger = pino();
+const LABEL = "concurrent-e2e";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+type ConcurrentConfig = {
+  nodeUrl: string;
+  l1RpcUrl: string;
+  attestationBaseUrl: string;
+  manifestPath: string;
+  concurrentN: number;
+  claimAmount: bigint;
+  messageTimeoutSeconds: number;
+  proverEnabled: boolean;
+  l1PrivateKey: Hex | null;
+  l1DeployerKey: string;
+};
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) {
+    throw new Error(`Required environment variable ${name} is not set`);
+  }
+  return value.trim();
+}
+
+function getConfig(): ConcurrentConfig {
+  const concurrentNRaw = process.env.FPC_CONCURRENT_N?.trim();
+  const concurrentN = concurrentNRaw ? Number(concurrentNRaw) : 20;
+  if (!Number.isSafeInteger(concurrentN) || concurrentN < 1) {
+    throw new Error(`Invalid FPC_CONCURRENT_N: ${concurrentNRaw}`);
+  }
+
+  const claimAmountRaw = process.env.FPC_COLD_START_CLAIM_AMOUNT?.trim();
+  const claimAmount = claimAmountRaw ? BigInt(claimAmountRaw) : 10_000_000_000_000_000n;
+
+  const timeoutRaw = process.env.FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS?.trim();
+  const messageTimeoutSeconds = timeoutRaw ? Number(timeoutRaw) : 120;
+
+  const l1KeyRaw = process.env.FPC_L1_PRIVATE_KEY?.trim();
+
+  return {
+    nodeUrl: process.env.AZTEC_NODE_URL ?? "http://localhost:8080",
+    l1RpcUrl: requireEnv("L1_RPC_URL"),
+    attestationBaseUrl: requireEnv("FPC_ATTESTATION_URL"),
+    manifestPath: requireEnv("FPC_COLD_START_MANIFEST"),
+    concurrentN,
+    claimAmount,
+    messageTimeoutSeconds,
+    proverEnabled:
+      process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
+    l1PrivateKey: l1KeyRaw ? (l1KeyRaw as Hex) : null,
+    l1DeployerKey: requireEnv("FPC_L1_DEPLOYER_KEY"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// L1 funding via anvil_setBalance
+// ---------------------------------------------------------------------------
+
+async function fundL1Account(l1RpcUrl: string, address: string): Promise<void> {
+  const response = await fetch(l1RpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "anvil_setBalance",
+      params: [address, "0xDE0B6B3A7640000"],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`anvil_setBalance failed: HTTP ${response.status} ${response.statusText}`);
+  }
+  const result = (await response.json()) as { error?: { message: string } };
+  if (result.error) {
+    throw new Error(`anvil_setBalance RPC error: ${result.error.message}`);
+  }
+  pinoLogger.info(`[${LABEL}] funded L1 account ${address} with 1 ETH`);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type UserContext = {
+  index: number;
+  wallet: EmbeddedWallet;
+  account: AccountData;
+  contracts: CoreContracts;
+  bridgeClaim: L2AmountClaim;
+};
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+setDefaultTimeout(900_000);
+
+let users: UserContext[];
+let fpcClient: FpcClient;
+let tokenAddress: AztecAddress;
+let bridgeAddress: AztecAddress;
+let node: AztecNode;
+
+describe("fpc concurrent e2e", () => {
+  beforeAll(async () => {
+    const config = getConfig();
+    const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+    pinoLogger.info(`[${LABEL}] N=${config.concurrentN} claimAmount=${config.claimAmount}`);
+
+    // 1. Common setup — node, wallet, contracts, FPC FeeJuice wait
+    const {
+      manifest,
+      node: sharedNode,
+      wallet: sharedWallet,
+      operator,
+      contracts: sharedContracts,
+    } = await commonSetup(
+      {
+        nodeUrl: config.nodeUrl,
+        manifestPath: config.manifestPath,
+        proverEnabled: config.proverEnabled,
+        messageTimeoutSeconds: config.messageTimeoutSeconds,
+      },
+      repoRoot,
+      LABEL,
+    );
+
+    node = sharedNode;
+
+    if (!sharedContracts.bridge) {
+      throw new Error("Manifest missing contracts.bridge (required for concurrent e2e)");
+    }
+    if (!manifest.l1_contracts) {
+      throw new Error("Manifest missing l1_contracts (required for concurrent e2e)");
+    }
+
+    tokenAddress = sharedContracts.token.address;
+    bridgeAddress = sharedContracts.bridge.address;
+    const fpcAddress = sharedContracts.fpc.address;
+
+    // 2. L1 infrastructure
+    let l1PrivateKey: Hex;
+    if (config.l1PrivateKey) {
+      l1PrivateKey = config.l1PrivateKey;
+      pinoLogger.info(`[${LABEL}] using provided L1 private key`);
+    } else {
+      l1PrivateKey = generatePrivateKey();
+      const l1Account = privateKeyToAccount(l1PrivateKey);
+      await fundL1Account(config.l1RpcUrl, l1Account.address);
+    }
+
+    const { l1WalletClient, l1Erc20, portalManager } = await setupL1Infrastructure({
+      l1RpcUrl: config.l1RpcUrl,
+      l1PrivateKey,
+      l1DeployerKey: config.l1DeployerKey,
+      l1PortalAddress: manifest.l1_contracts.token_portal,
+      l1Erc20Address: manifest.l1_contracts.erc20,
+      node,
+      loggerName: "concurrent-e2e:bridge",
+    });
+
+    // 3. Mint total ERC20 on L1
+    const totalClaimAmount = config.claimAmount * BigInt(config.concurrentN);
+    const mintHash = await l1Erc20.write.mint([l1WalletClient.account.address, totalClaimAmount]);
+    await l1WalletClient.waitForTransactionReceipt({ hash: mintHash });
+    pinoLogger.info(`[${LABEL}] minted ${totalClaimAmount} ERC20 on L1`);
+
+    // 4. Derive N account addresses (using shared wallet) and bridge sequentially
+    pinoLogger.info(`[${LABEL}] deriving accounts and bridging for ${config.concurrentN} users`);
+    const secrets: Fr[] = [];
+    const bridgeClaims: L2AmountClaim[] = [];
+    for (let i = 0; i < config.concurrentN; i++) {
+      const secret = Fr.random();
+      const account = await deriveAccount(secret, sharedWallet);
+      secrets.push(secret);
+
+      const claim = await portalManager.bridgeTokensPrivate(
+        account.address,
+        config.claimAmount,
+        false,
+      );
+      pinoLogger.info(
+        `[${LABEL}] user[${i}] address=${account.address.toString()} messageHash=${claim.messageHash}`,
+      );
+      bridgeClaims.push(claim);
+    }
+
+    // 5. Concurrent L2 setup: per-user wallets, contract registration, account derivation, message wait
+    pinoLogger.info(`[${LABEL}] starting concurrent L2 setup for ${config.concurrentN} users`);
+    users = await Promise.all(
+      secrets.map(async (secret, i) => {
+        const wallet = await EmbeddedWallet.create(node, {
+          ephemeral: true,
+          pxeConfig: { proverEnabled: config.proverEnabled },
+        });
+        const contracts = await registerCoreContracts(repoRoot, manifest, node, wallet);
+        const account = await deriveAccount(secret, wallet);
+
+        const msgHash = Fr.fromHexString(bridgeClaims[i].messageHash as string);
+        await waitForL1ToL2MessageReady(node, msgHash, {
+          timeoutSeconds: config.messageTimeoutSeconds,
+        });
+        pinoLogger.info(`[${LABEL}] user[${i}] L2 setup complete`);
+
+        return { index: i, wallet, account, contracts, bridgeClaim: bridgeClaims[i] };
+      }),
+    );
+
+    // 6. Create shared FpcClient
+    fpcClient = new FpcClient({
+      fpcAddress,
+      operator,
+      node,
+      attestationBaseUrl: config.attestationBaseUrl,
+    });
+
+    pinoLogger.info(`[${LABEL}] setup complete — ${users.length} users ready`);
+  });
+
+  it(`${getConfig().concurrentN} concurrent cold starts`, async () => {
+    pinoLogger.info(`[${LABEL}] starting ${users.length} concurrent cold starts`);
+
+    const results = await Promise.all(
+      users.map((u) =>
+        fpcClient.executeColdStart({
+          wallet: u.wallet,
+          userAddress: u.account.address,
+          tokenAddress,
+          bridgeAddress,
+          bridgeClaim: u.bridgeClaim,
+        }),
+      ),
+    );
+
+    for (const [i, r] of results.entries()) {
+      pinoLogger.info(`[${LABEL}] user[${i}] cold-start tx=${r.txHash} fee=${r.txFee}`);
+      expect(r.txHash).toBeTruthy();
+      expect(r.txFee).toBeGreaterThan(0n);
+    }
+  });
+
+  it(`${getConfig().concurrentN} concurrent account deployments`, async () => {
+    pinoLogger.info(`[${LABEL}] starting ${users.length} concurrent account deployments`);
+
+    const results = await Promise.all(
+      users.map(async (u) => {
+        const deployMethod = await u.account.accountManager.getDeployMethod();
+        const { estimatedGas } = await deployMethod.simulate({
+          from: AztecAddress.ZERO,
+          fee: { estimateGas: true },
+          skipClassPublication: true,
+        });
+        if (!estimatedGas) {
+          throw new Error(`Failed to estimate gas for user[${u.index}] deploy`);
+        }
+        const pm = await fpcClient.createPaymentMethod({
+          wallet: u.wallet,
+          user: u.account.address,
+          tokenAddress,
+          estimatedGas,
+        });
+        const { receipt } = await deployMethod.send({
+          from: AztecAddress.ZERO,
+          fee: pm.fee,
+          skipClassPublication: true,
+        });
+        return receipt.txHash;
+      }),
+    );
+
+    for (const [i, txHash] of results.entries()) {
+      pinoLogger.info(`[${LABEL}] user[${i}] account deployed tx=${txHash.toString()}`);
+      expect(txHash).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `fpc-concurrent-e2e.ts` — spins up N independent PXE wallets, bridges tokens via L1, then runs N cold starts and N account deployments concurrently via `FpcClient`
- Uses `setupL1Infrastructure` from common helpers for L1 setup; `bridgeTokensPrivate(…, mint=true)` eliminates need for a deployer key
- Add `e2e-concurrent` Docker Compose service (profiles: `e2e`, `full`) with deps on `block-producer`, `deploy`, `attestation`, `topup`
- Add `e2e-concurrent` to `wait` service's `depends_on`