### PR TITLE
refactor: default PXE_PROVER_ENABLED to false

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -54,8 +54,6 @@ jobs:
     needs: [changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
-    env:
-      PXE_PROVER_ENABLED: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/contract-deployment/src/configure-token.ts
+++ b/contract-deployment/src/configure-token.ts
@@ -197,7 +197,7 @@ async function initDeployDeps(): Promise<TestTokenDeployDeps> {
   const l1DeployerKey = requireEnv("FPC_L1_DEPLOYER_KEY");
   const deployerSecretKey = requireEnv("FPC_DEPLOYER_SECRET_KEY");
   const proverEnabled =
-    process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false";
+    process.env.PXE_PROVER_ENABLED === "1" || process.env.PXE_PROVER_ENABLED === "true";
 
   const node = createAztecNodeClient(nodeUrl);
   await waitForNode(node);

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -78,7 +78,7 @@ function usage(): string {
     "Options:",
     "  --operator <aztec_address>       Operator address (default: derived from key) [env: FPC_OPERATOR]",
     "  --sponsored-fpc-address <addr>   Use sponsored FPC payment mode [env: FPC_SPONSORED_FPC_ADDRESS]",
-    "  --pxe-prover-enabled <bool>      Enable PXE prover (default: true) [env: PXE_PROVER_ENABLED]",
+    "  --pxe-prover-enabled <bool>      Enable PXE prover (default: false) [env: PXE_PROVER_ENABLED]",
     "  --preflight-only                 Run checks only, do not deploy [env: FPC_PREFLIGHT_ONLY=1]",
     "",
     "Outputs:",
@@ -178,7 +178,7 @@ function parseCliArgs(argv: string[]): CliParseResult {
   let out: string = process.env.FPC_OUT ?? path.join(dataDir, "manifest.json");
   let proverEnabled = process.env.PXE_PROVER_ENABLED
     ? parseBooleanFlag(process.env.PXE_PROVER_ENABLED, "PXE_PROVER_ENABLED")
-    : true;
+    : false;
   let preflightOnly = process.env.FPC_PREFLIGHT_ONLY === "1";
 
   for (let i = 0; i < argv.length; i += 1) {

--- a/docker-compose.public.yaml
+++ b/docker-compose.public.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       FPC_DEPLOYER_SECRET_KEY: "${FPC_DEPLOYER_SECRET_KEY}"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
       FPC_DATA_DIR: "/app/data"
     env_file:
       - .env.${DEPLOYMENT}
@@ -80,7 +80,7 @@ services:
       - ./deployments/${DEPLOYMENT}:/app/data
     command: ["configure-token"]
     environment:
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
       FPC_DEPLOYER_SECRET_KEY: "${FPC_DEPLOYER_SECRET_KEY}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY}"
       FPC_DATA_DIR: "/app/data"
@@ -108,7 +108,7 @@ services:
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY}"
       FPC_L1_USER_KEY: "${FPC_L1_USER_KEY}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     env_file:
       - .env.${DEPLOYMENT}
     depends_on:
@@ -131,7 +131,7 @@ services:
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     env_file:
       - .env.${DEPLOYMENT}
     depends_on:
@@ -154,7 +154,7 @@ services:
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     env_file:
       - .env.${DEPLOYMENT}
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       - ./deployments/local:/app/data
     environment:
       AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
       FPC_DEPLOYER_SECRET_KEY: "${FPC_DEPLOYER_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_DATA_DIR: "/app/data"
@@ -132,7 +132,7 @@ services:
     environment:
       AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
       L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
       FPC_DEPLOYER_SECRET_KEY: "${FPC_DEPLOYER_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
       FPC_DATA_DIR: "/app/data"
@@ -204,7 +204,7 @@ services:
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     depends_on:
       block-producer:
         condition: service_started
@@ -229,7 +229,7 @@ services:
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     depends_on:
       block-producer:
         condition: service_started
@@ -255,7 +255,7 @@ services:
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_CONCURRENT_N: "${FPC_CONCURRENT_N:-20}"
       FPC_L1_DEPLOYER_KEY: "${FPC_L1_DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     depends_on:
       block-producer:
         condition: service_started
@@ -281,7 +281,7 @@ services:
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     depends_on:
       block-producer:
         condition: service_started
@@ -307,7 +307,7 @@ services:
       FPC_COLD_START_MANIFEST: "/app/data/manifest.json"
       FPC_TEST_TOKEN_MANIFEST: "/app/data/tokens/FpcAcceptedAsset.json"
       FPC_OPERATOR_SECRET_KEY: "${FPC_OPERATOR_SECRET_KEY:-0x2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281}"
-      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-true}"
+      PXE_PROVER_ENABLED: "${PXE_PROVER_ENABLED:-}"
     depends_on:
       block-producer:
         condition: service_started

--- a/scripts/tests/always-revert.ts
+++ b/scripts/tests/always-revert.ts
@@ -77,7 +77,7 @@ function getConfig(): AlwaysRevertConfig {
     testTokenManifestPath: requireEnv("FPC_TEST_TOKEN_MANIFEST"),
     operatorSecretKey: Fr.fromHexString(requireEnv("FPC_OPERATOR_SECRET_KEY")),
     proverEnabled:
-      process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
+      process.env.PXE_PROVER_ENABLED === "1" || process.env.PXE_PROVER_ENABLED === "true",
     messageTimeoutSeconds: readEnvPositiveInteger("FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS", 120),
     iterations: readEnvPositiveInteger("FPC_SMOKE_ITERATIONS", 3),
   };

--- a/scripts/tests/cold-start.ts
+++ b/scripts/tests/cold-start.ts
@@ -106,7 +106,7 @@ function getConfig(): ColdStartConfig {
     claimAmount: readEnvPositiveBigInt("FPC_COLD_START_CLAIM_AMOUNT", "10000000000000000"),
     aaPaymentAmount: readEnvPositiveBigInt("FPC_COLD_START_AA_PAYMENT_AMOUNT", "1000000000"),
     proverEnabled:
-      process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
+      process.env.PXE_PROVER_ENABLED === "1" || process.env.PXE_PROVER_ENABLED === "true",
     messageTimeoutSeconds: readEnvNonNegativeInt("FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS", 120),
   };
 }

--- a/scripts/tests/concurrent.ts
+++ b/scripts/tests/concurrent.ts
@@ -74,7 +74,7 @@ function getConfig(): ConcurrentConfig {
     claimAmount,
     messageTimeoutSeconds,
     proverEnabled:
-      process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
+      process.env.PXE_PROVER_ENABLED === "1" || process.env.PXE_PROVER_ENABLED === "true",
     l1PrivateKey: l1KeyRaw ? (l1KeyRaw as Hex) : null,
     l1DeployerKey: requireEnv("FPC_L1_DEPLOYER_KEY"),
   };

--- a/scripts/tests/fee-entrypoint-validation.ts
+++ b/scripts/tests/fee-entrypoint-validation.ts
@@ -214,7 +214,7 @@ function getConfig(): FullE2EConfig {
     daGasLimit: readEnvPositiveInteger("FPC_FULL_E2E_DA_GAS_LIMIT", 200_000),
     l2GasLimit: readEnvPositiveInteger("FPC_FULL_E2E_L2_GAS_LIMIT", 1_000_000),
     pxeProverEnabled:
-      process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
+      process.env.PXE_PROVER_ENABLED === "1" || process.env.PXE_PROVER_ENABLED === "true",
   };
 }
 

--- a/scripts/tests/same-token-transfer.ts
+++ b/scripts/tests/same-token-transfer.ts
@@ -86,7 +86,7 @@ function getConfig(): SameTokenTransferConfig {
     testTokenManifestPath: requireEnv("FPC_TEST_TOKEN_MANIFEST"),
     operatorSecretKey: Fr.fromHexString(requireEnv("FPC_OPERATOR_SECRET_KEY")),
     pxeProverEnabled:
-      process.env.PXE_PROVER_ENABLED !== "0" && process.env.PXE_PROVER_ENABLED !== "false",
+      process.env.PXE_PROVER_ENABLED === "1" || process.env.PXE_PROVER_ENABLED === "true",
     aaPaymentAmount: readEnvPositiveBigInt("FPC_COLD_START_AA_PAYMENT_AMOUNT", 1_000_000_000n),
     messageTimeoutSeconds: readEnvPositiveInteger("FPC_SMOKE_MESSAGE_TIMEOUT_SECONDS", 120),
   };


### PR DESCRIPTION
## Summary
- Change `PXE_PROVER_ENABLED` default from `true` to `false` across all application code
- Docker-compose files now pass through `PXE_PROVER_ENABLED` without a default (`${PXE_PROVER_ENABLED:-}`), letting the application own the fallback
- Flip boolean logic in test scripts and configure-token from opt-out (`!== "0" && !== "false"`) to opt-in (`=== "1" || === "true"`)
- Remove conditional `PXE_PROVER_ENABLED` override from CI workflow