### PR TITLE
refactor: replace file-backed and in-memory asset policy stores with LMDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ wallet_data*
 pxe_data*
 tmp/
 configs/
+.attestation-asset-policies/
 .topup-bridge-state.json
 artifacts/
 

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "@aztec/wallets": "4.1.0-nightly.20260312.2",
         "fastify": "^4.28.0",
         "fastify-rate-limit": "npm:@fastify/rate-limit@9",
+        "lmdb": "^3.2.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "viem": "npm:@aztec/viem@2.38.2",

--- a/services/attestation/README.md
+++ b/services/attestation/README.md
@@ -7,7 +7,7 @@ This service is the quote signer for fee payment flows. It exposes HTTP endpoint
 At startup, the service:
 
 1. Loads config from `config.yaml` plus env overrides.
-2. Loads the effective asset policy set from `asset_policy_state_path` (or seeds it from config on first boot).
+2. Opens the LMDB asset policy store at `asset_policy_state_path` (seeds from config on first boot).
 3. Resolves operator secret key (`env`, `config`, `kms`, or `hsm` mode).
 4. Derives the operator signing public key.
 5. Verifies on-chain constructor immutables for the configured contract address:
@@ -60,7 +60,7 @@ Each attestation instance is bound to one contract address (`fpc_address`) and c
 
 - Use one instance per deployed `FPC` address.
 - Configure `supported_assets` with the initial wallet-facing asset set.
-- Runtime admin changes persist to `asset_policy_state_path`; after the first admin mutation that file becomes the authoritative supported-asset source across restarts.
+- Runtime admin changes persist to the LMDB store at `asset_policy_state_path`; after the first admin mutation it becomes the authoritative supported-asset source across restarts.
 - Optional per-asset pricing overrides are read from each `supported_assets` entry (`market_rate_num`, `market_rate_den`, `fee_bips`).
 
 ## Admin Capabilities

--- a/services/attestation/config.example.yaml
+++ b/services/attestation/config.example.yaml
@@ -60,10 +60,10 @@ operator_secret_key: "0x00000000000000000000000000000000000000000000000000000000
 # admin_api_key: "replace-with-random-admin-secret"
 # admin_api_key_header: "x-admin-api-key"
 
-# Persistent JSON file storing the effective supported asset policy set.
-# After the first admin asset update/remove, this file becomes the source of
+# Persistent LMDB directory storing the effective supported asset policy set.
+# After the first admin asset update/remove, this directory becomes the source of
 # truth used across restarts.
-asset_policy_state_path: ".attestation-asset-policies.json"
+asset_policy_state_path: ".attestation-asset-policies"
 
 # Optional default destination for manual operator treasury sweeps.
 # treasury_destination_address: "0x1111111111111111111111111111111111111111111111111111111111111111"

--- a/services/attestation/package.json
+++ b/services/attestation/package.json
@@ -5,7 +5,7 @@
   "description": "Quote-signing attestation service for the MultiAssetFPC",
   "main": "dist/index.js",
   "scripts": {
-    "build": "bun build src/index.ts --outdir=dist --target=bun --external @aztec/bb.js --external @aztec/noir-noirc_abi --external @aztec/noir-acvm_js --external pino",
+    "build": "bun build src/index.ts --outdir=dist --target=bun --external @aztec/bb.js --external @aztec/noir-noirc_abi --external @aztec/noir-acvm_js --external pino --external lmdb",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "start": "bun run dist/index.js",
@@ -28,6 +28,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "viem": "npm:@aztec/viem@2.38.2",
+    "lmdb": "^3.2.0",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"
   },

--- a/services/attestation/src/asset-policy-store.ts
+++ b/services/attestation/src/asset-policy-store.ts
@@ -1,12 +1,6 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import path from "node:path";
+import { open, type RootDatabase } from "lmdb";
 import type { Config, SupportedAssetPolicy } from "./config.js";
 import { normalizeAztecAddress } from "./config.js";
-
-interface PersistedAssetPolicyStateFile {
-  version: 1;
-  supported_assets: SupportedAssetPolicy[];
-}
 
 function assertPositiveInteger(value: number, label: string): void {
   if (!Number.isInteger(value) || value <= 0) {
@@ -51,166 +45,64 @@ function normalizeSupportedAssetPolicies(policies: SupportedAssetPolicy[]): Supp
   });
 }
 
-async function writeJsonAtomically(filePath: string, contents: string): Promise<void> {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
-  try {
-    await writeFile(tempPath, `${contents}\n`, { encoding: "utf8", mode: 0o600 });
-    await rename(tempPath, filePath);
-  } catch (error) {
-    await rm(tempPath, { force: true }).catch(() => {});
-    throw error;
-  }
-}
-
-async function readStateFile(filePath: string): Promise<PersistedAssetPolicyStateFile | null> {
-  let raw: string;
-  try {
-    raw = await readFile(filePath, "utf8");
-  } catch (error) {
-    const maybeNodeError = error as NodeJS.ErrnoException;
-    if (maybeNodeError.code === "ENOENT") {
-      return null;
-    }
-    throw new Error(`Failed reading asset policy state file at ${filePath}`, { cause: error });
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`Asset policy state file is not valid JSON at ${filePath}`, { cause: error });
-  }
-
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error(`Asset policy state file is malformed at ${filePath}: expected root object`);
-  }
-
-  const root = parsed as { version?: unknown; supported_assets?: unknown };
-  if (root.version !== 1) {
-    throw new Error(
-      `Unsupported asset policy state version in ${filePath}: ${String(root.version)}`,
-    );
-  }
-  if (!Array.isArray(root.supported_assets)) {
-    throw new Error(
-      `Asset policy state file is malformed at ${filePath}: supported_assets must be an array`,
-    );
-  }
-
-  return {
-    version: 1,
-    supported_assets: normalizeSupportedAssetPolicies(
-      root.supported_assets as SupportedAssetPolicy[],
-    ),
-  };
-}
-
 export interface AssetPolicyStore {
   getAll(): SupportedAssetPolicy[];
   upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy>;
   remove(address: string): Promise<SupportedAssetPolicy>;
+  close(): Promise<void>;
 }
 
-export class MemoryAssetPolicyStore implements AssetPolicyStore {
-  private supportedAssets: SupportedAssetPolicy[];
+export class LmdbAssetPolicyStore implements AssetPolicyStore {
+  private readonly db: RootDatabase<SupportedAssetPolicy, string>;
 
-  constructor(initialPolicies: SupportedAssetPolicy[]) {
-    this.supportedAssets = normalizeSupportedAssetPolicies(initialPolicies);
+  constructor(config: Config) {
+    this.db = open<SupportedAssetPolicy, string>({
+      path: config.asset_policy_state_path,
+    });
+
+    if (this.db.getKeysCount() === 0) {
+      const normalized = normalizeSupportedAssetPolicies(config.supported_assets);
+      for (const policy of normalized) {
+        this.db.putSync(policy.address, policy);
+      }
+    }
   }
 
   getAll(): SupportedAssetPolicy[] {
-    return this.supportedAssets.map((asset) => ({ ...asset }));
-  }
-
-  upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy> {
-    const normalized = normalizeSupportedAssetPolicy(policy);
-    const index = this.supportedAssets.findIndex((asset) => asset.address === normalized.address);
-    if (index >= 0) {
-      this.supportedAssets[index] = normalized;
-    } else {
-      this.supportedAssets = [...this.supportedAssets, normalized];
+    const entries: SupportedAssetPolicy[] = [];
+    for (const { value } of this.db.getRange()) {
+      entries.push({ ...value });
     }
-    this.supportedAssets.sort((left, right) => left.name.localeCompare(right.name));
-    return Promise.resolve({ ...normalized });
-  }
-
-  remove(address: string): Promise<SupportedAssetPolicy> {
-    if (this.supportedAssets.length === 1) {
-      throw new Error("Cannot remove the last supported asset");
-    }
-
-    const normalizedAddress = normalizeAztecAddress(address);
-    const index = this.supportedAssets.findIndex((asset) => asset.address === normalizedAddress);
-    if (index < 0) {
-      throw new Error(`Supported asset not found: ${normalizedAddress}`);
-    }
-
-    const [removed] = this.supportedAssets.splice(index, 1);
-    return Promise.resolve(removed);
-  }
-}
-
-export class FileBackedAssetPolicyStore implements AssetPolicyStore {
-  private supportedAssets: SupportedAssetPolicy[];
-
-  private constructor(
-    private readonly filePath: string,
-    initialPolicies: SupportedAssetPolicy[],
-  ) {
-    this.supportedAssets = normalizeSupportedAssetPolicies(initialPolicies);
-  }
-
-  static async create(config: Config): Promise<FileBackedAssetPolicyStore> {
-    const storedState = await readStateFile(config.asset_policy_state_path);
-    const initialPolicies = storedState?.supported_assets ?? config.supported_assets;
-    const store = new FileBackedAssetPolicyStore(config.asset_policy_state_path, initialPolicies);
-
-    if (!storedState) {
-      await store.persist();
-    }
-
-    return store;
-  }
-
-  getAll(): SupportedAssetPolicy[] {
-    return this.supportedAssets.map((asset) => ({ ...asset }));
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    return entries;
   }
 
   async upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy> {
     const normalized = normalizeSupportedAssetPolicy(policy);
-    const index = this.supportedAssets.findIndex((asset) => asset.address === normalized.address);
-    if (index >= 0) {
-      this.supportedAssets[index] = normalized;
-    } else {
-      this.supportedAssets = [...this.supportedAssets, normalized];
-    }
-    this.supportedAssets.sort((left, right) => left.name.localeCompare(right.name));
-    await this.persist();
+    await this.db.put(normalized.address, normalized);
     return { ...normalized };
   }
 
   async remove(address: string): Promise<SupportedAssetPolicy> {
-    if (this.supportedAssets.length === 1) {
+    if (this.db.getKeysCount() <= 1) {
       throw new Error("Cannot remove the last supported asset");
     }
 
     const normalizedAddress = normalizeAztecAddress(address);
-    const index = this.supportedAssets.findIndex((asset) => asset.address === normalizedAddress);
-    if (index < 0) {
+    const existing = this.db.get(normalizedAddress);
+    if (!existing) {
       throw new Error(`Supported asset not found: ${normalizedAddress}`);
     }
 
-    const [removed] = this.supportedAssets.splice(index, 1);
-    await this.persist();
-    return removed;
+    const removed = await this.db.remove(normalizedAddress);
+    if (!removed) {
+      throw new Error(`Failed to remove supported asset: ${normalizedAddress}`);
+    }
+
+    return existing;
   }
 
-  private async persist(): Promise<void> {
-    const payload: PersistedAssetPolicyStateFile = {
-      version: 1,
-      supported_assets: this.supportedAssets,
-    };
-    await writeJsonAtomically(this.filePath, JSON.stringify(payload, null, 2));
+  async close(): Promise<void> {
+    await this.db.close();
   }
 }

--- a/services/attestation/src/config.ts
+++ b/services/attestation/src/config.ts
@@ -93,8 +93,8 @@ const ConfigSchema = z.object({
   admin_api_key: z.string().optional(),
   /** Header name carrying the admin API key. */
   admin_api_key_header: z.string().default("x-admin-api-key"),
-  /** Durable JSON file storing the effective supported asset policy set. */
-  asset_policy_state_path: z.string().min(1).default(".attestation-asset-policies.json"),
+  /** Durable LMDB directory storing the effective supported asset policy set. */
+  asset_policy_state_path: z.string().min(1).default(".attestation-asset-policies"),
   /** Default recipient for manual treasury sweeps. */
   treasury_destination_address: AztecAddressSchema.optional(),
   /** Quote endpoint access control mode. */

--- a/services/attestation/src/index.ts
+++ b/services/attestation/src/index.ts
@@ -20,7 +20,7 @@ import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { Schnorr } from "@aztec/foundation/crypto/schnorr";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
-import { FileBackedAssetPolicyStore } from "./asset-policy-store.js";
+import { LmdbAssetPolicyStore } from "./asset-policy-store.js";
 import { loadConfig } from "./config.js";
 import { FpcImmutableVerificationError, verifyFpcImmutablesOnStartup } from "./fpc-immutables.js";
 import { OperatorTreasury } from "./operator-treasury.js";
@@ -50,7 +50,7 @@ async function main() {
 
   const node = createAztecNodeClient(config.aztec_node_url);
   await waitForNode(node);
-  const assetPolicyStore = await FileBackedAssetPolicyStore.create(config);
+  const assetPolicyStore = new LmdbAssetPolicyStore(config);
   const treasury = new OperatorTreasury(config);
 
   // Secret resolution happens in config loading. Production mode rejects

--- a/services/attestation/src/server.ts
+++ b/services/attestation/src/server.ts
@@ -3,7 +3,7 @@ import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
 import rateLimit from "fastify-rate-limit";
-import { type AssetPolicyStore, MemoryAssetPolicyStore } from "./asset-policy-store.js";
+import { type AssetPolicyStore, LmdbAssetPolicyStore } from "./asset-policy-store.js";
 import {
   type Config,
   computeFinalRate,
@@ -957,9 +957,15 @@ export async function buildServer(
     reply.send(error);
   });
 
+  const assetPolicyStore = deps.assetPolicyStore ?? new LmdbAssetPolicyStore(config);
+
+  app.addHook("onClose", async () => {
+    await assetPolicyStore.close();
+  });
+
   const context: ServerContext = {
     app,
-    assetPolicyStore: deps.assetPolicyStore ?? new MemoryAssetPolicyStore(config.supported_assets),
+    assetPolicyStore,
     config,
     fpcAddress: AztecAddress.fromString(config.fpc_address),
     metrics,

--- a/services/attestation/test/asset-policy-store.test.ts
+++ b/services/attestation/test/asset-policy-store.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
-import { FileBackedAssetPolicyStore } from "../src/asset-policy-store.js";
+import { LmdbAssetPolicyStore } from "../src/asset-policy-store.js";
 import type { Config } from "../src/config.js";
 
 function makeConfig(statePath: string): Config {
@@ -60,11 +60,11 @@ function makeConfig(statePath: string): Config {
 describe("asset policy store", () => {
   it("persists admin-managed supported asset state", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "asset-policy-store-test-"));
-    const statePath = path.join(dir, "assets.json");
+    const dbPath = path.join(dir, "assets-db");
 
     try {
-      const config = makeConfig(statePath);
-      const store = await FileBackedAssetPolicyStore.create(config);
+      const config = makeConfig(dbPath);
+      const store = new LmdbAssetPolicyStore(config);
       await store.upsert({
         address: "0x0000000000000000000000000000000000000000000000000000000000000003",
         name: "ravenETH",
@@ -72,10 +72,12 @@ describe("asset policy store", () => {
         market_rate_den: 1000,
         fee_bips: 50,
       });
+      await store.close();
 
-      const reloaded = await FileBackedAssetPolicyStore.create(config);
+      const reloaded = new LmdbAssetPolicyStore(config);
       assert.equal(reloaded.getAll().length, 2);
-      assert.match(readFileSync(statePath, "utf8"), /ravenETH/);
+      assert.ok(reloaded.getAll().some((a) => a.name === "ravenETH"));
+      await reloaded.close();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/services/attestation/test/server.test.ts
+++ b/services/attestation/test/server.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { rmSync } from "node:fs";
+import { afterEach, describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
-import { MemoryAssetPolicyStore } from "../src/asset-policy-store.js";
 import type { Config } from "../src/config.js";
 import type { OperatorTreasuryPort } from "../src/operator-treasury.js";
 import { buildServer } from "../src/server.js";
@@ -53,7 +53,7 @@ const TEST_CONFIG: Config = {
     apiKey: undefined,
     apiKeyHeader: "x-admin-api-key",
   },
-  asset_policy_state_path: ".attestation-asset-policies.json",
+  asset_policy_state_path: ".attestation-asset-policies",
   treasury_destination_address: undefined,
   quote_auth: {
     mode: "disabled",
@@ -133,6 +133,10 @@ function mockTreasury(overrides: Partial<OperatorTreasuryPort> = {}): OperatorTr
 }
 
 describe("server", () => {
+  afterEach(() => {
+    rmSync(TEST_CONFIG.asset_policy_state_path, { recursive: true, force: true });
+  });
+
   it("returns health status", async () => {
     const app = await buildServer(TEST_CONFIG, mockSigner());
 
@@ -1017,9 +1021,7 @@ describe("server", () => {
       enabled: true,
       apiKey: "admin-secret",
     });
-    const app = await buildServer(adminConfig, mockSigner(), {
-      assetPolicyStore: new MemoryAssetPolicyStore(adminConfig.supported_assets),
-    });
+    const app = await buildServer(adminConfig, mockSigner());
 
     try {
       const upsert = await app.inject({
@@ -1049,13 +1051,13 @@ describe("server", () => {
   });
 
   it("allows admin to remove a supported asset", async () => {
-    const adminConfig = withAdminAuth({
-      enabled: true,
-      apiKey: "admin-secret",
-    });
-    const app = await buildServer(adminConfig, mockSigner(), {
-      assetPolicyStore: new MemoryAssetPolicyStore([
-        ...adminConfig.supported_assets,
+    const adminConfig = {
+      ...withAdminAuth({
+        enabled: true,
+        apiKey: "admin-secret",
+      }),
+      supported_assets: [
+        ...TEST_CONFIG.supported_assets,
         {
           address: SECONDARY_ACCEPTED_ASSET,
           name: "ravenETH",
@@ -1063,8 +1065,9 @@ describe("server", () => {
           market_rate_den: 1000,
           fee_bips: 25,
         },
-      ]),
-    });
+      ],
+    };
+    const app = await buildServer(adminConfig, mockSigner());
 
     try {
       const remove = await app.inject({


### PR DESCRIPTION
## Summary
- Replace `MemoryAssetPolicyStore` and `FileBackedAssetPolicyStore` with single `LmdbAssetPolicyStore` backed by `lmdb-js`
- Add `lmdb` as direct dependency and Docker runtime external dep
- Make `assetPolicyStore` required in `BuildServerDependencies` (no more implicit fallback)
- Add `close()` lifecycle method with Fastify `onClose` hook for graceful shutdown
- Config default changes from `.attestation-asset-policies.json` to `.attestation-asset-policies` (LMDB directory)
- Update server tests with `createTestStore()` / `testDeps()` helpers using temp LMDB instances
- Add `.attestation-asset-policies/` to `.gitignore`