### PR TITLE
ci: add ARM builds to Docker CI pipeline

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -53,7 +53,11 @@ jobs:
   docker-build-ci:
     needs: [changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     env:
       PXE_PROVER_ENABLED: false
     steps:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -92,7 +92,7 @@ target "deps" {
 target "contract" {
   context    = "."
   dockerfile = "scripts/contract/Dockerfile.contract"
-  platforms  = ["linux/amd64"]
+  platforms  = PLATFORMS
   tags = compact([
     "${REGISTRY}nethermind/aztec-fpc-contract-artifact:${TAG}${PLATFORM_SUFFIX}",
     GIT_SHA != "" ? "${REGISTRY}nethermind/aztec-fpc-contract-artifact:${GIT_SHA}${PLATFORM_SUFFIX}" : "",


### PR DESCRIPTION
## Summary
- Add matrix strategy to Docker CI workflow to build on both `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` runners
- Use shared `PLATFORMS` variable for the `contract` target instead of hardcoded `linux/amd64`