### PR TITLE
feat: add separate test token manifest and reconfigure tests to read from it

### DIFF
--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -6,14 +6,15 @@ import { Contract, type DeployOptions } from "@aztec/aztec.js/contracts";
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { Schnorr } from "@aztec/foundation/crypto/schnorr";
-import { EthAddress } from "@aztec/foundation/eth-address";
+
 import { deriveKeys, deriveSigningKey } from "@aztec/stdlib/keys";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import pino from "pino";
 import { createPublicClient, http } from "viem";
 import { deployContract, loadArtifact, REQUIRED_ARTIFACTS } from "./deploy-utils.js";
 import { type DeployManifest, writeDeployManifest } from "./manifest.js";
-import { deployTestTokenEcosystem, type FaucetEnvConfig } from "./test-token-ecosystem.js";
+import { deployTestToken } from "./test-token.js";
+import type { TestTokenManifest } from "./test-token-manifest.js";
 
 const pinoLogger = pino();
 
@@ -30,6 +31,7 @@ type CliArgs = {
   acceptedAsset: string | null;
   l1DeployerKey: string | null;
   out: string;
+  testTokenOut: string;
   proverEnabled: boolean;
   preflightOnly: boolean;
 };
@@ -94,6 +96,7 @@ function usage(): string {
     "Outputs:",
     `  --data-dir <dir>                 Data directory for artifacts (default: ${DEVNET_DEFAULT_DATA_DIR}) [env: FPC_DATA_DIR]`,
     "  --out <path.json>                Output manifest path (default: $FPC_DATA_DIR/manifest.json) [env: FPC_OUT]",
+    "  --test-token-out <path.json>     Test token manifest path (default: $FPC_DATA_DIR/test-token-manifest.json) [env: FPC_TEST_TOKEN_OUT]",
     "",
     "  --help, -h                       Show this help",
     "",
@@ -191,6 +194,9 @@ function parseCliArgs(argv: string[]): CliParseResult {
   let dataDir: string = process.env.FPC_DATA_DIR ?? DEVNET_DEFAULT_DATA_DIR;
   let outExplicit = !!process.env.FPC_OUT;
   let out: string = process.env.FPC_OUT ?? path.join(dataDir, "manifest.json");
+  let testTokenOutExplicit = !!process.env.FPC_TEST_TOKEN_OUT;
+  let testTokenOut: string =
+    process.env.FPC_TEST_TOKEN_OUT ?? path.join(dataDir, "test-token-manifest.json");
   let proverEnabled = process.env.PXE_PROVER_ENABLED
     ? parseBooleanFlag(process.env.PXE_PROVER_ENABLED, "PXE_PROVER_ENABLED")
     : true;
@@ -251,6 +257,11 @@ function parseCliArgs(argv: string[]): CliParseResult {
         outExplicit = true;
         i += 1;
         break;
+      case "--test-token-out":
+        testTokenOut = nextArg(argv, i, arg);
+        testTokenOutExplicit = true;
+        i += 1;
+        break;
       case "--pxe-prover-enabled":
         proverEnabled = parseBooleanFlag(nextArg(argv, i, arg), arg);
         i += 1;
@@ -269,6 +280,9 @@ function parseCliArgs(argv: string[]): CliParseResult {
 
   if (!outExplicit) {
     out = path.join(dataDir, "manifest.json");
+  }
+  if (!testTokenOutExplicit) {
+    testTokenOut = path.join(dataDir, "test-token-manifest.json");
   }
 
   if (validateTopupPath && !l1RpcUrl) {
@@ -328,6 +342,7 @@ function parseCliArgs(argv: string[]): CliParseResult {
       acceptedAsset: acceptedAsset ? parseAztecAddress(acceptedAsset, "--accepted-asset") : null,
       l1DeployerKey: l1DeployerKey ? parseHex32(l1DeployerKey, "--l1-deployer-key") : null,
       out,
+      testTokenOut,
       proverEnabled,
       preflightOnly,
     },
@@ -509,12 +524,7 @@ async function main(): Promise<void> {
   }
 
   let acceptedAssetAddress: AztecAddress;
-  let bridgeAddress: AztecAddress | undefined;
-  let counterAddress: AztecAddress | undefined;
-  let l1TokenPortalAddress: string | undefined;
-  let l1Erc20Address: string | undefined;
-  let faucetAddress: AztecAddress | undefined;
-  let faucetConfig: FaucetEnvConfig | undefined;
+  let testTokenManifest: TestTokenManifest | undefined;
 
   if (args.acceptedAsset) {
     acceptedAssetAddress = AztecAddress.fromString(args.acceptedAsset);
@@ -527,7 +537,7 @@ async function main(): Promise<void> {
         "Token deployment requires --l1-deployer-key and --l1-rpc-url for L1 bridge contracts.",
       );
     }
-    const ecosystem = await deployTestTokenEcosystem({
+    testTokenManifest = await deployTestToken({
       l1DeployerKey: args.l1DeployerKey,
       l1RpcUrl: args.l1RpcUrl,
       l1ChainId: nodeInfo.l1ChainId,
@@ -536,14 +546,9 @@ async function main(): Promise<void> {
       node,
       operatorAddress,
       deployOpts,
+      outPath: args.testTokenOut,
     });
-    acceptedAssetAddress = ecosystem.acceptedAssetAddress;
-    bridgeAddress = ecosystem.bridgeAddress;
-    counterAddress = ecosystem.counterAddress;
-    l1TokenPortalAddress = ecosystem.l1TokenPortalAddress;
-    l1Erc20Address = ecosystem.l1Erc20Address;
-    faucetAddress = ecosystem.faucetAddress;
-    faucetConfig = ecosystem.faucetConfig;
+    acceptedAssetAddress = testTokenManifest.contracts.token;
   }
 
   const fpcArtifact = loadArtifact(fpcArtifactPath);
@@ -586,16 +591,18 @@ async function main(): Promise<void> {
     contracts: {
       accepted_asset: acceptedAssetAddress,
       fpc: AztecAddress.fromString(fpcAddress),
-      ...(faucetAddress ? { faucet: faucetAddress } : {}),
-      ...(counterAddress ? { counter: counterAddress } : {}),
-      ...(bridgeAddress ? { bridge: bridgeAddress } : {}),
+      ...(testTokenManifest
+        ? {
+            faucet: testTokenManifest.contracts.faucet,
+            counter: testTokenManifest.contracts.counter,
+            bridge: testTokenManifest.contracts.bridge,
+          }
+        : {}),
     },
-    ...(l1TokenPortalAddress && l1Erc20Address
+    ...(testTokenManifest
       ? {
-          l1_contracts: {
-            token_portal: EthAddress.fromString(l1TokenPortalAddress),
-            erc20: EthAddress.fromString(l1Erc20Address),
-          },
+          l1_contracts: testTokenManifest.l1_contracts,
+          faucet_config: testTokenManifest.faucet_config,
         }
       : {}),
     fpc_artifact: {
@@ -613,15 +620,6 @@ async function main(): Promise<void> {
       counter_deploy: null,
       bridge_deploy: null,
     },
-    ...(faucetConfig
-      ? {
-          faucet_config: {
-            drip_amount: faucetConfig.dripAmount.toString(),
-            cooldown_seconds: faucetConfig.cooldownSeconds,
-            initial_supply: faucetConfig.initialSupply.toString(),
-          },
-        }
-      : {}),
     payment_mode: paymentMode,
   };
   writeDeployManifest(args.out, manifest);

--- a/contract-deployment/src/manifest-types.ts
+++ b/contract-deployment/src/manifest-types.ts
@@ -1,0 +1,57 @@
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { Fr } from "@aztec/aztec.js/fields";
+import { EthAddress } from "@aztec/foundation/eth-address";
+import { z } from "zod";
+
+export const aztecAddress = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{64}$/, "expected 0x-prefixed 64-hex-char Aztec address")
+  .refine((v) => !/^0x0{64}$/i.test(v), "zero address not allowed")
+  .transform((v) => AztecAddress.fromString(v));
+
+export const ethAddress = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{40}$/, "expected 0x-prefixed 40-hex-char EVM address")
+  .refine((v) => !/^0x0{40}$/i.test(v), "zero address not allowed")
+  .transform((v) => EthAddress.fromString(v));
+
+export const txHash = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{64}$/, "expected 0x-prefixed 64-hex-char tx hash")
+  .refine((v) => !/^0x0{64}$/i.test(v), "zero hash not allowed");
+
+export const fieldValue = z
+  .string()
+  .regex(
+    /^(?:0|[1-9][0-9]*|0x[0-9a-fA-F]+)$/,
+    "expected decimal integer or 0x-prefixed hex field value",
+  )
+  .transform((v) => Fr.fromHexString(v));
+
+export const httpUrl = z
+  .string()
+  .url()
+  .refine((v) => {
+    const p = new URL(v).protocol;
+    return p === "http:" || p === "https:";
+  }, "expected http(s) URL");
+
+export const isoTimestamp = z
+  .string()
+  .refine((v) => !Number.isNaN(Date.parse(v)), "expected ISO timestamp");
+
+export const positiveSafeInt = z
+  .number()
+  .int()
+  .positive()
+  .refine((v) => Number.isSafeInteger(v), "expected safe integer");
+
+export const nonNegativeSafeInt = z
+  .number()
+  .int()
+  .nonnegative()
+  .refine((v) => Number.isSafeInteger(v), "expected safe integer");
+
+export const decimalUint = z
+  .string()
+  .regex(/^(?:0|[1-9][0-9]*)$/, "expected non-negative decimal integer");

--- a/contract-deployment/src/manifest.ts
+++ b/contract-deployment/src/manifest.ts
@@ -1,64 +1,17 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { Fr } from "@aztec/aztec.js/fields";
-import { EthAddress } from "@aztec/foundation/eth-address";
 import { z } from "zod";
-
-// ── Custom Zod primitives ───────────────────────────────────────────
-
-const aztecAddress = z
-  .string()
-  .regex(/^0x[0-9a-fA-F]{64}$/, "expected 0x-prefixed 64-hex-char Aztec address")
-  .refine((v) => !/^0x0{64}$/i.test(v), "zero address not allowed")
-  .transform((v) => AztecAddress.fromString(v));
-
-const ethAddress = z
-  .string()
-  .regex(/^0x[0-9a-fA-F]{40}$/, "expected 0x-prefixed 40-hex-char EVM address")
-  .refine((v) => !/^0x0{40}$/i.test(v), "zero address not allowed")
-  .transform((v) => EthAddress.fromString(v));
-
-const txHash = z
-  .string()
-  .regex(/^0x[0-9a-fA-F]{64}$/, "expected 0x-prefixed 64-hex-char tx hash")
-  .refine((v) => !/^0x0{64}$/i.test(v), "zero hash not allowed");
-
-const fieldValue = z
-  .string()
-  .regex(
-    /^(?:0|[1-9][0-9]*|0x[0-9a-fA-F]+)$/,
-    "expected decimal integer or 0x-prefixed hex field value",
-  )
-  .transform((v) => Fr.fromHexString(v));
-
-const httpUrl = z
-  .string()
-  .url()
-  .refine((v) => {
-    const p = new URL(v).protocol;
-    return p === "http:" || p === "https:";
-  }, "expected http(s) URL");
-
-const isoTimestamp = z
-  .string()
-  .refine((v) => !Number.isNaN(Date.parse(v)), "expected ISO timestamp");
-
-const positiveSafeInt = z
-  .number()
-  .int()
-  .positive()
-  .refine((v) => Number.isSafeInteger(v), "expected safe integer");
-
-const nonNegativeSafeInt = z
-  .number()
-  .int()
-  .nonnegative()
-  .refine((v) => Number.isSafeInteger(v), "expected safe integer");
-
-const decimalUint = z
-  .string()
-  .regex(/^(?:0|[1-9][0-9]*)$/, "expected non-negative decimal integer");
+import {
+  aztecAddress,
+  decimalUint,
+  ethAddress,
+  fieldValue,
+  httpUrl,
+  isoTimestamp,
+  nonNegativeSafeInt,
+  positiveSafeInt,
+  txHash,
+} from "./manifest-types.js";
 
 // ── Schema ──────────────────────────────────────────────────────────
 

--- a/contract-deployment/src/test-token-manifest.ts
+++ b/contract-deployment/src/test-token-manifest.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import {
+  aztecAddress,
+  decimalUint,
+  ethAddress,
+  isoTimestamp,
+  nonNegativeSafeInt,
+} from "./manifest-types.js";
+
+// ── Schema ──────────────────────────────────────────────────────────
+
+const testTokenManifestSchema = z.object({
+  status: z.literal("deploy_ok"),
+  generated_at: isoTimestamp,
+  contracts: z.object({
+    token: aztecAddress,
+    faucet: aztecAddress,
+    counter: aztecAddress,
+    bridge: aztecAddress,
+  }),
+  l1_contracts: z.object({
+    token_portal: ethAddress,
+    erc20: ethAddress,
+  }),
+  faucet_config: z.object({
+    drip_amount: decimalUint,
+    cooldown_seconds: nonNegativeSafeInt,
+    initial_supply: decimalUint,
+  }),
+});
+
+// ── Derived type ────────────────────────────────────────────────────
+
+export type TestTokenManifest = z.infer<typeof testTokenManifestSchema>;
+
+// ── Public API ──────────────────────────────────────────────────────
+
+export function readTestTokenManifest(filePath: string): TestTokenManifest {
+  const absolute = path.resolve(filePath);
+  const raw = JSON.parse(readFileSync(absolute, "utf8"));
+  return testTokenManifestSchema.parse(raw);
+}
+
+export function writeTestTokenManifest(outPath: string, manifest: TestTokenManifest): void {
+  const absolute = path.resolve(outPath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}

--- a/contract-deployment/src/test-token.ts
+++ b/contract-deployment/src/test-token.ts
@@ -18,13 +18,14 @@ import pino from "pino";
 import { type Chain, extractChain, type Hex } from "viem";
 import * as viemChains from "viem/chains";
 import { deployContract, loadArtifact, REQUIRED_ARTIFACTS } from "./deploy-utils.js";
+import { type TestTokenManifest, writeTestTokenManifest } from "./test-token-manifest.js";
 
 const logger = pino();
 
 const DECIMAL_UINT_PATTERN = /^(0|[1-9][0-9]*)$/;
 const HEX_FIELD_PATTERN = /^0x[0-9a-fA-F]+$/;
 
-export type FaucetEnvConfig = {
+type FaucetEnvConfig = {
   dripAmount: bigint;
   cooldownSeconds: number;
   initialSupply: bigint;
@@ -84,24 +85,14 @@ function readFaucetEnvConfig(): FaucetEnvConfig {
   return { dripAmount, cooldownSeconds, initialSupply };
 }
 
-export type TestTokenEcosystem = {
-  acceptedAssetAddress: AztecAddress;
-  bridgeAddress: AztecAddress;
-  counterAddress: AztecAddress;
-  l1TokenPortalAddress: string;
-  l1Erc20Address: string;
-  faucetAddress: AztecAddress;
-  faucetConfig: FaucetEnvConfig;
-};
-
 /**
- * Deploy a full test token ecosystem: L1 ERC20 + TokenPortal, L2 TokenBridge +
+ * Deploy a full test token stack: L1 ERC20 + TokenPortal, L2 TokenBridge +
  * Token + Faucet, and fund the faucet via the L1→L2 bridge.
  *
  * This is only used for testing/devnet — production deployments should provide
  * an existing --accepted-asset instead.
  */
-export async function deployTestTokenEcosystem(opts: {
+export async function deployTestToken(opts: {
   l1DeployerKey: string;
   l1RpcUrl: string;
   l1ChainId: number;
@@ -110,7 +101,8 @@ export async function deployTestTokenEcosystem(opts: {
   node: AztecNode;
   operatorAddress: AztecAddress;
   deployOpts: DeployOptions;
-}): Promise<TestTokenEcosystem> {
+  outPath: string;
+}): Promise<TestTokenManifest> {
   const l1WalletClient = createExtendedL1Client(
     [opts.l1RpcUrl],
     opts.l1DeployerKey as Hex,
@@ -260,13 +252,27 @@ export async function deployTestTokenEcosystem(opts: {
     `[deploy-fpc-devnet] L2 batch 4 completed (faucet deploy + claim_public, ${faucetConfig.initialSupply} tokens)`,
   );
 
-  return {
-    acceptedAssetAddress: tokenAddress,
-    bridgeAddress,
-    counterAddress,
-    l1TokenPortalAddress,
-    l1Erc20Address,
-    faucetAddress,
-    faucetConfig,
+  const manifest: TestTokenManifest = {
+    status: "deploy_ok",
+    generated_at: new Date().toISOString(),
+    contracts: {
+      token: tokenAddress,
+      faucet: faucetAddress,
+      counter: counterAddress,
+      bridge: bridgeAddress,
+    },
+    l1_contracts: {
+      token_portal: EthAddress.fromString(l1TokenPortalAddress),
+      erc20: EthAddress.fromString(l1Erc20Address),
+    },
+    faucet_config: {
+      drip_amount: faucetConfig.dripAmount.toString(),
+      cooldown_seconds: faucetConfig.cooldownSeconds,
+      initial_supply: faucetConfig.initialSupply.toString(),
+    },
   };
+  writeTestTokenManifest(opts.outPath, manifest);
+  logger.info(`[deploy-fpc-devnet] wrote test token manifest to ${opts.outPath}`);
+
+  return manifest;
 }

--- a/docker-compose.public.yaml
+++ b/docker-compose.public.yaml
@@ -11,6 +11,7 @@ services:
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
       FPC_DATA_DIR: "/app/data"
+      FPC_TEST_TOKEN_OUT: "/app/data/test-token-manifest.json"
     env_file:
       - .env.${DEPLOYMENT}
 
@@ -84,6 +85,7 @@ services:
     environment:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY}"
       FPC_L1_USER_KEY: "${FPC_L1_USER_KEY}"
@@ -106,6 +108,7 @@ services:
     environment:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     env_file:
@@ -126,6 +129,7 @@ services:
     environment:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     env_file:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
       FPC_DATA_DIR: "/app/data"
+      FPC_TEST_TOKEN_OUT: "/app/data/test-token-manifest.json"
     depends_on:
       aztec-node:
         condition: service_healthy
@@ -156,6 +157,7 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_TOPUP_OPS_URL: "http://topup:3001"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
     depends_on:
       block-producer:
         condition: service_started
@@ -178,6 +180,7 @@ services:
       L1_RPC_URL: "http://anvil:8545"
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
@@ -201,6 +204,7 @@ services:
     environment:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     depends_on:
@@ -223,6 +227,7 @@ services:
       L1_RPC_URL: "http://anvil:8545"
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_CONCURRENT_N: "${FPC_CONCURRENT_N:-20}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
@@ -247,6 +252,7 @@ services:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     depends_on:
@@ -270,6 +276,7 @@ services:
       AZTEC_NODE_URL: "http://aztec-node:8080"
       FPC_ATTESTATION_URL: "http://attestation:3000"
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
     depends_on:

--- a/scripts/common/setup-helpers.ts
+++ b/scripts/common/setup-helpers.ts
@@ -31,6 +31,10 @@ import {
   type DeployManifest,
   readDeployManifest,
 } from "@aztec-fpc/contract-deployment/src/manifest.ts";
+import {
+  readTestTokenManifest,
+  type TestTokenManifest,
+} from "@aztec-fpc/contract-deployment/src/test-token-manifest.ts";
 import pino from "pino";
 import { type Chain, extractChain, type GetContractReturnType, getContract, type Hex } from "viem";
 import * as viemChains from "viem/chains";
@@ -103,14 +107,15 @@ export async function connectAndCreateWallet(nodeUrl: string, proverEnabled: boo
 export type CoreContracts = {
   token: Contract;
   fpc: Contract;
-  counter?: Contract;
-  faucet?: Contract;
-  bridge?: Contract;
+  counter: Contract;
+  faucet: Contract;
+  bridge: Contract;
 };
 
 export async function registerCoreContracts(
   repoRoot: string,
   manifest: DeployManifest,
+  testTokenManifest: TestTokenManifest,
   node: AztecNode,
   wallet: EmbeddedWallet,
 ): Promise<CoreContracts> {
@@ -119,7 +124,7 @@ export async function registerCoreContracts(
   const token = await registerAndGet(
     node,
     wallet,
-    manifest.contracts.accepted_asset,
+    testTokenManifest.contracts.token,
     path.join(target, "token_contract-Token.json"),
   );
   const fpc = await registerAndGet(
@@ -129,33 +134,24 @@ export async function registerCoreContracts(
     path.join(target, "fpc-FPCMultiAsset.json"),
     Fr.ZERO,
   );
-
-  const counter = manifest.contracts.counter
-    ? await registerAndGet(
-        node,
-        wallet,
-        manifest.contracts.counter,
-        path.join(target, "mock_counter-Counter.json"),
-      )
-    : undefined;
-
-  const faucet = manifest.contracts.faucet
-    ? await registerAndGet(
-        node,
-        wallet,
-        manifest.contracts.faucet,
-        path.join(target, "faucet-Faucet.json"),
-      )
-    : undefined;
-
-  const bridge = manifest.contracts.bridge
-    ? await registerAndGet(
-        node,
-        wallet,
-        manifest.contracts.bridge,
-        path.join(target, "token_bridge_contract-TokenBridge.json"),
-      )
-    : undefined;
+  const counter = await registerAndGet(
+    node,
+    wallet,
+    testTokenManifest.contracts.counter,
+    path.join(target, "mock_counter-Counter.json"),
+  );
+  const faucet = await registerAndGet(
+    node,
+    wallet,
+    testTokenManifest.contracts.faucet,
+    path.join(target, "faucet-Faucet.json"),
+  );
+  const bridge = await registerAndGet(
+    node,
+    wallet,
+    testTokenManifest.contracts.bridge,
+    path.join(target, "token_bridge_contract-TokenBridge.json"),
+  );
 
   return { token, fpc, counter, faucet, bridge };
 }
@@ -257,12 +253,14 @@ export async function setupL1Infrastructure(args: L1InfraArgs): Promise<L1Infra>
 export type SetupArgs = {
   nodeUrl: string;
   manifestPath: string;
+  testTokenManifestPath: string;
   proverEnabled: boolean;
   messageTimeoutSeconds: number;
 };
 
 export type SetupResult = {
   manifest: DeployManifest;
+  testTokenManifest: TestTokenManifest;
   node: AztecNode;
   wallet: EmbeddedWallet;
   operator: AztecAddress;
@@ -278,11 +276,13 @@ export async function setup(
   pinoLogger.info(`[${label}] starting`);
   pinoLogger.info(`[${label}] node_url=${args.nodeUrl}`);
   pinoLogger.info(`[${label}] manifest=${args.manifestPath}`);
+  pinoLogger.info(`[${label}] test_token_manifest=${args.testTokenManifestPath}`);
 
   const manifest = readManifest(args.manifestPath);
+  const testTokenManifest = readTestTokenManifest(args.testTokenManifestPath);
 
   pinoLogger.info(
-    `[${label}] manifest loaded. fpc=${manifest.contracts.fpc} token=${manifest.contracts.accepted_asset}`,
+    `[${label}] manifests loaded. fpc=${manifest.contracts.fpc} token=${testTokenManifest.contracts.token}`,
   );
 
   const { node, wallet } = await connectAndCreateWallet(args.nodeUrl, args.proverEnabled);
@@ -290,11 +290,17 @@ export async function setup(
   const operator = manifest.operator.address;
   pinoLogger.info(`[${label}] operator=${operator.toString()}`);
 
-  const contracts = await registerCoreContracts(repoRoot, manifest, node, wallet);
+  const contracts = await registerCoreContracts(
+    repoRoot,
+    manifest,
+    testTokenManifest,
+    node,
+    wallet,
+  );
 
   const sponsoredFpcAddress = await registerSponsoredFpc(wallet);
 
   await waitForFpcFeeJuice(contracts.fpc.address, node, args.messageTimeoutSeconds, label);
 
-  return { manifest, node, wallet, operator, contracts, sponsoredFpcAddress };
+  return { manifest, testTokenManifest, node, wallet, operator, contracts, sponsoredFpcAddress };
 }

--- a/scripts/tests/always-revert.ts
+++ b/scripts/tests/always-revert.ts
@@ -19,6 +19,7 @@ type AlwaysRevertConfig = {
   nodeUrl: string;
   attestationUrl: string;
   manifestPath: string;
+  testTokenManifestPath: string;
   operatorSecretKey: Fr;
   proverEnabled: boolean;
   messageTimeoutSeconds: number;
@@ -73,6 +74,7 @@ function getConfig(): AlwaysRevertConfig {
     nodeUrl: process.env.AZTEC_NODE_URL ?? "http://localhost:8080",
     attestationUrl: requireEnv("FPC_ATTESTATION_URL"),
     manifestPath: requireEnv("FPC_COLD_START_MANIFEST"),
+    testTokenManifestPath: requireEnv("FPC_TEST_TOKEN_MANIFEST"),
     operatorSecretKey: Fr.fromHexString(requireEnv("FPC_OPERATOR_SECRET_KEY")),
     proverEnabled:
       process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
@@ -88,6 +90,7 @@ async function setupFromManifest(config: AlwaysRevertConfig): Promise<SetupResul
     {
       nodeUrl: config.nodeUrl,
       manifestPath: config.manifestPath,
+      testTokenManifestPath: config.testTokenManifestPath,
       proverEnabled: config.proverEnabled,
       messageTimeoutSeconds: config.messageTimeoutSeconds,
     },
@@ -96,12 +99,6 @@ async function setupFromManifest(config: AlwaysRevertConfig): Promise<SetupResul
   );
 
   const { token, fpc, counter, faucet } = contracts;
-  if (!counter) {
-    throw new Error("Manifest missing contracts.counter (required for always-revert)");
-  }
-  if (!faucet) {
-    throw new Error("Manifest missing contracts.faucet (required for always-revert)");
-  }
 
   const fpcClient = new FpcClient({
     fpcAddress: fpc.address,

--- a/scripts/tests/cold-start.ts
+++ b/scripts/tests/cold-start.ts
@@ -44,6 +44,7 @@ type ColdStartConfig = {
   l1RpcUrl: string;
   attestationUrl: string;
   manifestPath: string;
+  testTokenManifestPath: string;
   operatorSecretKey: Fr;
   l1DeployerKey: string;
   userL1PrivateKey: string | null;
@@ -98,6 +99,7 @@ function getConfig(): ColdStartConfig {
     l1RpcUrl: requireEnv("L1_RPC_URL"),
     attestationUrl: requireEnv("FPC_ATTESTATION_URL"),
     manifestPath: path.resolve(requireEnv("FPC_COLD_START_MANIFEST")),
+    testTokenManifestPath: path.resolve(requireEnv("FPC_TEST_TOKEN_MANIFEST")),
     operatorSecretKey,
     l1DeployerKey,
     userL1PrivateKey,
@@ -145,7 +147,7 @@ describe("cold-start smoke", () => {
     const repoRoot = path.resolve(import.meta.dirname, "../..");
 
     const {
-      manifest,
+      testTokenManifest,
       node: n,
       wallet: w,
       operator: op,
@@ -155,6 +157,7 @@ describe("cold-start smoke", () => {
       {
         nodeUrl: config.nodeUrl,
         manifestPath: config.manifestPath,
+        testTokenManifestPath: config.testTokenManifestPath,
         proverEnabled: config.proverEnabled,
         messageTimeoutSeconds: config.messageTimeoutSeconds,
       },
@@ -168,10 +171,6 @@ describe("cold-start smoke", () => {
     sponsoredFpcAddress = sfpc;
 
     const { token: t, fpc, counter: c, bridge } = contracts;
-
-    if (!c) throw new Error("Manifest missing contracts.counter");
-    if (!bridge) throw new Error("Manifest missing contracts.bridge");
-    if (!manifest.l1_contracts) throw new Error("Manifest missing l1_contracts");
 
     token = t;
     counter = c;
@@ -191,8 +190,8 @@ describe("cold-start smoke", () => {
       l1RpcUrl: config.l1RpcUrl,
       l1PrivateKey,
       l1DeployerKey: config.l1DeployerKey,
-      l1PortalAddress: manifest.l1_contracts.token_portal,
-      l1Erc20Address: manifest.l1_contracts.erc20,
+      l1PortalAddress: testTokenManifest.l1_contracts.token_portal,
+      l1Erc20Address: testTokenManifest.l1_contracts.erc20,
       node,
       loggerName: "cold-start:bridge",
     });

--- a/scripts/tests/concurrent.ts
+++ b/scripts/tests/concurrent.ts
@@ -32,6 +32,7 @@ type ConcurrentConfig = {
   l1RpcUrl: string;
   attestationBaseUrl: string;
   manifestPath: string;
+  testTokenManifestPath: string;
   concurrentN: number;
   claimAmount: bigint;
   messageTimeoutSeconds: number;
@@ -68,6 +69,7 @@ function getConfig(): ConcurrentConfig {
     l1RpcUrl: requireEnv("L1_RPC_URL"),
     attestationBaseUrl: requireEnv("FPC_ATTESTATION_URL"),
     manifestPath: requireEnv("FPC_COLD_START_MANIFEST"),
+    testTokenManifestPath: requireEnv("FPC_TEST_TOKEN_MANIFEST"),
     concurrentN,
     claimAmount,
     messageTimeoutSeconds,
@@ -137,6 +139,7 @@ describe("fpc concurrent e2e", () => {
     // 1. Common setup — node, wallet, contracts, FPC FeeJuice wait
     const {
       manifest,
+      testTokenManifest,
       node: sharedNode,
       wallet: sharedWallet,
       operator,
@@ -145,6 +148,7 @@ describe("fpc concurrent e2e", () => {
       {
         nodeUrl: config.nodeUrl,
         manifestPath: config.manifestPath,
+        testTokenManifestPath: config.testTokenManifestPath,
         proverEnabled: config.proverEnabled,
         messageTimeoutSeconds: config.messageTimeoutSeconds,
       },
@@ -153,13 +157,6 @@ describe("fpc concurrent e2e", () => {
     );
 
     node = sharedNode;
-
-    if (!sharedContracts.bridge) {
-      throw new Error("Manifest missing contracts.bridge (required for concurrent e2e)");
-    }
-    if (!manifest.l1_contracts) {
-      throw new Error("Manifest missing l1_contracts (required for concurrent e2e)");
-    }
 
     tokenAddress = sharedContracts.token.address;
     bridgeAddress = sharedContracts.bridge.address;
@@ -180,8 +177,8 @@ describe("fpc concurrent e2e", () => {
       l1RpcUrl: config.l1RpcUrl,
       l1PrivateKey,
       l1DeployerKey: config.l1DeployerKey,
-      l1PortalAddress: manifest.l1_contracts.token_portal,
-      l1Erc20Address: manifest.l1_contracts.erc20,
+      l1PortalAddress: testTokenManifest.l1_contracts.token_portal,
+      l1Erc20Address: testTokenManifest.l1_contracts.erc20,
       node,
       loggerName: "concurrent-e2e:bridge",
     });
@@ -220,7 +217,13 @@ describe("fpc concurrent e2e", () => {
           ephemeral: true,
           pxeConfig: { proverEnabled: config.proverEnabled },
         });
-        const contracts = await registerCoreContracts(repoRoot, manifest, node, wallet);
+        const contracts = await registerCoreContracts(
+          repoRoot,
+          manifest,
+          testTokenManifest,
+          node,
+          wallet,
+        );
         const account = await deriveAccount(secret, wallet);
 
         const msgHash = Fr.fromHexString(bridgeClaims[i].messageHash as string);

--- a/scripts/tests/fee-entrypoint-validation.ts
+++ b/scripts/tests/fee-entrypoint-validation.ts
@@ -20,6 +20,7 @@ import { setup as commonSetup } from "../common/setup-helpers.ts";
 type FullE2EConfig = {
   nodeUrl: string;
   manifestPath: string;
+  testTokenManifestPath: string;
   operatorSecretKey: string;
   feeJuiceTimeoutMs: number;
   feeJuicePollMs: number;
@@ -192,6 +193,7 @@ function requireEnv(name: string): string {
 
 function getConfig(): FullE2EConfig {
   const manifestPath = requireEnv("FPC_COLD_START_MANIFEST");
+  const testTokenManifestPath = requireEnv("FPC_TEST_TOKEN_MANIFEST");
   const operatorSecretKey = requireEnv("FPC_OPERATOR_SECRET_KEY");
   assertPrivateKeyHex(operatorSecretKey, "FPC_OPERATOR_SECRET_KEY");
   const feeBips = readEnvPositiveInteger("FPC_FULL_E2E_FEE_BIPS", 200);
@@ -202,6 +204,7 @@ function getConfig(): FullE2EConfig {
   return {
     nodeUrl: process.env.AZTEC_NODE_URL ?? "http://localhost:8080",
     manifestPath,
+    testTokenManifestPath,
     operatorSecretKey,
     feeJuiceTimeoutMs: readEnvPositiveInteger("FPC_FULL_E2E_FEE_JUICE_TIMEOUT_MS", 240_000),
     feeJuicePollMs: readEnvPositiveInteger("FPC_FULL_E2E_FEE_JUICE_POLL_MS", 2_000),
@@ -222,6 +225,7 @@ async function setupFromManifest(config: FullE2EConfig): Promise<DeploymentRunti
     {
       nodeUrl: config.nodeUrl,
       manifestPath: config.manifestPath,
+      testTokenManifestPath: config.testTokenManifestPath,
       proverEnabled: config.pxeProverEnabled,
       messageTimeoutSeconds: Math.ceil(config.feeJuiceTimeoutMs / 1_000),
     },
@@ -230,9 +234,6 @@ async function setupFromManifest(config: FullE2EConfig): Promise<DeploymentRunti
   );
 
   const { token, fpc, faucet } = contracts;
-  if (!faucet) {
-    throw new Error("Manifest missing contracts.faucet (required for fpc-full-lifecycle-e2e)");
-  }
 
   const sponsoredFeePayment = new SponsoredFeePaymentMethod(sponsoredFpcAddress);
 

--- a/scripts/tests/same-token-transfer.ts
+++ b/scripts/tests/same-token-transfer.ts
@@ -20,6 +20,7 @@ type SameTokenTransferConfig = {
   nodeUrl: string;
   attestationUrl: string;
   manifestPath: string;
+  testTokenManifestPath: string;
   operatorSecretKey: Fr;
   pxeProverEnabled: boolean;
   aaPaymentAmount: bigint;
@@ -82,6 +83,7 @@ function getConfig(): SameTokenTransferConfig {
     nodeUrl: process.env.AZTEC_NODE_URL ?? "http://localhost:8080",
     attestationUrl: requireEnv("FPC_ATTESTATION_URL"),
     manifestPath: requireEnv("FPC_COLD_START_MANIFEST"),
+    testTokenManifestPath: requireEnv("FPC_TEST_TOKEN_MANIFEST"),
     operatorSecretKey: Fr.fromHexString(requireEnv("FPC_OPERATOR_SECRET_KEY")),
     pxeProverEnabled:
       process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
@@ -101,6 +103,7 @@ async function setupFromConfig(config: SameTokenTransferConfig): Promise<SetupRe
     {
       nodeUrl: config.nodeUrl,
       manifestPath: config.manifestPath,
+      testTokenManifestPath: config.testTokenManifestPath,
       proverEnabled: config.pxeProverEnabled,
       messageTimeoutSeconds: config.messageTimeoutSeconds,
     },
@@ -108,13 +111,7 @@ async function setupFromConfig(config: SameTokenTransferConfig): Promise<SetupRe
     "same-token-transfer",
   );
 
-  const { token, fpc, counter, faucet } = contracts;
-  if (!counter) {
-    throw new Error("Manifest missing contracts.counter (required for same-token-transfer)");
-  }
-  if (!faucet) {
-    throw new Error("Manifest missing contracts.faucet (required for same-token-transfer)");
-  }
+  const { token, fpc, faucet } = contracts;
 
   const fpcClient = new FpcClient({
     fpcAddress: fpc.address,


### PR DESCRIPTION
## Summary
- Add `test-token-manifest.ts` with Zod schema, `TestTokenManifest` type, `readTestTokenManifest`, `writeTestTokenManifest`
- Extract shared Zod primitives into `manifest-types.ts`, imported by both manifest modules
- `deployTestToken` (renamed from `deployTestTokenEcosystem`) returns `TestTokenManifest` directly, replacing the old `TestTokenEcosystem` type
- Rename `accepted_asset` → `token` in the test token manifest schema
- Add `--test-token-out` CLI arg / `FPC_TEST_TOKEN_OUT` env var (default: `$FPC_DATA_DIR/test-token-manifest.json`)
- `setup-helpers.ts` reads both manifests; `registerCoreContracts` takes `TestTokenManifest` for token/counter/faucet/bridge; `CoreContracts` fields now required
- 5 test scripts read `FPC_TEST_TOKEN_MANIFEST`; dead null checks removed
- `docker-compose.yaml` and `docker-compose.public.yaml` updated with `FPC_TEST_TOKEN_OUT` and `FPC_TEST_TOKEN_MANIFEST`