### PR TITLE
docs: update deployment guides for deploy/configure-token split

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,14 @@ Deploy the FPC contract and run the full operator stack with a single Docker Com
 export FPC_DEPLOYER_SECRET_KEY=0x<deployer_key>
 export FPC_OPERATOR_SECRET_KEY=0x<operator_key>
 export FPC_L1_DEPLOYER_KEY=0x<l1_deployer_key>
+export ADMIN_API_KEY=<admin_secret>
 
 DEPLOYMENT=testnet docker compose -f docker-compose.public.yaml up -d
 ```
 
-This deploys contracts, generates service configs, and starts the attestation and topup services. Output goes to `deployments/testnet/`.
+This deploys the FPC contract, starts the attestation and topup services, then deploys/registers tokens via the `configure-token` step. Output goes to `deployments/testnet/`.
 
-To deploy FPC against an existing token (skip test token deployment):
-
-```bash
-export FPC_ACCEPTED_ASSET=0x<token_address>
-DEPLOYMENT=testnet docker compose -f docker-compose.public.yaml up -d
-```
+To use existing tokens instead of deploying test tokens, set explicit `address` values in the `tokens` section of `deployments/testnet/fpc-config.yaml` before running compose.
 
 **[Full deployment & integration guide](docs/aztec-deployer-user-guide.md)** — deployer setup, service configuration, SDK integration, API reference, and troubleshooting.
 

--- a/docs/aztec-deployer-user-guide.md
+++ b/docs/aztec-deployer-user-guide.md
@@ -28,10 +28,11 @@ VERSION=4.1.0-nightly.20260312.2 bash -i <(curl -sL https://install.aztec.networ
 2. [Architecture](#architecture)
 3. [For Deployers](#for-deployers)
    - [Prerequisites](#deployer-prerequisites)
-   - [1. Deploy Contracts](#1-deploy-contracts)
+   - [1. Deploy FPC Contract](#1-deploy-fpc-contract)
    - [2. Configure & Start the Attestation Service](#2-configure--start-the-attestation-service)
-   - [3. Configure & Start the Top-up Service](#3-configure--start-the-top-up-service)
-   - [4. Verify the Deployment](#4-verify-the-deployment)
+   - [3. Configure Tokens](#3-configure-tokens)
+   - [4. Configure & Start the Top-up Service](#4-configure--start-the-top-up-service)
+   - [5. Verify the Deployment](#5-verify-the-deployment)
    - [Docker Compose (All-in-One)](#docker-compose-all-in-one)
 4. [For Users (SDK Integration)](#for-users-sdk-integration)
    - [Prerequisites](#user-prerequisites)
@@ -95,9 +96,11 @@ Aztec Network
 - An operator L2 secret key (or same as deployer)
 - An L1 private key (for the top-up service and optional test-token deploy)
 
-### 1. Deploy Contracts
+### 1. Deploy FPC Contract
 
 The `nethermind/aztec-fpc-contract-deployment` Docker image ships pre-compiled artifacts — no local Noir/Bun needed.
+
+Deployment is a two-phase process. This step deploys the FPC contract only. Token deployment and registration happen separately in [step 3](#3-configure-tokens), after the attestation service is running.
 
 #### Docker Image Tags
 
@@ -118,7 +121,7 @@ Available images: `nethermind/aztec-fpc-contract-deployment`, `nethermind/aztec-
 
 Replace `:local` with the appropriate tag if using pre-built images from a registry.
 
-#### Deploy FPC with an existing token
+#### Deploy FPC
 
 ```bash
 export FPC_DEPLOYER_SECRET_KEY=0x<deployer_hex32>
@@ -128,22 +131,6 @@ mkdir -p deployments
 
 docker run \
   -e AZTEC_NODE_URL=<AZTEC_NODE_URL> \
-  -e FPC_DEPLOYER_SECRET_KEY \
-  -e FPC_OPERATOR_SECRET_KEY \
-  -v ./deployments:/app/deployments \
-  nethermind/aztec-fpc-contract-deployment:local \
-  --accepted-asset <TOKEN_ADDRESS>
-```
-
-#### Deploy test tokens + FPC (for staging)
-
-```bash
-export FPC_L1_DEPLOYER_KEY=0x<l1_key>
-
-docker run \
-  -e AZTEC_NODE_URL=<AZTEC_NODE_URL> \
-  -e L1_RPC_URL=<L1_RPC_URL> \
-  -e FPC_L1_DEPLOYER_KEY \
   -e FPC_DEPLOYER_SECRET_KEY \
   -e FPC_OPERATOR_SECRET_KEY \
   -v ./deployments:/app/deployments \
@@ -159,22 +146,29 @@ docker run \
   -e FPC_OPERATOR_SECRET_KEY \
   -v ./deployments:/app/deployments \
   nethermind/aztec-fpc-contract-deployment:local \
-  --accepted-asset <TOKEN_ADDRESS> \
   --sponsored-fpc-address <EXISTING_FPC_ADDRESS>
 ```
 
 #### Output
 
-After deployment, `./deployments/` contains:
+After FPC deployment, `./deployments/` contains:
 
 ```
 deployments/
-├── manifest.json                ← deployment manifest (TREAT AS SECRET)
+├── manifest.json                ← FPC deployment manifest (TREAT AS SECRET)
 ├── fpc-config.yaml              ← master config (your copy)
 ├── attestation/
 │   └── config.yaml              ← generated attestation config
 └── topup/
     └── config.yaml              ← generated topup config
+```
+
+After token configuration ([step 3](#3-configure-tokens)), a `tokens/` directory is added:
+
+```
+deployments/
+└── tokens/
+    └── FpcAcceptedAsset.json    ← test token manifest (one per deployed token)
 ```
 
 > **Note:** If you provide a `fpc-config.yaml` before deploying, the container auto-generates per-service configs. Otherwise, deployment succeeds but config generation is skipped.
@@ -191,11 +185,11 @@ Key fields:
 
 | Section | Field | Description |
 |---------|-------|-------------|
-| `attestation` | `accepted_asset_name` | Human-readable token name (e.g. `"humanUSDC"`) |
-| `attestation` | `market_rate_num` / `market_rate_den` | Exchange rate: accepted_asset per 1 FeeJuice |
-| `attestation` | `fee_bips` | Operator margin in basis points (200 = 2%) |
+| `tokens` | `name` / `symbol` | Token identity (used for test token deployment and attestation registration) |
+| `tokens` | `address` | Existing token address (omit to deploy a test token) |
+| `tokens` | `market_rate_num` / `market_rate_den` | Exchange rate: accepted_asset per 1 FeeJuice |
+| `tokens` | `fee_bips` | Operator margin in basis points (200 = 2%) |
 | `attestation` | `quote_validity_seconds` | Quote TTL (default 300) |
-| `attestation` | `quote_format` | `amount_quote` (default) or `rate_quote`; changes response shape |
 | `attestation` | `quote_auth_mode` | Auth mode: `disabled`, `api_key`, `trusted_header`, etc. |
 | `topup` | `threshold` | Bridge when FPC balance drops below this (wei) |
 | `topup` | `top_up_amount` | Amount to bridge each time (wei) |
@@ -306,7 +300,75 @@ curl "http://localhost:3000/quote?user=<USER_ADDRESS>&accepted_asset=<TOKEN_ADDR
 
 ---
 
-### 3. Configure & Start the Top-up Service
+### 3. Configure Tokens
+
+Once the attestation service is running, use the `configure-token` subcommand to deploy test tokens (if needed) and register them with the attestation service.
+
+The `configure-token` subcommand reads the `tokens` section from `fpc-config.yaml`. For each token:
+- If `address` is provided, it registers the existing token with the attestation service.
+- If `address` is omitted, it first deploys a full test token stack (L1 ERC20 + L2 Token + Bridge + Faucet), then registers it.
+
+#### Configure tokens (deploy test tokens + register)
+
+```bash
+export FPC_DEPLOYER_SECRET_KEY=0x<deployer_hex32>
+export FPC_L1_DEPLOYER_KEY=0x<l1_key>
+export ADMIN_API_KEY=<admin_secret>
+
+docker run \
+  -e AZTEC_NODE_URL=<AZTEC_NODE_URL> \
+  -e L1_RPC_URL=<L1_RPC_URL> \
+  -e FPC_DEPLOYER_SECRET_KEY \
+  -e FPC_L1_DEPLOYER_KEY \
+  -e FPC_ATTESTATION_URL=<ATTESTATION_URL> \
+  -e ADMIN_API_KEY \
+  -v ./deployments:/app/deployments \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token
+```
+
+> If the attestation service is on `localhost`, add `--network host` so the container can reach the host network.
+
+#### Register existing tokens only
+
+If all tokens in `fpc-config.yaml` have explicit `address` values, no L1/L2 deployment keys are needed:
+
+```bash
+export ADMIN_API_KEY=<admin_secret>
+
+docker run \
+  -e FPC_ATTESTATION_URL=<ATTESTATION_URL> \
+  -e ADMIN_API_KEY \
+  -v ./deployments:/app/deployments \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token
+```
+
+#### Deploy tokens without registration
+
+Deploy test tokens only, skipping attestation registration (useful when attestation is not yet running):
+
+```bash
+docker run \
+  -e AZTEC_NODE_URL=<AZTEC_NODE_URL> \
+  -e L1_RPC_URL=<L1_RPC_URL> \
+  -e FPC_DEPLOYER_SECRET_KEY \
+  -e FPC_L1_DEPLOYER_KEY \
+  -v ./deployments:/app/deployments \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token --skip-registration
+```
+
+#### Output
+
+Test token manifests are written to `deployments/tokens/<TokenName>.json` and contain:
+- L2 addresses: token, bridge, faucet, counter
+- L1 addresses: ERC20, token portal
+- Faucet configuration and deployment tx hashes
+
+---
+
+### 4. Configure & Start the Top-up Service
 
 The top-up service monitors the FPC's Fee Juice balance and bridges from L1 when it drops below a threshold.
 
@@ -395,7 +457,7 @@ curl http://localhost:3001/metrics
 
 ---
 
-### 4. Verify the Deployment
+### 5. Verify the Deployment
 
 Run the post-deploy smoke test to confirm the full flow works end-to-end.
 
@@ -419,14 +481,18 @@ For testnet deployments, use the public compose file:
 export FPC_DEPLOYER_SECRET_KEY=0x<deployer_key>
 export FPC_OPERATOR_SECRET_KEY=0x<operator_key>
 export FPC_L1_DEPLOYER_KEY=0x<l1_key>
-
-# Optional: reuse existing token
-export FPC_ACCEPTED_ASSET=<TOKEN_ADDRESS>
+export ADMIN_API_KEY=<admin_secret>
 
 DEPLOYMENT=testnet docker compose -f docker-compose.public.yaml up -d
 ```
 
-This reads network defaults from `.env.testnet` and outputs everything to `deployments/testnet/`.
+The compose file reads network defaults from `.env.testnet` and mounts `deployments/${DEPLOYMENT}/` as the data directory. The service dependency chain is:
+
+1. `deploy` — deploys the FPC contract, writes manifest and service configs.
+2. `attestation` + `topup` — start once deploy completes.
+3. `configure-token` — deploys test tokens (if needed) and registers them with the running attestation service.
+
+After the run, all output lives in `deployments/testnet/`.
 
 ---
 
@@ -617,7 +683,7 @@ console.log(`Token charged: ${result.aaPaymentAmount}`);
 3. Builds the `cold_start_entrypoint` call that atomically claims bridged tokens and pays the FPC fee
 4. Proves, sends, and waits for the tx — returns the result once mined
 
-> **Where to find `<BRIDGE_ADDRESS>`:** The token bridge address is recorded in the deployment manifest (`manifest.json`) after contract deployment. If you deployed test tokens, the bridge was deployed alongside them. If you used an existing token (`--accepted-asset`), obtain the bridge address from the token's deployment records or the operator.
+> **Where to find `<BRIDGE_ADDRESS>`:** If test tokens were deployed via `configure-token`, the bridge address is recorded in the token manifest (`tokens/<TokenName>.json`). For production tokens with an existing address, obtain the bridge address from the token's deployment records or the operator.
 
 ---
 
@@ -814,13 +880,13 @@ docker run -v ./deployments:/app/deployments \
 [ ] Aztec node accessible at <AZTEC_NODE_URL>
 [ ] L1 RPC accessible at <L1_RPC_URL>
 [ ] Deployer and operator keys generated and secured
-[ ] Accepted token deployed (or address known)
-[ ] Master config (fpc-config.yaml) edited with correct exchange rates
+[ ] Master config (fpc-config.yaml) edited with tokens and exchange rates
 [ ] Docker images built or pulled (docker buildx bake or use registry tag)
-[ ] Contract deployed; manifest.json generated
+[ ] FPC contract deployed; manifest.json generated
 [ ] L1 operator account funded with ETH + Fee Juice tokens
 [ ] Attestation service running and /health returns 200
 [ ] quote_base_url set if behind a reverse proxy
+[ ] Tokens configured (configure-token completed; token manifests in tokens/)
 [ ] Top-up service running and /ready returns 200
 [ ] Auto-claim configured (TOPUP_AUTOCLAIM_SECRET_KEY set)
 [ ] Smoke test passing (docker compose smoke profile)
@@ -830,5 +896,5 @@ docker run -v ./deployments:/app/deployments \
     [ ] OPERATOR_ADDRESS: <OPERATOR_ADDRESS>
     [ ] TOKEN_ADDRESS: <TOKEN_ADDRESS>
     [ ] AZTEC_NODE_URL: <AZTEC_NODE_URL>
-    [ ] BRIDGE_ADDRESS: <BRIDGE_ADDRESS> (from manifest.json; required for cold-start)
+    [ ] BRIDGE_ADDRESS: <BRIDGE_ADDRESS> (from tokens/<TokenName>.json; required for cold-start)
 ```

--- a/docs/ops/docker-deployment-guide.md
+++ b/docs/ops/docker-deployment-guide.md
@@ -1,6 +1,11 @@
 # Docker Deployment Guide
 
-Deploy the FPC contract and generate service configs using the `nethermind/aztec-fpc-contract-deployment` Docker image. The image ships with pre-compiled contract artifacts and all required tooling — no local Aztec CLI, Bun, or Noir installation needed.
+Deploy the FPC contract and configure tokens using the `nethermind/aztec-fpc-contract-deployment` Docker image. The image ships with pre-compiled contract artifacts and all required tooling — no local Aztec CLI, Bun, or Noir installation needed.
+
+Deployment is a two-phase process:
+
+1. **FPC deploy** — deploys the `FPCMultiAsset` contract and generates service configs.
+2. **Token configuration** (`configure-token` subcommand) — deploys test tokens (if needed) and registers them with the attestation service via its admin API.
 
 ## Prerequisites
 
@@ -14,41 +19,75 @@ Deploy the FPC contract and generate service configs using the `nethermind/aztec
 # 1. Prepare the service master config
 mkdir -p deployments
 cp deployments/fpc-config.example.yaml deployments/fpc-config.yaml
-# Edit deployments/fpc-config.yaml — set exchange rates, thresholds, ports, etc.
+# Edit deployments/fpc-config.yaml — set tokens, exchange rates, thresholds, ports, etc.
 
 # 2. Export secrets (keep values out of docker commands)
 export FPC_DEPLOYER_SECRET_KEY=0x<deployer_hex32>
 export FPC_OPERATOR_SECRET_KEY=0x<operator_hex32>
 
-# 3. Deploy contracts and generate service configs
+# 3. Deploy FPC contract and generate service configs
 docker run -v ./deployments:/app/deployments \
   -e AZTEC_NODE_URL=https://rpc.testnet.aztec-labs.com \
   -e FPC_DEPLOYER_SECRET_KEY \
   -e FPC_OPERATOR_SECRET_KEY \
   nethermind/aztec-fpc-contract-deployment:local
+
+# 4. Start the attestation service (required before configure-token)
+#    ... see attestation service docs ...
+
+# 5. Deploy test tokens and register with attestation
+export FPC_L1_DEPLOYER_KEY=0x<l1_key>
+export ADMIN_API_KEY=<admin_secret>
+
+docker run -v ./deployments:/app/deployments \
+  -e AZTEC_NODE_URL=https://rpc.testnet.aztec-labs.com \
+  -e L1_RPC_URL=<L1_RPC_URL> \
+  -e FPC_DEPLOYER_SECRET_KEY \
+  -e FPC_L1_DEPLOYER_KEY \
+  -e FPC_ATTESTATION_URL=<ATTESTATION_URL> \
+  -e ADMIN_API_KEY \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token
 ```
 
-The container:
+## Phase 1: FPC deploy
+
+The default entrypoint (no subcommand) deploys the FPC contract:
 
 1. Deploys `FPCMultiAsset` to the target Aztec node.
 2. Writes a deployment manifest to `deployments/manifest.json`.
 3. Auto-generates service configs from the manifest + `deployments/fpc-config.yaml`.
 
+## Phase 2: Token configuration
+
+The `configure-token` subcommand handles tokens separately:
+
+1. Reads the `tokens` section from `fpc-config.yaml`.
+2. For each token without an `address`, deploys a test token stack (L1 ERC20 + L2 Token + Bridge + Faucet).
+3. Registers each token with the attestation service via `PUT /admin/asset-policies/:address`.
+4. Writes test token manifests to `deployments/tokens/<TokenName>.json`.
+
+This requires the attestation service to be running and healthy (it waits for the health check).
+
 ## Output
 
-After the run completes, your local `./deployments/` directory will contain:
+After both phases complete, your local `./deployments/` directory will contain:
 
 ```text
 deployments/
-├── manifest.json                ← deployment manifest (treat as secret material)
+├── manifest.json                ← FPC deployment manifest (treat as secret material)
 ├── fpc-config.yaml              ← master config (your copy)
 ├── attestation/
 │   └── config.yaml              ← generated attestation service config
-└── topup/
-    └── config.yaml              ← generated topup service config
+├── topup/
+│   └── config.yaml              ← generated topup service config
+└── tokens/
+    └── FpcAcceptedAsset.json    ← test token manifest (one per deployed token)
 ```
 
 The generated `attestation/config.yaml` and `topup/config.yaml` have the deployed contract addresses (`fpc_address`) injected and are ready to mount into the service containers.
+
+Test token manifests in `tokens/` contain the L2 token, bridge, faucet, and counter addresses plus L1 ERC20 and portal addresses.
 
 ## Master config
 
@@ -62,17 +101,21 @@ Key fields:
 
 | Section | Field | Description |
 |---------|-------|-------------|
+| `tokens` | `name` / `symbol` | Token identity (used for test token deployment) |
+| `tokens` | `address` | Existing token address (omit to deploy a test token) |
+| `tokens` | `market_rate_num` / `market_rate_den` | Exchange rate: accepted_asset per 1 FeeJuice |
+| `tokens` | `fee_bips` | Operator margin in basis points (200 = 2%) |
 | `attestation` | `quote_validity_seconds` | Quote TTL (default 300) |
 | `attestation` | `quote_auth_mode` | Auth mode: `disabled`, `api_key`, `trusted_header`, etc. |
 | `topup` | `threshold` | Bridge when FPC balance drops below this (wei) |
 | `topup` | `top_up_amount` | Amount to bridge each time (wei) |
 | `topup` | `check_interval_ms` | Balance poll interval (default 60000) |
 
-See [`deployments/fpc-config.example.yaml`](../deployments/fpc-config.example.yaml) for the full reference with comments.
+See [`deployments/fpc-config.example.yaml`](../../deployments/fpc-config.example.yaml) for the full reference with comments.
 
 If the master config is not present at deploy time, deployment still succeeds but config generation is skipped.
 
-## CLI arguments
+## CLI arguments — FPC deploy
 
 All arguments are optional. CLI args take precedence over environment variables.
 
@@ -121,6 +164,29 @@ CLI equivalents (`--deployer-secret-key`, `--operator-secret-key`, etc.) exist b
 
 Run `--help` for the built-in usage text.
 
+## CLI arguments — configure-token
+
+The `configure-token` subcommand is invoked by passing `configure-token` as the first argument to the container.
+
+| Argument | Description | Env var |
+|----------|-------------|---------|
+| `--config <path>` | Master config path (default: `$FPC_DATA_DIR/fpc-config.yaml`) | `FPC_MASTER_CONFIG` |
+| `--attestation-url <url>` | Attestation server URL (required unless `--skip-registration`) | `FPC_ATTESTATION_URL` |
+| `--admin-api-key <key>` | Admin API key for attestation registration (required unless `--skip-registration`) | `ADMIN_API_KEY` |
+| `--health-timeout-ms <ms>` | Attestation health check timeout (default: 30000) | `FPC_HEALTH_TIMEOUT_MS` |
+| `--skip-registration` | Deploy tokens only, skip attestation registration | `FPC_SKIP_REGISTRATION=1` |
+
+Token deployment also requires:
+
+| Env var | Description |
+|---------|-------------|
+| `AZTEC_NODE_URL` | Aztec node URL (required for deploying test tokens) |
+| `L1_RPC_URL` | L1 RPC URL (required for deploying test tokens) |
+| `FPC_DEPLOYER_SECRET_KEY` | Deployer L2 secret key (required for deploying test tokens) |
+| `FPC_L1_DEPLOYER_KEY` | L1 deployer private key (required for deploying test tokens) |
+
+These are only needed when one or more tokens in the config omit `address` (i.e. test tokens need to be deployed). If all tokens have explicit addresses, only attestation registration is performed.
+
 ## Examples
 
 All examples below assume secrets are exported beforehand:
@@ -141,7 +207,7 @@ docker run \
   nethermind/aztec-fpc-contract-deployment:local
 ```
 
-### Reuse a token with sponsored FPC payment
+### Deploy FPC with sponsored FPC payment
 
 ```bash
 docker run \
@@ -151,6 +217,54 @@ docker run \
   -v ./deployments:/app/deployments \
   nethermind/aztec-fpc-contract-deployment:local \
   --sponsored-fpc-address 0x<fpc_address>
+```
+
+### Configure tokens (deploy test tokens + register with attestation)
+
+```bash
+export FPC_L1_DEPLOYER_KEY=0x<l1_key>
+export ADMIN_API_KEY=<admin_secret>
+
+docker run \
+  -e AZTEC_NODE_URL=https://rpc.testnet.aztec-labs.com \
+  -e L1_RPC_URL=<L1_RPC_URL> \
+  -e FPC_DEPLOYER_SECRET_KEY \
+  -e FPC_L1_DEPLOYER_KEY \
+  -e FPC_ATTESTATION_URL=<ATTESTATION_URL> \
+  -e ADMIN_API_KEY \
+  -v ./deployments:/app/deployments \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token
+```
+
+> If the attestation service is on `localhost`, add `--network host` so the container can reach the host network.
+
+### Register existing tokens only (no test token deployment)
+
+If all tokens in `fpc-config.yaml` have explicit `address` values, no L1/L2 deployment is needed:
+
+```bash
+export ADMIN_API_KEY=<admin_secret>
+
+docker run \
+  -e FPC_ATTESTATION_URL=<ATTESTATION_URL> \
+  -e ADMIN_API_KEY \
+  -v ./deployments:/app/deployments \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token
+```
+
+### Deploy tokens without attestation registration
+
+```bash
+docker run \
+  -e AZTEC_NODE_URL=https://rpc.testnet.aztec-labs.com \
+  -e L1_RPC_URL=<L1_RPC_URL> \
+  -e FPC_DEPLOYER_SECRET_KEY \
+  -e FPC_L1_DEPLOYER_KEY \
+  -v ./deployments:/app/deployments \
+  nethermind/aztec-fpc-contract-deployment:local \
+  configure-token --skip-registration
 ```
 
 ### Preflight check (no deployment)
@@ -203,21 +317,31 @@ docker run -v ./deployments:/app/deployments \
 
 ## Docker Compose for public networks
 
-For deploying to public networks (devnet, testnet), use `docker-compose.public.yaml`. This runs the full stack — contract deployment, post-deploy smoke, attestation service, and topup service — in one command.
+For deploying to public networks (devnet, testnet), use `docker-compose.public.yaml`. This runs the full stack — FPC deployment, token configuration, attestation service, and topup service — in one command.
 
 ```bash
 DEPLOYMENT=testnet docker compose -f docker-compose.public.yaml up -d
 ```
 
-The compose file reads network defaults (node URL, L1 RPC) from `.env.${DEPLOYMENT}` (e.g. `.env.testnet`) and mounts `deployments/${DEPLOYMENT}/` as the data directory. After the run, all output — manifest, generated service configs — lives in `deployments/testnet/`:
+The compose file reads network defaults (node URL, L1 RPC) from `.env.${DEPLOYMENT}` (e.g. `.env.testnet`) and mounts `deployments/${DEPLOYMENT}/` as the data directory.
+
+The service dependency chain is:
+
+1. `deploy` — deploys the FPC contract, writes manifest and service configs.
+2. `attestation` + `topup` — start once deploy completes.
+3. `configure-token` — deploys test tokens (if needed) and registers them with the running attestation service.
+
+After the run, all output lives in `deployments/testnet/`:
 
 ```text
 deployments/testnet/
 ├── manifest.json
 ├── attestation/
 │   └── config.yaml
-└── topup/
-    └── config.yaml
+├── topup/
+│   └── config.yaml
+└── tokens/
+    └── FpcAcceptedAsset.json
 ```
 
 Secrets must be exported before running:
@@ -225,6 +349,8 @@ Secrets must be exported before running:
 ```bash
 export FPC_DEPLOYER_SECRET_KEY=0x<deployer_key>
 export FPC_OPERATOR_SECRET_KEY=0x<operator_key>
+export FPC_L1_DEPLOYER_KEY=0x<l1_key>
+export ADMIN_API_KEY=<admin_secret>
 ```
 
 ## Building the image


### PR DESCRIPTION
## Summary
- Updated both `docs/ops/docker-deployment-guide.md` and `docs/aztec-deployer-user-guide.md` to reflect the split between FPC contract deployment and token configuration
- Documented the two-phase deployment process: FPC deploy (phase 1) → configure-token subcommand (phase 2)
- Added new "CLI arguments — configure-token" section with all flags and env vars
- Added new "Configure Tokens" step (step 3) to the deployer user guide between attestation and topup
- Updated master config documentation to reflect the `tokens` section replacing single-asset `attestation` fields
- Updated output directory structure to include `tokens/` for test token manifests
- Removed stale `--accepted-asset` references and "Deploy test tokens + FPC" examples
- Updated Docker Compose sections with the new service dependency chain (deploy → attestation → configure-token)
- Fixed secret handling: all secrets (`FPC_L1_DEPLOYER_KEY`, `ADMIN_API_KEY`) are now exported separately, never passed inline
- Removed unnecessary `--network host` from examples; added note about when it's needed
- Updated deployment checklist and bridge address references to point to `tokens/<TokenName>.json`