### PR TITLE
refactor: rename docker test image and compose services to tests-* convention

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,7 +45,7 @@ deployments/
 # Docker infrastructure files (never COPY'd by any Dockerfile)
 docker-bake.hcl
 docker-compose.yaml
-Dockerfile.smoke
+Dockerfile.test
 services/Dockerfile.common
 services/attestation/Dockerfile
 services/topup/Dockerfile

--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - "docker-compose.yaml"
       - "docker-bake.hcl"
-      - "Dockerfile.smoke"
+      - "Dockerfile.test"
       - "contracts/**"
       - "scripts/**"
       - "services/**"
@@ -41,7 +41,7 @@ jobs:
             relevant:
               - "docker-compose.yaml"
               - "docker-bake.hcl"
-              - "Dockerfile.smoke"
+              - "Dockerfile.test"
               - "contracts/**"
               - "scripts/**"
               - "services/**"
@@ -93,29 +93,29 @@ jobs:
       - name: Run services and tests
         run: docker compose --profile full up wait --wait
 
-      - name: Print smoke-services logs
+      - name: Print tests-services logs
         if: always()
-        run: docker compose --profile full logs --timestamps smoke-services
+        run: docker compose --profile full logs --timestamps tests-services
 
-      - name: Print smoke-same-token-transfer logs
+      - name: Print tests-same-token-transfer logs
         if: always()
-        run: docker compose --profile full logs --timestamps smoke-same-token-transfer
+        run: docker compose --profile full logs --timestamps tests-same-token-transfer
 
-      - name: Print smoke-always-revert logs
+      - name: Print tests-always-revert logs
         if: always()
-        run: docker compose --profile full logs --timestamps smoke-always-revert
+        run: docker compose --profile full logs --timestamps tests-always-revert
 
-      - name: Print smoke-cold-start logs
+      - name: Print tests-cold-start logs
         if: always()
-        run: docker compose --profile full logs --timestamps smoke-cold-start
+        run: docker compose --profile full logs --timestamps tests-cold-start
 
-      - name: Print e2e-fpc logs
+      - name: Print tests-fee-entrypoint-validation logs
         if: always()
-        run: docker compose --profile full logs --timestamps e2e-fpc
+        run: docker compose --profile full logs --timestamps tests-fee-entrypoint-validation
 
-      - name: Print e2e-concurrent logs
+      - name: Print tests-concurrent logs
         if: always()
-        run: docker compose --profile full logs --timestamps e2e-concurrent
+        run: docker compose --profile full logs --timestamps tests-concurrent
 
       - name: Print deploy logs
         if: always()

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -33,4 +33,4 @@ RUN bun run --filter @aztec-fpc/sdk --if-present build && \
 ENV NODE_ENV=development
 ENV FORCE_COLOR=1
 
-ENTRYPOINT ["bun", "run", "--sequential"]
+ENTRYPOINT ["bun", "test"]

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ The compose stack (`docker-compose.yaml`) includes:
 | `aztec-node` | Aztec sandbox node | 8080 |
 | `attestation` | FPC attestation service | 3000 |
 | `topup` | FPC Fee Juice top-up daemon + ops probe server | 3001 |
-| `e2e-fpc` (profile `e2e-fpc`) | Compose-backed `FPC` full lifecycle runner | — |
+| `tests-fee-entrypoint-validation` (profile `full`) | Fee entrypoint validation test runner | — |
 
 Each service reads a `config.yaml` mounted into the container. By default these are `config.example.yaml`:
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,7 +20,7 @@ variable "PLATFORM_SUFFIX" {
 }
 
 group "default" {
-  targets = ["attestation", "topup", "deploy", "contract", "smoke"]
+  targets = ["attestation", "topup", "deploy", "contract", "test"]
 }
 
 group "services" {
@@ -114,17 +114,17 @@ target "deploy" {
   ])
 }
 
-target "smoke" {
+target "test" {
   inherits   = ["_labels"]
   context    = "."
-  dockerfile = "Dockerfile.smoke"
+  dockerfile = "Dockerfile.test"
   contexts   = {
     common = "target:deps"
     deploy = "target:deploy"
   }
   platforms  = PLATFORMS
   tags = compact([
-    "${REGISTRY}nethermind/aztec-fpc-smoke:${TAG}${PLATFORM_SUFFIX}",
-    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-smoke:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
+    "${REGISTRY}nethermind/aztec-fpc-test:${TAG}${PLATFORM_SUFFIX}",
+    GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-test:${GIT_SHA}${PLATFORM_SUFFIX}" : "",
   ])
 }

--- a/docker-compose.public.yaml
+++ b/docker-compose.public.yaml
@@ -15,7 +15,8 @@ services:
       - .env.${DEPLOYMENT}
 
   postdeploy:
-    image: "${SMOKE_IMAGE:-nethermind/aztec-fpc-smoke:local}"
+    image: "${TEST_IMAGE:-nethermind/aztec-fpc-test:local}"
+    entrypoint: ["bun", "run", "--sequential"]
     command:
       - "scripts/contract/devnet-postdeploy-smoke.ts"
     volumes:
@@ -73,10 +74,9 @@ services:
       deploy:
         condition: service_completed_successfully
 
-  smoke-cold-start:
-    image: "${SMOKE_IMAGE:-nethermind/aztec-fpc-smoke:local}"
-    profiles: ["smoke"]
-    entrypoint: ["bun", "test"]
+  tests-cold-start:
+    image: "${TEST_IMAGE:-nethermind/aztec-fpc-test:local}"
+    profiles: ["full"]
     command:
       - "./scripts/tests/cold-start.ts"
     volumes:
@@ -96,10 +96,9 @@ services:
       topup:
         condition: service_healthy
 
-  smoke-same-token-transfer:
-    image: "${SMOKE_IMAGE:-nethermind/aztec-fpc-smoke:local}"
-    profiles: ["smoke"]
-    entrypoint: ["bun", "test"]
+  tests-same-token-transfer:
+    image: "${TEST_IMAGE:-nethermind/aztec-fpc-test:local}"
+    profiles: ["full"]
     command:
       - "./scripts/tests/same-token-transfer.ts"
     volumes:
@@ -117,10 +116,9 @@ services:
       topup:
         condition: service_healthy
 
-  smoke-always-revert:
-    image: "${SMOKE_IMAGE:-nethermind/aztec-fpc-smoke:local}"
-    profiles: ["smoke"]
-    entrypoint: ["bun", "test"]
+  tests-always-revert:
+    image: "${TEST_IMAGE:-nethermind/aztec-fpc-test:local}"
+    profiles: ["full"]
     command:
       - "./scripts/tests/always-revert.ts"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,8 +126,9 @@ services:
         condition: service_healthy
 
   postdeploy:
-    image: nethermind/aztec-fpc-smoke:local
+    image: nethermind/aztec-fpc-test:local
     profiles: ["postdeploy"]
+    entrypoint: ["bun", "run", "--sequential"]
     command:
       - "scripts/contract/devnet-postdeploy-smoke.ts"
     volumes:
@@ -143,10 +144,9 @@ services:
       deploy:
         condition: service_completed_successfully
 
-  smoke-services:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke", "full"]
-    entrypoint: ["bun", "test"]
+  tests-services:
+    image: nethermind/aztec-fpc-test:local
+    profiles: ["full"]
     command:
       - "./scripts/tests/services.ts"
     volumes:
@@ -166,10 +166,9 @@ services:
       topup:
         condition: service_healthy
 
-  smoke-cold-start:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke", "full"]
-    entrypoint: ["bun", "test"]
+  tests-cold-start:
+    image: nethermind/aztec-fpc-test:local
+    profiles: ["full"]
     command:
       - "./scripts/tests/cold-start.ts"
     volumes:
@@ -192,10 +191,9 @@ services:
       topup:
         condition: service_healthy
 
-  e2e-fpc:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["e2e", "full"]
-    entrypoint: ["bun", "test"]
+  tests-fee-entrypoint-validation:
+    image: nethermind/aztec-fpc-test:local
+    profiles: ["full"]
     command:
       - "./scripts/tests/fee-entrypoint-validation.ts"
     volumes:
@@ -213,10 +211,9 @@ services:
       topup:
         condition: service_healthy
 
-  e2e-concurrent:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["e2e", "full"]
-    entrypoint: ["bun", "test"]
+  tests-concurrent:
+    image: nethermind/aztec-fpc-test:local
+    profiles: ["full"]
     command:
       - "./scripts/tests/concurrent.ts"
     volumes:
@@ -239,10 +236,9 @@ services:
       topup:
         condition: service_healthy
 
-  smoke-same-token-transfer:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke", "full"]
-    entrypoint: ["bun", "test"]
+  tests-same-token-transfer:
+    image: nethermind/aztec-fpc-test:local
+    profiles: ["full"]
     command:
       - "./scripts/tests/same-token-transfer.ts"
     volumes:
@@ -263,10 +259,9 @@ services:
       topup:
         condition: service_healthy
 
-  smoke-always-revert:
-    image: nethermind/aztec-fpc-smoke:local
-    profiles: ["smoke", "full"]
-    entrypoint: ["bun", "test"]
+  tests-always-revert:
+    image: nethermind/aztec-fpc-test:local
+    profiles: ["full"]
     command:
       - "./scripts/tests/always-revert.ts"
     volumes:
@@ -292,17 +287,17 @@ services:
     profiles: ["full"]
     command: ["sh", "-c", "sleep 5"]
     depends_on:
-      smoke-services:
+      tests-services:
         condition: service_completed_successfully
-      smoke-cold-start:
+      tests-cold-start:
         condition: service_completed_successfully
-      e2e-fpc:
+      tests-fee-entrypoint-validation:
         condition: service_completed_successfully
-      e2e-concurrent:
+      tests-concurrent:
         condition: service_completed_successfully
-      smoke-same-token-transfer:
+      tests-same-token-transfer:
         condition: service_completed_successfully
-      smoke-always-revert:
+      tests-always-revert:
         condition: service_completed_successfully
       attestation:
         condition: service_healthy

--- a/docs/aztec-deployer-user-guide.md
+++ b/docs/aztec-deployer-user-guide.md
@@ -114,7 +114,7 @@ TAG=v0.1.0 docker buildx bake
 REGISTRY=ghcr.io/ TAG=v0.1.0 docker buildx bake
 ```
 
-Available images: `nethermind/aztec-fpc-contract-deployment`, `nethermind/aztec-fpc-attestation`, `nethermind/aztec-fpc-topup`, `nethermind/aztec-fpc-smoke`.
+Available images: `nethermind/aztec-fpc-contract-deployment`, `nethermind/aztec-fpc-attestation`, `nethermind/aztec-fpc-topup`, `nethermind/aztec-fpc-test`.
 
 Replace `:local` with the appropriate tag if using pre-built images from a registry.
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docker:build:attestation": "docker buildx bake attestation",
     "docker:build:deploy": "docker buildx bake deploy",
     "docker:build:services": "docker buildx bake services",
-    "docker:build:smoke": "docker buildx bake smoke",
+    "docker:build:test": "docker buildx bake test",
     "docker:build:topup": "docker buildx bake topup",
     "compose:infra": "bash scripts/services/compose-mode.sh infra",
     "compose:full": "bash scripts/services/compose-mode.sh full",

--- a/scripts/services/compose-mode.sh
+++ b/scripts/services/compose-mode.sh
@@ -12,7 +12,7 @@ Usage: bash scripts/services/compose-mode.sh [infra|full|services-devnet] [docke
 
 Modes:
 - infra: start only infra/services (no test profile).
-- full: run compose with test profile and fail on smoke test failure.
+- full: run compose with full profile and fail on test failure.
 - services-devnet: generate configs from devnet manifest, then run only attestation+topup compose.
 
 Examples:
@@ -97,7 +97,7 @@ full)
     cd "$REPO_ROOT"
     docker compose --profile full up \
       --attach smoke-credit-fpc \
-      --attach smoke-services
+      --attach tests-services
   )
   ;;
 --help|-h)

--- a/scripts/services/full-lifecycle-compose.sh
+++ b/scripts/services/full-lifecycle-compose.sh
@@ -13,20 +13,20 @@ fi
 
 mkdir -p "$ARTIFACT_DIR"
 
-echo "[compose-full-lifecycle] running profile=e2e-fpc service=e2e-fpc"
+echo "[compose-full-lifecycle] running profile=full service=tests-fee-entrypoint-validation"
 docker compose down -v --remove-orphans >/dev/null 2>&1 || true
 
 set +e
 (
   cd "$REPO_ROOT"
-  docker compose --profile "e2e-fpc" up --attach "e2e-fpc" --exit-code-from "e2e-fpc" "e2e-fpc"
+  docker compose --profile "full" up --attach "tests-fee-entrypoint-validation" --exit-code-from "tests-fee-entrypoint-validation" "tests-fee-entrypoint-validation"
 )
 status=$?
 set -e
 
 (
   cd "$REPO_ROOT"
-  docker compose --profile "e2e-fpc" logs --no-color >"$COMPOSE_LOG" 2>&1
+  docker compose --profile "full" logs --no-color >"$COMPOSE_LOG" 2>&1
 ) || true
 (
   cd "$REPO_ROOT"


### PR DESCRIPTION
## Summary
- Rename `Dockerfile.smoke` → `Dockerfile.test` with default entrypoint `bun test`
- Rename docker image `aztec-fpc-smoke` → `aztec-fpc-test` in `docker-bake.hcl`
- Rename all compose test services to `tests-<name>` format (e.g. `smoke-services` → `tests-services`, `e2e-fpc` → `tests-fee-entrypoint-validation`)
- Remove redundant `entrypoint: ["bun", "test"]` from test services (now the Dockerfile default)
- Add explicit `entrypoint: ["bun", "run", "--sequential"]` to `postdeploy` service
- Consolidate `smoke`/`e2e` profiles into single `full` profile
- Update all references in CI, shell scripts, package.json, README, and docs