### PR TITLE
chore: scope docker bake to services target

### DIFF
--- a/.github/workflows/docker-build-services.yml
+++ b/.github/workflows/docker-build-services.yml
@@ -66,6 +66,7 @@ jobs:
           PLATFORMS: 'linux/amd64,linux/arm64'
         with:
           source: .
+          targets: services
           push: true
           set: |
             *.cache-from=type=gha


### PR DESCRIPTION
## Summary
- Add `targets: services` to the docker-build-services workflow so `docker buildx bake` only builds the services group instead of all targets in the bake file