### PR TITLE
refactor: remove l1_contract_addresses and protocol_contract_addresses from deploy manifest

### DIFF
--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -459,8 +459,6 @@ async function main(): Promise<void> {
       rollup_version: nodeInfo.rollupVersion,
     },
     aztec_required_addresses: {
-      l1_contract_addresses: nodeInfo.l1ContractAddresses,
-      protocol_contract_addresses: nodeInfo.protocolContractAddresses,
       ...(args.sponsoredFpcAddress
         ? { sponsored_fpc_address: AztecAddress.fromString(args.sponsoredFpcAddress) }
         : {}),

--- a/contract-deployment/src/manifest.ts
+++ b/contract-deployment/src/manifest.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { z } from "zod";
 import {
   aztecAddress,
-  ethAddress,
   fieldValue,
   httpUrl,
   isoTimestamp,
@@ -23,21 +22,6 @@ const deployManifestSchema = z.object({
     rollup_version: positiveSafeInt,
   }),
   aztec_required_addresses: z.object({
-    l1_contract_addresses: z.object({
-      registryAddress: ethAddress,
-      rollupAddress: ethAddress,
-      inboxAddress: ethAddress,
-      outboxAddress: ethAddress,
-      feeJuiceAddress: ethAddress,
-      feeJuicePortalAddress: ethAddress,
-      feeAssetHandlerAddress: ethAddress.optional(),
-    }),
-    protocol_contract_addresses: z.object({
-      instanceRegistry: aztecAddress,
-      classRegistry: aztecAddress,
-      multiCallEntrypoint: aztecAddress,
-      feeJuice: aztecAddress,
-    }),
     sponsored_fpc_address: aztecAddress.optional(),
   }),
   deployer_address: aztecAddress,

--- a/deployments/devnet-manifest-v2.json
+++ b/deployments/devnet-manifest-v2.json
@@ -8,21 +8,6 @@
     "rollup_version": 615022430
   },
   "aztec_required_addresses": {
-    "l1_contract_addresses": {
-      "registryAddress": "0x52945c29d2788ccb076e910509c0449bfcbe29e6",
-      "rollupAddress": "0xcd1a7be18501092f3ba8d80ce5629501ba178de0",
-      "inboxAddress": "0xef5730d1e07b306aecbe01400630d61e3ccb68af",
-      "outboxAddress": "0x34fc558b6f97e50149bcc140060bbe3f7d04bc59",
-      "feeJuiceAddress": "0x35d0186d1fd53b72996475d965c5ed171d52b986",
-      "feeJuicePortalAddress": "0x516e3f74fd1c19b24da0706d28b5a30578f054ab",
-      "feeAssetHandlerAddress": "0xed9c5557d2e0abcc7c7fca958ee4292199413494"
-    },
-    "protocol_contract_addresses": {
-      "instanceRegistry": "0x0000000000000000000000000000000000000000000000000000000000000002",
-      "classRegistry": "0x0000000000000000000000000000000000000000000000000000000000000003",
-      "multiCallEntrypoint": "0x0000000000000000000000000000000000000000000000000000000000000004",
-      "feeJuice": "0x0000000000000000000000000000000000000000000000000000000000000005"
-    },
     "sponsored_fpc_address": "0x09a4df73aa47f82531a038d1d51abfc85b27665c4b7ca751e2d4fa9f19caffb2"
   },
   "deployer_address": "0x18a15b90bea06cea7cbd06b3940533952aa9e5f94c157000c727321644d07af8",

--- a/deployments/testnet/manifest.json
+++ b/deployments/testnet/manifest.json
@@ -7,23 +7,7 @@
     "l1_chain_id": 11155111,
     "rollup_version": 4127419662
   },
-  "aztec_required_addresses": {
-    "l1_contract_addresses": {
-      "registryAddress": "0xa0bfb1b494fb49041e5c6e8c2c1be09cd171c6ba",
-      "rollupAddress": "0xf6d0d42ace06829becb78c74f49879528fc632c1",
-      "inboxAddress": "0xf1bb424ac888aa239f1e658b5bddabc65a1c94e6",
-      "outboxAddress": "0x5fe63c32b7ca20445e813bdb1019f1ffc5f52376",
-      "feeJuiceAddress": "0x762c132040fda6183066fa3b14d985ee55aa3c18",
-      "feeJuicePortalAddress": "0xd3361019e40026ce8a9745c19e67fd3acc10d596",
-      "feeAssetHandlerAddress": "0x5602c39a6e9c5ace589f64f754927bcda4f4bfc9"
-    },
-    "protocol_contract_addresses": {
-      "instanceRegistry": "0x0000000000000000000000000000000000000000000000000000000000000002",
-      "classRegistry": "0x0000000000000000000000000000000000000000000000000000000000000003",
-      "multiCallEntrypoint": "0x0000000000000000000000000000000000000000000000000000000000000004",
-      "feeJuice": "0x0000000000000000000000000000000000000000000000000000000000000005"
-    }
-  },
+  "aztec_required_addresses": {},
   "deployer_address": "0x0aa818ff7e9bb59334e0106eeeacc5ce8d32610d34917b213f305a30a87cf974",
   "contracts": {
     "accepted_asset": "0x07348d12aae72d1c2ff67cb2bf6b0e54f2ac39484f21cad7247d4e27b4822afb",

--- a/docs/ops/devnet-deployment-how-to.md
+++ b/docs/ops/devnet-deployment-how-to.md
@@ -244,7 +244,4 @@ jq . deployments/devnet-manifest-v2.json
 
 Check non-zero:
 
-- `contracts.accepted_asset`
 - `contracts.fpc`
-- `aztec_required_addresses.l1_contract_addresses.*`
-- `aztec_required_addresses.protocol_contract_addresses.*`

--- a/scripts/contract/manifest.ts
+++ b/scripts/contract/manifest.ts
@@ -20,21 +20,6 @@ function buildSelfCheckFixture() {
       rollup_version: 615022430,
     },
     aztec_required_addresses: {
-      l1_contract_addresses: {
-        registryAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        rollupAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        inboxAddress: "0xcccccccccccccccccccccccccccccccccccccccc",
-        outboxAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
-        feeJuiceAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-        feeJuicePortalAddress: "0xffffffffffffffffffffffffffffffffffffffff",
-        feeAssetHandlerAddress: "0x1111111111111111111111111111111111111111",
-      },
-      protocol_contract_addresses: {
-        instanceRegistry: "0x0000000000000000000000000000000000000000000000000000000000000002",
-        classRegistry: "0x0000000000000000000000000000000000000000000000000000000000000003",
-        multiCallEntrypoint: "0x0000000000000000000000000000000000000000000000000000000000000004",
-        feeJuice: "0x0000000000000000000000000000000000000000000000000000000000000005",
-      },
       sponsored_fpc_address: "0x09a4df73aa47f82531a038d1d51abfc85b27665c4b7ca751e2d4fa9f19caffb2",
     },
     deployer_address: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",

--- a/scripts/services/fund-l1-fee-juice.ts
+++ b/scripts/services/fund-l1-fee-juice.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { createExtendedL1Client } from "@aztec/ethereum/client";
 import pino from "pino";
@@ -38,7 +38,7 @@ type NodeInfoL1Addresses = {
 type ResolvedFundingTargets = {
   feeJuiceTokenAddress: Address;
   feeAssetHandlerAddress: Address | null;
-  source: "cli" | "node" | "manifest" | "mixed";
+  source: "cli" | "node" | "mixed";
 };
 
 const HEX_32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
@@ -411,44 +411,6 @@ async function loadNodeInfoL1Addresses(nodeUrl: string): Promise<NodeInfoL1Addre
   };
 }
 
-function loadManifestL1Addresses(manifestPath: string): NodeInfoL1Addresses {
-  let raw: string;
-  try {
-    raw = readFileSync(manifestPath, "utf8");
-  } catch (error) {
-    throw new CliError(`Failed to read deploy manifest at ${manifestPath}: ${String(error)}`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw) as unknown;
-  } catch (error) {
-    throw new CliError(`Deploy manifest at ${manifestPath} is not valid JSON: ${String(error)}`);
-  }
-
-  if (!parsed || typeof parsed !== "object") {
-    throw new CliError(`Deploy manifest at ${manifestPath} must be a JSON object`);
-  }
-  const root = parsed as Record<string, unknown>;
-
-  const aztecRequired = root.aztec_required_addresses;
-  if (!aztecRequired || typeof aztecRequired !== "object") {
-    return {};
-  }
-  const l1 = (aztecRequired as Record<string, unknown>).l1_contract_addresses;
-  if (!l1 || typeof l1 !== "object") {
-    return {};
-  }
-  const l1Record = l1 as Record<string, unknown>;
-
-  return {
-    feeJuiceAddress:
-      extractAddressCandidate(l1Record, ["feeJuiceAddress", "feeJuice"]) ?? undefined,
-    feeAssetHandlerAddress:
-      extractAddressCandidate(l1Record, ["feeAssetHandlerAddress", "feeAssetHandler"]) ?? undefined,
-  };
-}
-
 async function resolveFundingTargets(args: CliArgs): Promise<ResolvedFundingTargets> {
   const fromCliToken = args.feeJuiceTokenAddress
     ? parseAddress(args.feeJuiceTokenAddress, "--fee-juice-token-address")
@@ -462,26 +424,15 @@ async function resolveFundingTargets(args: CliArgs): Promise<ResolvedFundingTarg
     fromNode = await loadNodeInfoL1Addresses(args.nodeUrl);
   }
 
-  let fromManifest: NodeInfoL1Addresses = {};
-  if (args.manifestPath && existsSync(args.manifestPath)) {
-    fromManifest = loadManifestL1Addresses(args.manifestPath);
-  }
-
   const tokenAddress =
     fromCliToken ??
     (fromNode.feeJuiceAddress
       ? parseAddress(fromNode.feeJuiceAddress, "node_getNodeInfo.feeJuiceAddress")
-      : null) ??
-    (fromManifest.feeJuiceAddress
-      ? parseAddress(
-          fromManifest.feeJuiceAddress,
-          "manifest.aztec_required_addresses.l1_contract_addresses.feeJuiceAddress",
-        )
       : null);
 
   if (!tokenAddress) {
     throw new CliError(
-      "Could not resolve FeeJuice token address. Provide --fee-juice-token-address (or L1_FEE_JUICE_TOKEN_ADDRESS), or provide --node-url / AZTEC_NODE_URL, or a valid deploy manifest.",
+      "Could not resolve FeeJuice token address. Provide --fee-juice-token-address (or L1_FEE_JUICE_TOKEN_ADDRESS), or provide --node-url / AZTEC_NODE_URL.",
     );
   }
 
@@ -489,24 +440,10 @@ async function resolveFundingTargets(args: CliArgs): Promise<ResolvedFundingTarg
     fromCliHandler ??
     (fromNode.feeAssetHandlerAddress
       ? parseAddress(fromNode.feeAssetHandlerAddress, "node_getNodeInfo.feeAssetHandlerAddress")
-      : null) ??
-    (fromManifest.feeAssetHandlerAddress
-      ? parseAddress(
-          fromManifest.feeAssetHandlerAddress,
-          "manifest.aztec_required_addresses.l1_contract_addresses.feeAssetHandlerAddress",
-        )
       : null);
 
   const source: ResolvedFundingTargets["source"] =
-    fromCliToken || fromCliHandler
-      ? fromNode.feeJuiceAddress || fromManifest.feeJuiceAddress
-        ? "mixed"
-        : "cli"
-      : fromNode.feeJuiceAddress
-        ? fromManifest.feeJuiceAddress
-          ? "mixed"
-          : "node"
-        : "manifest";
+    fromCliToken || fromCliHandler ? (fromNode.feeJuiceAddress ? "mixed" : "cli") : "node";
 
   return {
     feeJuiceTokenAddress: tokenAddress,


### PR DESCRIPTION
## Summary
- Removed `l1_contract_addresses` and `protocol_contract_addresses` from the deploy manifest Zod schema, deploy pipeline, self-check fixture, and JSON manifests
- Removed `loadManifestL1Addresses` and the manifest fallback path from `fund-l1-fee-juice` (address resolution now uses CLI flags or node info only)
- Cleaned up unused `ethAddress` and `readFileSync` imports, and dropped the `"manifest"` source variant