### PR TITLE
fix: docker build ci intermittent error

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -154,5 +154,6 @@ jobs:
             -e FPC_ACCEPTED_ASSET \
             -e AZTEC_NODE_URL \
             -e FPC_SKIP_CONFIG_GEN=1 \
+            -e PXE_SYNC_CHAIN_TIP=checkpointed \
             -v ${{ github.workspace }}/deployments:/app/data \
             nethermind/aztec-fpc-contract-deployment:local

--- a/contract-deployment/src/deploy-utils.ts
+++ b/contract-deployment/src/deploy-utils.ts
@@ -93,9 +93,10 @@ export async function deployContract(
       const { receipt } = await deployMethod.send(opts);
       return receipt.txHash.toString();
     } catch (error) {
-      if (isClassPublicationRace(error) && attempt < MAX_RETRIES) {
+      if ((isClassPublicationRace(error) || isTransientBlockError(error)) && attempt < MAX_RETRIES) {
+        const reason = isClassPublicationRace(error) ? "class publication race" : "transient block error";
         pinoLogger.info(
-          `Contract class publication race detected (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying after ${RETRY_DELAY_MS}ms`,
+          `${reason} detected (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying after ${RETRY_DELAY_MS}ms`,
         );
         await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
         continue;
@@ -114,4 +115,9 @@ function isClassPublicationRace(error: unknown): boolean {
     msg.includes("Existing nullifier") ||
     msg.includes("dropped by P2P node")
   );
+}
+
+function isTransientBlockError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes("not found when querying world state");
 }

--- a/contract-deployment/src/index.ts
+++ b/contract-deployment/src/index.ts
@@ -391,7 +391,7 @@ async function main(): Promise<void> {
 
   // --- JS API wallet setup for contract deployments ---
   const wallet = await EmbeddedWallet.create(node, {
-    pxeConfig: { proverEnabled: args.proverEnabled },
+    pxeConfig: { proverEnabled: args.proverEnabled, syncChainTip: "checkpointed" },
   });
 
   const deployerSecretFr = Fr.fromHexString(args.deployerSecretKey);


### PR DESCRIPTION
The "Deploy to testnet" step sometimes fails with Block hash not found when querying world state because the embedded PXE anchors to the latest proposed (unfinalized) block, which can get pruned during proving.

Changes:

Set syncChainTip: "checkpointed" on the embedded wallet's PXE config — anchors to L1-committed blocks instead of the chain tip. This is the pattern Aztec's own E2E tests use for stability.
Add retry logic for transient block errors in deployContract() as a safety net.
Pass PXE_SYNC_CHAIN_TIP=checkpointed env var in the CI docker run step.