### PR TITLE
fix: fund-l1-fee-juice reads fee juice address from node_getNodeInfo

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -62,14 +62,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # Pull + start anvil & aztec-node in the background while images build.
       # The two use external images unaffected by bake, so they can start early

--- a/.github/workflows/docker-build-services.yml
+++ b/.github/workflows/docker-build-services.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,20 @@ services:
       aztec-node:
         condition: service_healthy
 
+  fund-l1-fee-juice:
+    image: ghcr.io/foundry-rs/foundry:v1.4.1
+    volumes:
+      - ./scripts:/app/scripts:ro
+    entrypoint: ["bash", "/app/scripts/services/fund-l1-fee-juice.sh"]
+    environment:
+      AZTEC_NODE_URL: "${AZTEC_NODE_URL:-http://aztec-node:8080}"
+      L1_RPC_URL: "${L1_RPC_URL:-http://anvil:8545}"
+      L1_OPERATOR_PRIVATE_KEY: "${L1_OPERATOR_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+      L1_FEE_JUICE_FUND_AMOUNT_WEI: "${L1_FEE_JUICE_FUND_AMOUNT_WEI:-1000000000000000000000}"
+    depends_on:
+      aztec-node:
+        condition: service_healthy
+
   attestation:
     image: nethermind/aztec-fpc-attestation:local
     ports:
@@ -94,6 +108,8 @@ services:
     depends_on:
       deploy:
         condition: service_completed_successfully
+      fund-l1-fee-juice:
+        condition: service_completed_successfully
 
   block-producer:
     image: nethermind/aztec-fpc-contract-artifact:local
@@ -121,8 +137,8 @@ services:
       FPC_ATTESTATION_URL: "http://attestation:3000"
       ADMIN_API_KEY: "${ADMIN_API_KEY:-admin-secret}"
     depends_on:
-      aztec-node:
-        condition: service_healthy
+      fund-l1-fee-juice:
+        condition: service_completed_successfully
 
   postdeploy:
     image: nethermind/aztec-fpc-test:local

--- a/scripts/services/fund-l1-fee-juice.sh
+++ b/scripts/services/fund-l1-fee-juice.sh
@@ -1,41 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-L1_RPC_URL="${L1_RPC_URL:-http://anvil:8545}"
-FPC_DATA_DIR="${FPC_DATA_DIR:-./deployments}"
-FPC_DEPLOY_MANIFEST="${FPC_DEPLOY_MANIFEST:-$FPC_DATA_DIR/manifest.json}"
-L1_FEE_JUICE_FUNDER_PRIVATE_KEY="${L1_FEE_JUICE_FUNDER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-L1_OPERATOR_PRIVATE_KEY="${L1_OPERATOR_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+L1_RPC_URL="${L1_RPC_URL:?L1_RPC_URL is required}"
+AZTEC_NODE_URL="${AZTEC_NODE_URL:?AZTEC_NODE_URL is required}"
+L1_OPERATOR_PRIVATE_KEY="${L1_OPERATOR_PRIVATE_KEY:?L1_OPERATOR_PRIVATE_KEY is required}"
 L1_FEE_JUICE_FUND_AMOUNT_WEI="${L1_FEE_JUICE_FUND_AMOUNT_WEI:-1000000000000000000000}"
 
-if [ -n "${L1_FEE_JUICE_TOKEN_ADDRESS:-}" ]; then
-  FEE_JUICE_TOKEN_ADDRESS="${L1_FEE_JUICE_TOKEN_ADDRESS}"
-else
-  if [ ! -f "$FPC_DEPLOY_MANIFEST" ]; then
-    echo "ERROR: missing deploy manifest at $FPC_DEPLOY_MANIFEST" >&2
-    exit 1
-  fi
-
-  FEE_JUICE_TOKEN_ADDRESS="$(
-    grep -oE '"feeJuiceAddress"[[:space:]]*:[[:space:]]*"0x[0-9a-fA-F]+"' "$FPC_DEPLOY_MANIFEST" \
-      | head -n1 \
-      | sed -E 's/.*"(0x[0-9a-fA-F]+)".*/\1/'
-  )"
-fi
+FEE_JUICE_TOKEN_ADDRESS="$(
+  cast rpc node_getNodeInfo --rpc-url "$AZTEC_NODE_URL" \
+    | grep -oE '"(feeJuiceAddress|feeJuice)"[[:space:]]*:[[:space:]]*"0x[0-9a-fA-F]+"' \
+    | head -n1 \
+    | sed -E 's/.*"(0x[0-9a-fA-F]+)".*/\1/'
+)"
 
 if [ -z "${FEE_JUICE_TOKEN_ADDRESS:-}" ]; then
-  echo "ERROR: could not resolve feeJuiceAddress from manifest or L1_FEE_JUICE_TOKEN_ADDRESS" >&2
+  echo "ERROR: could not resolve feeJuiceAddress from node_getNodeInfo at $AZTEC_NODE_URL" >&2
   exit 1
 fi
 
 OPERATOR_ADDRESS="$(cast wallet address --private-key "$L1_OPERATOR_PRIVATE_KEY")"
 
-echo "[fund-l1-fee-juice] token=$FEE_JUICE_TOKEN_ADDRESS amount=$L1_FEE_JUICE_FUND_AMOUNT_WEI"
+echo "[fund-l1-fee-juice] token=$FEE_JUICE_TOKEN_ADDRESS"
+echo "[fund-l1-fee-juice] amount=$L1_FEE_JUICE_FUND_AMOUNT_WEI"
 echo "[fund-l1-fee-juice] operator=$OPERATOR_ADDRESS"
 
 cast send "$FEE_JUICE_TOKEN_ADDRESS" "mint(address,uint256)" "$OPERATOR_ADDRESS" "$L1_FEE_JUICE_FUND_AMOUNT_WEI" \
   --rpc-url "$L1_RPC_URL" \
-  --private-key "$L1_FEE_JUICE_FUNDER_PRIVATE_KEY" >/dev/null
+  --private-key "$L1_OPERATOR_PRIVATE_KEY" >/dev/null
 
 BALANCE="$(cast call "$FEE_JUICE_TOKEN_ADDRESS" "balanceOf(address)(uint256)" "$OPERATOR_ADDRESS" --rpc-url "$L1_RPC_URL")"
 echo "[fund-l1-fee-juice] funded balance=$BALANCE"


### PR DESCRIPTION
## Summary
- Re-add `fund-l1-fee-juice` docker-compose service (removed in #313)
- Replace manifest file reading with `node_getNodeInfo` JSON-RPC call to resolve `feeJuiceAddress`
- Consolidate `L1_FEE_JUICE_FUNDER_PRIVATE_KEY` and `L1_OPERATOR_PRIVATE_KEY` into a single key
- Remove defaults for required env vars (`L1_RPC_URL`, `AZTEC_NODE_URL`, `L1_OPERATOR_PRIVATE_KEY`)
- Restore `topup` dependency on `fund-l1-fee-juice`