### PR TITLE
refactor: populate tx_hashes and remove dead deploy manifest fields

### DIFF
--- a/contract-deployment/src/deploy-utils.ts
+++ b/contract-deployment/src/deploy-utils.ts
@@ -72,7 +72,7 @@ export async function deployContract(
   deployMethod: DeployMethod<Contract>,
   sendOptions: DeployOptions,
   extraCalls?: ContractFunctionInteraction[],
-): Promise<void> {
+): Promise<string> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const opts = { ...sendOptions };
@@ -86,12 +86,12 @@ export async function deployContract(
 
       if (extraCalls && extraCalls.length > 0) {
         const batch = new BatchCall(wallet, [deployMethod, ...extraCalls]);
-        await batch.send(opts);
-        return;
+        const { receipt } = await batch.send(opts);
+        return receipt.txHash.toString();
       }
 
-      await deployMethod.send(opts);
-      return;
+      const { receipt } = await deployMethod.send(opts);
+      return receipt.txHash.toString();
     } catch (error) {
       if (isClassPublicationRace(error) && attempt < MAX_RETRIES) {
         pinoLogger.info(

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -481,8 +481,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  const paymentMode = args.sponsoredFpcAddress ? "fpc-sponsored" : "fee_juice";
-
   // --- JS API wallet setup for contract deployments ---
   const wallet = await EmbeddedWallet.create(node, {
     pxeConfig: { proverEnabled: args.proverEnabled },
@@ -563,7 +561,7 @@ async function main(): Promise<void> {
     operatorIdentity.pubkeyY,
   ]);
   const fpcAddress = (await fpcDeployMethod.getInstance()).address.toString();
-  await deployContract(wallet, fpcArtifact, fpcDeployMethod, deployOpts);
+  const fpcDeployTxHash = await deployContract(wallet, fpcArtifact, fpcDeployMethod, deployOpts);
   pinoLogger.info(`[deploy-fpc-devnet] fpc deployed. address=${fpcAddress}`);
 
   const feeAssetHandlerAddress = nodeInfo.l1ContractAddresses.feeAssetHandlerAddress;
@@ -591,23 +589,6 @@ async function main(): Promise<void> {
     contracts: {
       accepted_asset: acceptedAssetAddress,
       fpc: AztecAddress.fromString(fpcAddress),
-      ...(testTokenManifest
-        ? {
-            faucet: testTokenManifest.contracts.faucet,
-            counter: testTokenManifest.contracts.counter,
-            bridge: testTokenManifest.contracts.bridge,
-          }
-        : {}),
-    },
-    ...(testTokenManifest
-      ? {
-          l1_contracts: testTokenManifest.l1_contracts,
-          faucet_config: testTokenManifest.faucet_config,
-        }
-      : {}),
-    fpc_artifact: {
-      name: "FPCMultiAsset",
-      path: fpcArtifactPath,
     },
     operator: {
       address: AztecAddress.fromString(operatorIdentity.address),
@@ -615,12 +596,8 @@ async function main(): Promise<void> {
       pubkey_y: Fr.fromHexString(operatorIdentity.pubkeyY),
     },
     tx_hashes: {
-      accepted_asset_deploy: null,
-      fpc_deploy: null,
-      counter_deploy: null,
-      bridge_deploy: null,
+      fpc_deploy: fpcDeployTxHash,
     },
-    payment_mode: paymentMode,
   };
   writeDeployManifest(args.out, manifest);
 
@@ -628,7 +605,7 @@ async function main(): Promise<void> {
     `[deploy-fpc-devnet] deployment completed. wrote manifest to ${path.resolve(args.out)}`,
   );
   pinoLogger.info(
-    `[deploy-fpc-devnet] output contracts: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} faucet=${manifest.contracts.faucet ?? "n/a"} counter=${manifest.contracts.counter ?? "n/a"} bridge=${manifest.contracts.bridge ?? "n/a"} variant=${fpcArtifact.name}`,
+    `[deploy-fpc-devnet] output contracts: accepted_asset=${manifest.contracts.accepted_asset} fpc=${manifest.contracts.fpc} variant=${fpcArtifact.name}`,
   );
 
   process.exit(0);

--- a/contract-deployment/src/manifest.ts
+++ b/contract-deployment/src/manifest.ts
@@ -3,12 +3,10 @@ import path from "node:path";
 import { z } from "zod";
 import {
   aztecAddress,
-  decimalUint,
   ethAddress,
   fieldValue,
   httpUrl,
   isoTimestamp,
-  nonNegativeSafeInt,
   positiveSafeInt,
   txHash,
 } from "./manifest-types.js";
@@ -46,42 +44,15 @@ const deployManifestSchema = z.object({
   contracts: z.object({
     accepted_asset: aztecAddress,
     fpc: aztecAddress,
-    faucet: aztecAddress.optional(),
-    counter: aztecAddress.optional(),
-    bridge: aztecAddress.optional(),
   }),
-  l1_contracts: z
-    .object({
-      token_portal: ethAddress,
-      erc20: ethAddress,
-    })
-    .optional(),
-  fpc_artifact: z
-    .object({
-      name: z.literal("FPCMultiAsset"),
-      path: z.string().min(1),
-    })
-    .optional(),
   operator: z.object({
     address: aztecAddress,
     pubkey_x: fieldValue,
     pubkey_y: fieldValue,
   }),
   tx_hashes: z.object({
-    accepted_asset_deploy: txHash.nullable(),
-    fpc_deploy: txHash.nullable(),
-    faucet_deploy: txHash.nullable().optional(),
-    counter_deploy: txHash.nullable().optional(),
-    bridge_deploy: txHash.nullable().optional(),
+    fpc_deploy: txHash,
   }),
-  faucet_config: z
-    .object({
-      drip_amount: decimalUint,
-      cooldown_seconds: nonNegativeSafeInt,
-      initial_supply: decimalUint,
-    })
-    .optional(),
-  payment_mode: z.string().min(1).optional(),
 });
 
 // ── Derived type ────────────────────────────────────────────────────

--- a/contract-deployment/src/test-token-manifest.ts
+++ b/contract-deployment/src/test-token-manifest.ts
@@ -7,6 +7,7 @@ import {
   ethAddress,
   isoTimestamp,
   nonNegativeSafeInt,
+  txHash,
 } from "./manifest-types.js";
 
 // ── Schema ──────────────────────────────────────────────────────────
@@ -28,6 +29,14 @@ const testTokenManifestSchema = z.object({
     drip_amount: decimalUint,
     cooldown_seconds: nonNegativeSafeInt,
     initial_supply: decimalUint,
+  }),
+  tx_hashes: z.object({
+    token_deploy: txHash,
+    bridge_deploy: txHash,
+    counter_deploy: txHash,
+    faucet_deploy: txHash,
+    l1_erc20_deploy: txHash,
+    l1_token_portal_deploy: txHash,
   }),
 });
 

--- a/contract-deployment/src/test-token.ts
+++ b/contract-deployment/src/test-token.ts
@@ -219,17 +219,31 @@ export async function deployTestToken(opts: {
 
   // ── Phase 2: L2 batch 1 — bridge deploy + set_config (4 units) ────
   const bridgeContract = Contract.at(bridgeAddress, bridgeArtifact, opts.wallet);
-  await deployContract(opts.wallet, bridgeArtifact, bridgeDeploy, opts.deployOpts, [
-    bridgeContract.methods.set_config(tokenAddress, EthAddress.fromString(l1TokenPortalAddress)),
-  ]);
+  const bridgeDeployTxHash = await deployContract(
+    opts.wallet,
+    bridgeArtifact,
+    bridgeDeploy,
+    opts.deployOpts,
+    [bridgeContract.methods.set_config(tokenAddress, EthAddress.fromString(l1TokenPortalAddress))],
+  );
   logger.info("[deploy-fpc-devnet] L2 batch 1 completed (bridge deploy + set_config)");
 
   // ── Phase 3: L2 batch 2 — token deploy ─────────────────────────────
-  await deployContract(opts.wallet, tokenArtifact, tokenDeploy, opts.deployOpts);
+  const tokenDeployTxHash = await deployContract(
+    opts.wallet,
+    tokenArtifact,
+    tokenDeploy,
+    opts.deployOpts,
+  );
   logger.info("[deploy-fpc-devnet] L2 batch 2 completed (token deploy)");
 
   // ── Phase 4: L2 batch 3 — counter deploy ───────────────────────────
-  await deployContract(opts.wallet, counterArtifact, counterDeploy, opts.deployOpts);
+  const counterDeployTxHash = await deployContract(
+    opts.wallet,
+    counterArtifact,
+    counterDeploy,
+    opts.deployOpts,
+  );
   logger.info("[deploy-fpc-devnet] L2 batch 3 completed (counter deploy)");
 
   // ── Phase 5: Wait for L1→L2 message ───────────────────────────────
@@ -240,14 +254,20 @@ export async function deployTestToken(opts: {
   logger.info("[deploy-fpc-devnet] L1→L2 message ready");
 
   // ── Phase 6: L2 batch 4 — faucet deploy + claim_public (4 units) ──
-  await deployContract(opts.wallet, faucetArtifact, faucetDeploy, opts.deployOpts, [
-    bridgeContract.methods.claim_public(
-      faucetAddress,
-      faucetBridgeClaim.claimAmount,
-      faucetBridgeClaim.claimSecret,
-      faucetBridgeClaim.messageLeafIndex,
-    ),
-  ]);
+  const faucetDeployTxHash = await deployContract(
+    opts.wallet,
+    faucetArtifact,
+    faucetDeploy,
+    opts.deployOpts,
+    [
+      bridgeContract.methods.claim_public(
+        faucetAddress,
+        faucetBridgeClaim.claimAmount,
+        faucetBridgeClaim.claimSecret,
+        faucetBridgeClaim.messageLeafIndex,
+      ),
+    ],
+  );
   logger.info(
     `[deploy-fpc-devnet] L2 batch 4 completed (faucet deploy + claim_public, ${faucetConfig.initialSupply} tokens)`,
   );
@@ -269,6 +289,14 @@ export async function deployTestToken(opts: {
       drip_amount: faucetConfig.dripAmount.toString(),
       cooldown_seconds: faucetConfig.cooldownSeconds,
       initial_supply: faucetConfig.initialSupply.toString(),
+    },
+    tx_hashes: {
+      token_deploy: tokenDeployTxHash,
+      bridge_deploy: bridgeDeployTxHash,
+      counter_deploy: counterDeployTxHash,
+      faucet_deploy: faucetDeployTxHash,
+      l1_erc20_deploy: l1Erc20Hash,
+      l1_token_portal_deploy: l1PortalHash,
     },
   };
   writeTestTokenManifest(opts.outPath, manifest);

--- a/docker-compose.public.yaml
+++ b/docker-compose.public.yaml
@@ -24,6 +24,7 @@ services:
       - ./deployments/${DEPLOYMENT}:/app/data:ro
     environment:
       FPC_DEVNET_SMOKE_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       L1_OPERATOR_PRIVATE_KEY: "${FPC_L1_DEPLOYER_KEY}"
     env_file:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -136,6 +136,7 @@ services:
       - ./deployments/local:/app/data:ro
     environment:
       FPC_DEVNET_SMOKE_MANIFEST: "/app/data/manifest.json"
+      FPC_TEST_TOKEN_MANIFEST: "/app/data/test-token-manifest.json"
       L1_RPC_URL: "http://anvil:8545"
       FPC_OPERATOR_SECRET_KEY: "${FPC_LOCAL_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       L1_OPERATOR_PRIVATE_KEY: "${L1_OPERATOR_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"

--- a/scripts/contract/devnet-postdeploy-smoke.ts
+++ b/scripts/contract/devnet-postdeploy-smoke.ts
@@ -6,12 +6,14 @@ import {
   type DeployManifest,
   readDeployManifest,
 } from "@aztec-fpc/contract-deployment/src/manifest.ts";
+import { readTestTokenManifest } from "@aztec-fpc/contract-deployment/src/test-token-manifest.ts";
 import pino from "pino";
 
 const pinoLogger = pino();
 
 type CliArgs = {
   manifestPath: string;
+  testTokenManifestPath: string;
   l1RpcUrl: string;
   operatorSecretKey: string | null;
   l1OperatorPrivateKey: string | null;
@@ -279,6 +281,9 @@ function parseHex32(value: string, fieldName: string): string {
 
 function parseCliArgs(argv: string[]): CliParseResult {
   let manifestPath = readEnvString("FPC_DEVNET_SMOKE_MANIFEST") ?? DEFAULT_MANIFEST_PATH;
+  const testTokenManifestPath =
+    readEnvString("FPC_TEST_TOKEN_MANIFEST") ??
+    path.join(path.dirname(manifestPath), "test-token-manifest.json");
   let l1RpcUrlRaw =
     readEnvString("FPC_DEVNET_L1_RPC_URL") ??
     readEnvString("L1_RPC_URL") ??
@@ -400,6 +405,7 @@ function parseCliArgs(argv: string[]): CliParseResult {
     kind: "args",
     args: {
       manifestPath: path.resolve(manifestPath),
+      testTokenManifestPath: path.resolve(testTokenManifestPath),
       l1RpcUrl: parseHttpUrl(l1RpcUrlRaw, "l1-rpc-url"),
       operatorSecretKey: operatorSecretKey
         ? parseHex32(operatorSecretKey, "operator-secret-key")
@@ -765,6 +771,7 @@ async function topUpFeePayer(params: {
 async function runSmoke(args: CliArgs): Promise<void> {
   const deps = await loadDeps();
   const manifest = parseManifestFromDisk(args.manifestPath);
+  const testTokenManifest = readTestTokenManifest(args.testTokenManifestPath);
 
   if (!existsSync(FPC_ARTIFACT_PATH)) {
     throw new CliError(`FPC artifact not found: ${FPC_ARTIFACT_PATH}`);
@@ -862,16 +869,11 @@ async function runSmoke(args: CliArgs): Promise<void> {
   const fpc = deps.Contract.at(fpcAddress, selectedFpcArtifact, wallet);
 
   // Register faucet contract for dripping tokens (bridge is the minter, not operator)
-  if (!manifest.contracts.faucet) {
-    throw new CliError(
-      "Manifest missing contracts.faucet (required for token funding in smoke test)",
-    );
-  }
-  const faucetAddress = manifest.contracts.faucet;
+  const faucetAddress = testTokenManifest.contracts.faucet;
   const faucetArtifact = loadArtifact(deps, path.join(REPO_ROOT, "target", "faucet-Faucet.json"));
   const faucetInstance = await node.getContract(faucetAddress);
   if (!faucetInstance) {
-    throw new CliError(`Faucet contract not found on node at ${manifest.contracts.faucet}`);
+    throw new CliError(`Faucet contract not found on node at ${faucetAddress}`);
   }
   await wallet.registerContract(faucetInstance, faucetArtifact);
   const faucet = deps.Contract.at(faucetAddress, faucetArtifact, wallet);

--- a/scripts/contract/manifest.ts
+++ b/scripts/contract/manifest.ts
@@ -41,7 +41,6 @@ function buildSelfCheckFixture() {
     contracts: {
       accepted_asset: "0x0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
       fpc: "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
-      counter: "0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
     },
     operator: {
       address: "0x0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d",
@@ -49,11 +48,8 @@ function buildSelfCheckFixture() {
       pubkey_y: "987654321",
     },
     tx_hashes: {
-      accepted_asset_deploy: "0x1111111111111111111111111111111111111111111111111111111111111111",
       fpc_deploy: "0x2222222222222222222222222222222222222222222222222222222222222222",
-      counter_deploy: "0x3333333333333333333333333333333333333333333333333333333333333333",
     },
-    payment_mode: "fpc-sponsored",
   };
 }
 


### PR DESCRIPTION
## Summary
- `deployContract` now returns the tx hash string instead of `void`
- Deploy manifest: remove dead fields (`contracts.faucet/counter/bridge`, `l1_contracts`, `fpc_artifact`, `faucet_config`, `payment_mode`, nullable tx_hashes); populate `tx_hashes.fpc_deploy` with real hash
- Test token manifest: add `tx_hashes` with L2 hashes (`token_deploy`, `bridge_deploy`, `counter_deploy`, `faucet_deploy`) and L1 hashes (`l1_erc20_deploy`, `l1_token_portal_deploy`)
- `devnet-postdeploy-smoke` reads faucet address from test token manifest instead of deploy manifest
- `docker-compose.yaml` and `docker-compose.public.yaml`: add `FPC_TEST_TOKEN_MANIFEST` to postdeploy service
- `scripts/contract/manifest.ts` self-check fixture updated to match slimmed schema