### PR TITLE
refactor: remove legacy FPC immutables path and /asset endpoint

### DIFF
--- a/docs/aztec-deployer-user-guide.md
+++ b/docs/aztec-deployer-user-guide.md
@@ -633,7 +633,6 @@ console.log(`Token charged: ${result.aaPaymentAmount}`);
 | `GET` | `/health` | Liveness probe (returns 200) |
 | `GET` | `/.well-known/fpc.json` | Discovery metadata (network, FPC address, supported assets, endpoints) |
 | `GET` | `/accepted-assets` | List of supported assets with pricing |
-| `GET` | `/asset` | Legacy: default accepted asset |
 | `GET` | `/quote` | Request a signed fee quote |
 | `GET` | `/cold-start-quote` | Request a signed cold-start quote (includes claim fields) |
 | `GET` | `/metrics` | Prometheus metrics |

--- a/docs/spec/protocol-spec.md
+++ b/docs/spec/protocol-spec.md
@@ -164,7 +164,7 @@ Returns wallet discovery metadata for this attestation instance.
   "endpoints": {
     "discovery": "/.well-known/fpc.json",
     "health": "/health",
-    "asset": "/asset",
+    "accepted_assets": "/accepted-assets",
     "quote": "/quote"
   },
   "supported_assets": [{ "address": "0x...", "name": "humanUSDC" }]
@@ -177,11 +177,14 @@ Use HTTPS for `quote_base_url` in production; HTTP is acceptable for local devel
 #### `GET /health`
 Returns `{ status: "ok" }`. Use for liveness probes.
 
-#### `GET /asset`
-Returns the default configured asset name and address (`accepted_asset_*`), kept for backward compatibility.
+#### `GET /accepted-assets`
+Returns the supported accepted-assets list.
 
 ```json
-{ "name": "humanUSDC", "address": "0x..." }
+[
+  { "name": "humanUSDC", "address": "0x..." },
+  { "name": "ravenETH", "address": "0x..." }
+]
 ```
 
 #### `GET /quote?user=<address>&accepted_asset=<address>&fj_amount=<positive_u128_decimal>`

--- a/docs/spec/wallet-discovery-spec.md
+++ b/docs/spec/wallet-discovery-spec.md
@@ -100,7 +100,7 @@ Concrete `GET /.well-known/fpc.json` response:
   "endpoints": {
     "discovery": "/.well-known/fpc.json",
     "health": "/health",
-    "asset": "/asset",
+    "accepted_assets": "/accepted-assets",
     "quote": "/quote"
   },
   "supported_assets": [

--- a/scripts/tests/services.ts
+++ b/scripts/tests/services.ts
@@ -187,22 +187,22 @@ async function fetchQuote(
   throw new Error(`Timed out requesting quote. Last error: ${lastError}`);
 }
 
-async function fetchAsset(assetUrl: string, timeoutMs: number): Promise<AssetResponse> {
+async function fetchAcceptedAssets(url: string, timeoutMs: number): Promise<AssetResponse[]> {
   const deadline = Date.now() + timeoutMs;
   let lastError: string | undefined;
 
   while (Date.now() <= deadline) {
     try {
-      const response = await fetch(assetUrl);
+      const response = await fetch(url);
       const bodyText = await response.text();
       if (!response.ok) {
         lastError = `HTTP ${response.status}: ${bodyText}`;
       } else {
-        const parsed = JSON.parse(bodyText) as AssetResponse;
-        if (typeof parsed.name === "string" && typeof parsed.address === "string") {
+        const parsed = JSON.parse(bodyText) as AssetResponse[];
+        if (Array.isArray(parsed) && parsed.length > 0) {
           return parsed;
         }
-        lastError = `Invalid asset payload: ${bodyText}`;
+        lastError = `Invalid accepted-assets payload: ${bodyText}`;
       }
     } catch (error) {
       lastError = (error as Error).message;
@@ -211,7 +211,7 @@ async function fetchAsset(assetUrl: string, timeoutMs: number): Promise<AssetRes
     await sleep(500);
   }
 
-  throw new Error(`Timed out requesting asset metadata. Last error: ${lastError}`);
+  throw new Error(`Timed out requesting accepted-assets. Last error: ${lastError}`);
 }
 
 async function fetchMetrics(metricsUrl: string, timeoutMs: number): Promise<string> {
@@ -410,13 +410,16 @@ describe("fpc services smoke", () => {
       expect(response.status).toBe(400);
     });
 
-    it("asset endpoint returns matching token address", async () => {
-      const asset = await fetchAsset(
-        `${ctx.config.attestationBaseUrl}/asset`,
+    it("accepted-assets endpoint includes configured token", async () => {
+      const assets = await fetchAcceptedAssets(
+        `${ctx.config.attestationBaseUrl}/accepted-assets`,
         ctx.config.httpTimeoutMs,
       );
-      expect(asset.name.trim().length).toBeGreaterThan(0);
-      expect(asset.address.toLowerCase()).toBe(ctx.tokenAddress.toString().toLowerCase());
+      const match = assets.find(
+        (a) => a.address.toLowerCase() === ctx.tokenAddress.toString().toLowerCase(),
+      );
+      expect(match).toBeDefined();
+      expect(match?.name.trim().length).toBeGreaterThan(0);
     });
 
     it("returns valid quote with correct signature", async () => {

--- a/services/attestation/README.md
+++ b/services/attestation/README.md
@@ -167,7 +167,6 @@ Response:
     "discovery": "/.well-known/fpc.json",
     "health": "/health",
     "accepted_assets": "/accepted-assets",
-    "asset": "/asset",
     "quote": "/quote"
   },
   "supported_assets": [{ "address": "0x...", "name": "humanUSDC" }]
@@ -244,19 +243,6 @@ Request body:
 ### `DELETE /admin/asset-policies/:assetAddress`
 
 Requires the configured admin API key header.
-
-### `GET /asset` (legacy compatibility)
-
-Returns configured accepted asset metadata.
-
-Response:
-
-```json
-{
-  "name": "humanUSDC",
-  "address": "0x..."
-}
-```
 
 ### `GET /quote?user=<aztec_address>&accepted_asset=<aztec_address>&fj_amount=<positive_u128_decimal>`
 
@@ -352,7 +338,7 @@ Example checks:
 ```bash
 curl http://localhost:3000/.well-known/fpc.json
 curl http://localhost:3000/health
-curl http://localhost:3000/asset
+curl http://localhost:3000/accepted-assets
 curl "http://localhost:3000/quote?user=<aztec_address>&accepted_asset=<asset_address>&fj_amount=1000000"
 curl -H "x-admin-api-key: <admin-key>" http://localhost:3000/admin/asset-policies
 ```

--- a/services/attestation/config.example.yaml
+++ b/services/attestation/config.example.yaml
@@ -104,7 +104,6 @@ accepted_asset_address: "0x00000000000000000000000000000000000000000000000000000
 # This powers both discovery `supported_assets` and `GET /accepted-assets`.
 # If omitted, the service falls back to [{ accepted_asset_address, accepted_asset_name }]
 # until admin endpoints write `asset_policy_state_path`.
-# Legacy `GET /asset` exposes the current primary asset from the effective set.
 # supported_assets:
 #   - address: "0x0000000000000000000000000000000000000000000000000000000000000002"
 #     name: "humanUSDC"

--- a/services/attestation/src/asset-policy-store.ts
+++ b/services/attestation/src/asset-policy-store.ts
@@ -112,7 +112,6 @@ async function readStateFile(filePath: string): Promise<PersistedAssetPolicyStat
 
 export interface AssetPolicyStore {
   getAll(): SupportedAssetPolicy[];
-  getPrimaryAsset(): SupportedAssetPolicy;
   upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy>;
   remove(address: string): Promise<SupportedAssetPolicy>;
 }
@@ -120,20 +119,12 @@ export interface AssetPolicyStore {
 export class MemoryAssetPolicyStore implements AssetPolicyStore {
   private supportedAssets: SupportedAssetPolicy[];
 
-  constructor(
-    initialPolicies: SupportedAssetPolicy[],
-    private readonly primaryAddressHint: string,
-  ) {
+  constructor(initialPolicies: SupportedAssetPolicy[]) {
     this.supportedAssets = normalizeSupportedAssetPolicies(initialPolicies);
   }
 
   getAll(): SupportedAssetPolicy[] {
     return this.supportedAssets.map((asset) => ({ ...asset }));
-  }
-
-  getPrimaryAsset(): SupportedAssetPolicy {
-    const hinted = this.supportedAssets.find((asset) => asset.address === this.primaryAddressHint);
-    return { ...(hinted ?? this.supportedAssets[0]) };
   }
 
   upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy> {
@@ -170,7 +161,6 @@ export class FileBackedAssetPolicyStore implements AssetPolicyStore {
   private constructor(
     private readonly filePath: string,
     initialPolicies: SupportedAssetPolicy[],
-    private readonly primaryAddressHint: string,
   ) {
     this.supportedAssets = normalizeSupportedAssetPolicies(initialPolicies);
   }
@@ -178,11 +168,7 @@ export class FileBackedAssetPolicyStore implements AssetPolicyStore {
   static async create(config: Config): Promise<FileBackedAssetPolicyStore> {
     const storedState = await readStateFile(config.asset_policy_state_path);
     const initialPolicies = storedState?.supported_assets ?? config.supported_assets;
-    const store = new FileBackedAssetPolicyStore(
-      config.asset_policy_state_path,
-      initialPolicies,
-      normalizeAztecAddress(config.accepted_asset_address),
-    );
+    const store = new FileBackedAssetPolicyStore(config.asset_policy_state_path, initialPolicies);
 
     if (!storedState) {
       await store.persist();
@@ -193,11 +179,6 @@ export class FileBackedAssetPolicyStore implements AssetPolicyStore {
 
   getAll(): SupportedAssetPolicy[] {
     return this.supportedAssets.map((asset) => ({ ...asset }));
-  }
-
-  getPrimaryAsset(): SupportedAssetPolicy {
-    const hinted = this.supportedAssets.find((asset) => asset.address === this.primaryAddressHint);
-    return { ...(hinted ?? this.supportedAssets[0]) };
   }
 
   async upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy> {

--- a/services/attestation/src/fpc-immutables.ts
+++ b/services/attestation/src/fpc-immutables.ts
@@ -11,7 +11,7 @@ const AZTEC_ADDRESS_TYPE: ABIParameter["type"] = {
   fields: [{ name: "inner", type: { kind: "field" } }],
 };
 
-const FPC_CONSTRUCTOR_ABI_V2: FunctionAbi = {
+const FPC_CONSTRUCTOR_ABI: FunctionAbi = {
   name: "constructor",
   functionType: FunctionType.PUBLIC,
   isOnlySelf: false,
@@ -38,18 +38,6 @@ const FPC_CONSTRUCTOR_ABI_V2: FunctionAbi = {
   errorTypes: {},
 };
 
-const FPC_CONSTRUCTOR_ABI_LEGACY: FunctionAbi = {
-  ...FPC_CONSTRUCTOR_ABI_V2,
-  parameters: [
-    ...FPC_CONSTRUCTOR_ABI_V2.parameters,
-    {
-      name: "accepted_asset",
-      type: AZTEC_ADDRESS_TYPE,
-      visibility: "private",
-    },
-  ],
-};
-
 export type FpcImmutableVerificationReason =
   | "CONTRACT_QUERY_FAILED"
   | "CONTRACT_NOT_FOUND"
@@ -67,7 +55,6 @@ export class FpcImmutableVerificationError extends Error {
 
 export interface FpcImmutableInputs {
   fpcAddress: AztecAddress;
-  acceptedAsset: AztecAddress;
   operatorAddress: AztecAddress;
   operatorPubkeyX: Fr;
   operatorPubkeyY: Fr;
@@ -76,24 +63,10 @@ export interface FpcImmutableInputs {
 export async function computeExpectedFpcInitializationHash(
   inputs: Pick<FpcImmutableInputs, "operatorAddress" | "operatorPubkeyX" | "operatorPubkeyY">,
 ): Promise<Fr> {
-  return await computeInitializationHash(FPC_CONSTRUCTOR_ABI_V2, [
+  return await computeInitializationHash(FPC_CONSTRUCTOR_ABI, [
     inputs.operatorAddress,
     inputs.operatorPubkeyX,
     inputs.operatorPubkeyY,
-  ]);
-}
-
-async function computeExpectedLegacyFpcInitializationHash(
-  inputs: Pick<
-    FpcImmutableInputs,
-    "acceptedAsset" | "operatorAddress" | "operatorPubkeyX" | "operatorPubkeyY"
-  >,
-): Promise<Fr> {
-  return await computeInitializationHash(FPC_CONSTRUCTOR_ABI_LEGACY, [
-    inputs.operatorAddress,
-    inputs.operatorPubkeyX,
-    inputs.operatorPubkeyY,
-    inputs.acceptedAsset,
   ]);
 }
 
@@ -120,18 +93,14 @@ export async function verifyFpcImmutablesOnStartup(
   }
 
   const expectedInitializationHash = await computeExpectedFpcInitializationHash(inputs);
-  const expectedLegacyInitializationHash = await computeExpectedLegacyFpcInitializationHash(inputs);
   const onChainInitializationHash = deployed.initializationHash;
 
-  if (
-    !onChainInitializationHash.equals(expectedInitializationHash) &&
-    !onChainInitializationHash.equals(expectedLegacyInitializationHash)
-  ) {
+  if (!onChainInitializationHash.equals(expectedInitializationHash)) {
     const currentClassId = deployed.currentContractClassId?.toString() ?? "unknown";
     const originalClassId = deployed.originalContractClassId?.toString() ?? "unknown";
     throw new FpcImmutableVerificationError(
       "IMMUTABLE_MISMATCH",
-      `[startup] on-chain FPC immutable mismatch: expected operator=${inputs.operatorAddress.toString()} (pubkey_x=${inputs.operatorPubkeyX.toString()}, pubkey_y=${inputs.operatorPubkeyY.toString()}) for contract ${inputs.fpcAddress.toString()}, but deployment initialization_hash differs (expected_v2=${expectedInitializationHash.toString()}, expected_legacy=${expectedLegacyInitializationHash.toString()}, on_chain=${onChainInitializationHash.toString()}, current_class_id=${currentClassId}, original_class_id=${originalClassId})`,
+      `[startup] on-chain FPC immutable mismatch: expected operator=${inputs.operatorAddress.toString()} (pubkey_x=${inputs.operatorPubkeyX.toString()}, pubkey_y=${inputs.operatorPubkeyY.toString()}) for contract ${inputs.fpcAddress.toString()}, but deployment initialization_hash differs (expected=${expectedInitializationHash.toString()}, on_chain=${onChainInitializationHash.toString()}, current_class_id=${currentClassId}, original_class_id=${originalClassId})`,
     );
   }
 }

--- a/services/attestation/src/index.ts
+++ b/services/attestation/src/index.ts
@@ -75,7 +75,6 @@ async function main() {
   try {
     await verifyFpcImmutablesOnStartup(node, {
       fpcAddress,
-      acceptedAsset: acceptedAssetAddress,
       operatorAddress,
       operatorPubkeyX: Fr.fromString(operatorPubKey.x.toString()),
       operatorPubkeyY: Fr.fromString(operatorPubKey.y.toString()),

--- a/services/attestation/src/server.ts
+++ b/services/attestation/src/server.ts
@@ -663,7 +663,6 @@ function registerPublicRoutes(context: ServerContext): void {
       discovery: "/.well-known/fpc.json",
       health: "/health",
       accepted_assets: "/accepted-assets",
-      asset: "/asset",
       quote: "/quote",
       cold_start_quote: "/cold-start-quote",
     },
@@ -677,14 +676,6 @@ function registerPublicRoutes(context: ServerContext): void {
       .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
       .send(metrics.renderPrometheus()),
   );
-
-  app.get("/asset", NO_RATE_LIMIT, () => {
-    const primaryAsset = assetPolicyStore.getPrimaryAsset();
-    return {
-      name: primaryAsset.name,
-      address: primaryAsset.address,
-    };
-  });
 
   app.get("/accepted-assets", NO_RATE_LIMIT, () =>
     buildSupportedAssetsForDiscovery(assetPolicyStore),
@@ -968,12 +959,7 @@ export async function buildServer(
 
   const context: ServerContext = {
     app,
-    assetPolicyStore:
-      deps.assetPolicyStore ??
-      new MemoryAssetPolicyStore(
-        config.supported_assets,
-        normalizeAztecAddress(config.accepted_asset_address),
-      ),
+    assetPolicyStore: deps.assetPolicyStore ?? new MemoryAssetPolicyStore(config.supported_assets),
     config,
     fpcAddress: AztecAddress.fromString(config.fpc_address),
     metrics,

--- a/services/attestation/test/fpc-immutables.test.ts
+++ b/services/attestation/test/fpc-immutables.test.ts
@@ -12,9 +12,6 @@ import {
 const TEST_FPC_ADDRESS = AztecAddress.fromString(
   "0x27e0f62fe6edf34f850dd7c1cc7cd638f7ec38ed3eb5ae4bd8c0c941c78e67ac",
 );
-const TEST_ACCEPTED_ASSET = AztecAddress.fromString(
-  "0x0000000000000000000000000000000000000000000000000000000000000002",
-);
 const TEST_OPERATOR = AztecAddress.fromString(
   "0x089323ce9a610e9f013b661ce80dde444b554e9f6ed9f5167adb234668f0af72",
 );
@@ -52,7 +49,6 @@ function mockNodeGetContractThrows(message: string): Pick<AztecNode, "getContrac
 describe("fpc immutable startup verification", () => {
   it("passes when on-chain immutables match expected config and signer", async () => {
     const expectedHash = await computeExpectedFpcInitializationHash({
-      acceptedAsset: TEST_ACCEPTED_ASSET,
       operatorAddress: TEST_OPERATOR,
       operatorPubkeyX: TEST_OPERATOR_PUBKEY_X,
       operatorPubkeyY: TEST_OPERATOR_PUBKEY_Y,
@@ -61,7 +57,6 @@ describe("fpc immutable startup verification", () => {
 
     await verifyFpcImmutablesOnStartup(node, {
       fpcAddress: TEST_FPC_ADDRESS,
-      acceptedAsset: TEST_ACCEPTED_ASSET,
       operatorAddress: TEST_OPERATOR,
       operatorPubkeyX: TEST_OPERATOR_PUBKEY_X,
       operatorPubkeyY: TEST_OPERATOR_PUBKEY_Y,
@@ -74,7 +69,6 @@ describe("fpc immutable startup verification", () => {
     await assert.rejects(
       verifyFpcImmutablesOnStartup(node, {
         fpcAddress: TEST_FPC_ADDRESS,
-        acceptedAsset: TEST_ACCEPTED_ASSET,
         operatorAddress: TEST_OPERATOR,
         operatorPubkeyX: TEST_OPERATOR_PUBKEY_X,
         operatorPubkeyY: TEST_OPERATOR_PUBKEY_Y,
@@ -97,7 +91,6 @@ describe("fpc immutable startup verification", () => {
     await assert.rejects(
       verifyFpcImmutablesOnStartup(node, {
         fpcAddress: TEST_FPC_ADDRESS,
-        acceptedAsset: TEST_ACCEPTED_ASSET,
         operatorAddress: TEST_OPERATOR,
         operatorPubkeyX: TEST_OPERATOR_PUBKEY_X,
         operatorPubkeyY: TEST_OPERATOR_PUBKEY_Y,
@@ -121,7 +114,6 @@ describe("fpc immutable startup verification", () => {
     await assert.rejects(
       verifyFpcImmutablesOnStartup(node, {
         fpcAddress: TEST_FPC_ADDRESS,
-        acceptedAsset: TEST_ACCEPTED_ASSET,
         operatorAddress: TEST_OPERATOR,
         operatorPubkeyX: TEST_OPERATOR_PUBKEY_X,
         operatorPubkeyY: TEST_OPERATOR_PUBKEY_Y,
@@ -132,8 +124,7 @@ describe("fpc immutable startup verification", () => {
           return false;
         }
         assert.equal(error.reason, "IMMUTABLE_MISMATCH");
-        assert.match(error.message, /expected_v2=/);
-        assert.match(error.message, /expected_legacy=/);
+        assert.match(error.message, /expected=/);
         assert.match(error.message, /operator=/);
         assert.match(error.message, /initialization_hash/);
         assert.match(error.message, /current_class_id=/);

--- a/services/attestation/test/server.test.ts
+++ b/services/attestation/test/server.test.ts
@@ -173,7 +173,6 @@ describe("server", () => {
           discovery: "/.well-known/fpc.json",
           health: "/health",
           accepted_assets: "/accepted-assets",
-          asset: "/asset",
           quote: "/quote",
           cold_start_quote: "/cold-start-quote",
         },
@@ -273,21 +272,6 @@ describe("server", () => {
         { address: DEFAULT_ACCEPTED_ASSET, name: "humanUSDC" },
         { address: SECONDARY_ACCEPTED_ASSET, name: "ravenETH" },
       ]);
-    } finally {
-      await app.close();
-    }
-  });
-
-  it("returns accepted asset metadata", async () => {
-    const app = await buildServer(TEST_CONFIG, mockSigner());
-
-    try {
-      const response = await app.inject({ method: "GET", url: "/asset" });
-      assert.equal(response.statusCode, 200);
-      assert.deepEqual(response.json(), {
-        name: TEST_CONFIG.accepted_asset_name,
-        address: TEST_CONFIG.accepted_asset_address,
-      });
     } finally {
       await app.close();
     }
@@ -1039,10 +1023,7 @@ describe("server", () => {
       apiKey: "admin-secret",
     });
     const app = await buildServer(adminConfig, mockSigner(), {
-      assetPolicyStore: new MemoryAssetPolicyStore(
-        adminConfig.supported_assets,
-        adminConfig.accepted_asset_address,
-      ),
+      assetPolicyStore: new MemoryAssetPolicyStore(adminConfig.supported_assets),
     });
 
     try {
@@ -1078,19 +1059,16 @@ describe("server", () => {
       apiKey: "admin-secret",
     });
     const app = await buildServer(adminConfig, mockSigner(), {
-      assetPolicyStore: new MemoryAssetPolicyStore(
-        [
-          ...adminConfig.supported_assets,
-          {
-            address: SECONDARY_ACCEPTED_ASSET,
-            name: "ravenETH",
-            market_rate_num: 3,
-            market_rate_den: 1000,
-            fee_bips: 25,
-          },
-        ],
-        adminConfig.accepted_asset_address,
-      ),
+      assetPolicyStore: new MemoryAssetPolicyStore([
+        ...adminConfig.supported_assets,
+        {
+          address: SECONDARY_ACCEPTED_ASSET,
+          name: "ravenETH",
+          market_rate_num: 3,
+          market_rate_den: 1000,
+          fee_bips: 25,
+        },
+      ]),
     });
 
     try {


### PR DESCRIPTION
## Summary
- Remove legacy FPC constructor ABI (`FPC_CONSTRUCTOR_ABI_LEGACY`) and dual-check fallback in `verifyFpcImmutablesOnStartup`; verification now only checks the v2 initialization hash
- Remove `acceptedAsset` from `FpcImmutableInputs` and drop `computeExpectedLegacyFpcInitializationHash`
- Remove `GET /asset` legacy endpoint from server and its entry in discovery metadata
- Remove `getPrimaryAsset()` and `primaryAddressHint` from `AssetPolicyStore` interface and both implementations
- Update docs (protocol-spec, wallet-discovery-spec, deployer user guide, README) to reflect `/accepted-assets` as the canonical asset endpoint