### PR TITLE
refactor: reorder configure-token to deploy first, then register

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -121,6 +121,10 @@ jobs:
         if: always()
         run: docker compose --profile full logs --timestamps deploy
 
+      - name: Print configure-token logs
+        if: always()
+        run: docker compose --profile full logs --timestamps configure-token
+
       - name: Print attestation logs
         if: always()
         run: docker compose --profile full logs --timestamps attestation

--- a/contract-deployment/src/configure-token.ts
+++ b/contract-deployment/src/configure-token.ts
@@ -232,15 +232,10 @@ async function main(): Promise<void> {
   const tokens = readTokenConfigs(args.configPath);
   pinoLogger.info(`[${LABEL}] loaded ${tokens.length} token(s) from ${args.configPath}`);
 
-  if (args.registration) {
-    await waitForAttestationHealth(
-      args.registration.attestationUrl,
-      args.registration.healthTimeoutMs,
-    );
-  }
-
+  // Phase 1: resolve / deploy all tokens (no attestation dependency)
   const dataDir = process.env.FPC_DATA_DIR ?? "./deployments";
   let deployDeps: TestTokenDeployDeps | undefined;
+  const resolved: { address: AztecAddress; token: TokenConfig }[] = [];
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
     let address: AztecAddress;
@@ -259,7 +254,16 @@ async function main(): Promise<void> {
       address = manifest.contracts.token;
       pinoLogger.info(`[${LABEL}] token[${i}] "${token.name}" — deployed test token at ${address}`);
     }
-    if (args.registration) {
+    resolved.push({ address, token });
+  }
+
+  // Phase 2: wait for attestation and register all tokens
+  if (args.registration) {
+    await waitForAttestationHealth(
+      args.registration.attestationUrl,
+      args.registration.healthTimeoutMs,
+    );
+    for (const { address, token } of resolved) {
       await registerAssetPolicy(
         args.registration.attestationUrl,
         args.registration.adminApiKey,

--- a/docker-compose.public.yaml
+++ b/docker-compose.public.yaml
@@ -88,11 +88,6 @@ services:
       ADMIN_API_KEY: "${ADMIN_API_KEY}"
     env_file:
       - .env.${DEPLOYMENT}
-    depends_on:
-      deploy:
-        condition: service_completed_successfully
-      attestation:
-        condition: service_healthy
 
   tests-cold-start:
     image: "${TEST_IMAGE:-nethermind/aztec-fpc-test:local}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,24 +60,6 @@ services:
       aztec-node:
         condition: service_healthy
 
-  fund-l1-fee-juice:
-    image: ghcr.io/foundry-rs/foundry:v1.4.1
-    volumes:
-      - ./deployments/local:/app/data:ro
-      - ./scripts:/app/scripts:ro
-    entrypoint: ["bash", "/app/scripts/services/fund-l1-fee-juice.sh"]
-    environment:
-      L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
-      FPC_DATA_DIR: "/app/data"
-      L1_OPERATOR_PRIVATE_KEY: "${L1_OPERATOR_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-      L1_FEE_JUICE_FUNDER_PRIVATE_KEY: "${L1_FEE_JUICE_FUNDER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-      L1_FEE_JUICE_FUND_AMOUNT_WEI: "${L1_FEE_JUICE_FUND_AMOUNT_WEI:-1000000000000000000000}"
-    depends_on:
-      anvil:
-        condition: service_healthy
-      deploy:
-        condition: service_completed_successfully
-
   attestation:
     image: nethermind/aztec-fpc-attestation:local
     ports:
@@ -110,7 +92,7 @@ services:
       TOPUP_DATA_DIR: "${TOPUP_DATA_DIR:-/tmp/.topup-data}"
       TOPUP_AUTOCLAIM_ENABLED: "${TOPUP_AUTOCLAIM_ENABLED:-1}"
     depends_on:
-      fund-l1-fee-juice:
+      deploy:
         condition: service_completed_successfully
 
   block-producer:
@@ -139,9 +121,7 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       ADMIN_API_KEY: "${ADMIN_API_KEY:-admin-secret}"
     depends_on:
-      deploy:
-        condition: service_completed_successfully
-      attestation:
+      aztec-node:
         condition: service_healthy
 
   postdeploy:


### PR DESCRIPTION
## Summary
- Reorder `configure-token` flow: deploy/resolve all tokens first, then wait for attestation and register — allows the container to start without waiting for attestation
- Remove `attestation` from `configure-token` `depends_on` in both docker-compose files; local compose now depends only on `aztec-node`, public compose has no `depends_on`
- Remove `fund-l1-fee-juice` service from local docker-compose; `topup` now depends directly on `deploy`
- Add `configure-token` log step to CI workflow