### PR TITLE
feat: migrate service tests to vitest and add AssetPolicyStore.get()

### DIFF
--- a/services/attestation/package.json
+++ b/services/attestation/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "bun build src/index.ts --outdir=dist --target=${BUILD_TARGET:-bun} --external @aztec/bb.js --external @aztec/noir-noirc_abi --external @aztec/noir-acvm_js --external pino --external lmdb --external ordered-binary",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/*.test.ts",
+    "test": "vitest run",
     "start": "bun run dist/index.js",
     "dev": "tsx src/index.ts"
   },
@@ -31,6 +31,12 @@
     "lmdb": "^3.2.0",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"
+  },
+  "imports": {
+    "#test": {
+      "bun": "bun:test",
+      "default": "vitest"
+    }
   },
   "engines": {
     "bun": "1.3.11"

--- a/services/attestation/src/asset-policy-store.ts
+++ b/services/attestation/src/asset-policy-store.ts
@@ -46,6 +46,7 @@ function normalizeSupportedAssetPolicies(policies: SupportedAssetPolicy[]): Supp
 }
 
 export interface AssetPolicyStore {
+  get(address: string): SupportedAssetPolicy | undefined;
   getAll(): SupportedAssetPolicy[];
   upsert(policy: SupportedAssetPolicy): Promise<SupportedAssetPolicy>;
   remove(address: string): Promise<SupportedAssetPolicy>;
@@ -66,6 +67,12 @@ export class LmdbAssetPolicyStore implements AssetPolicyStore {
         this.db.putSync(policy.address, policy);
       }
     }
+  }
+
+  get(address: string): SupportedAssetPolicy | undefined {
+    const normalizedAddress = normalizeAztecAddress(address);
+    const policy = this.db.get(normalizedAddress);
+    return policy ? { ...policy } : undefined;
   }
 
   getAll(): SupportedAssetPolicy[] {

--- a/services/attestation/src/server.ts
+++ b/services/attestation/src/server.ts
@@ -8,7 +8,6 @@ import {
   type Config,
   computeFinalRate,
   modeNeedsApiKey,
-  normalizeAztecAddress,
   type SupportedAssetPolicy,
 } from "./config.js";
 import { AttestationMetrics, type QuoteOutcome } from "./metrics.js";
@@ -275,16 +274,8 @@ function parseRequiredNonZeroAztecAddress(
   return { ok: true, value: parsedAddress };
 }
 
-function resolveSelectedAssetPolicy(
-  supportedAssets: SupportedAssetPolicy[],
-  selectedAcceptedAssetAddress: string,
-): SupportedAssetPolicy | undefined {
-  const selectedAddress = normalizeAztecAddress(selectedAcceptedAssetAddress);
-  return supportedAssets.find((asset) => asset.address === selectedAddress);
-}
-
 function parseQuoteRequest(
-  supportedAssets: SupportedAssetPolicy[],
+  assetPolicyStore: AssetPolicyStore,
   query: QuoteRequestQuery,
 ): QuoteRequestParseResult {
   const parsedUserAddress = parseRequiredNonZeroAztecAddress(
@@ -305,10 +296,7 @@ function parseQuoteRequest(
     return parsedAcceptedAsset;
   }
 
-  const selectedAssetPolicy = resolveSelectedAssetPolicy(
-    supportedAssets,
-    parsedAcceptedAsset.value.toString(),
-  );
+  const selectedAssetPolicy = assetPolicyStore.get(parsedAcceptedAsset.value.toString());
   if (!selectedAssetPolicy) {
     return { ok: false, message: "Unsupported accepted_asset" };
   }
@@ -354,10 +342,10 @@ function parseRequiredHexField(
 }
 
 function parseColdStartQuoteRequest(
-  supportedAssets: SupportedAssetPolicy[],
+  assetPolicyStore: AssetPolicyStore,
   query: ColdStartQuoteRequestQuery,
 ): ColdStartQuoteRequestParseResult {
-  const baseResult = parseQuoteRequest(supportedAssets, query);
+  const baseResult = parseQuoteRequest(assetPolicyStore, query);
   if (!baseResult.ok) {
     return baseResult;
   }
@@ -614,7 +602,7 @@ function parseAdminSweepRequest(
   if (!acceptedAsset) {
     throw new Error("Missing required field: accepted_asset");
   }
-  if (!resolveSelectedAssetPolicy(assetPolicyStore.getAll(), acceptedAsset)) {
+  if (!assetPolicyStore.get(acceptedAsset)) {
     throw new Error("Unsupported accepted_asset");
   }
 
@@ -713,7 +701,7 @@ function registerQuoteRoute(context: ServerContext): void {
       return reply.code(401).send(unauthorized());
     }
 
-    const parsedRequest = parseQuoteRequest(assetPolicyStore.getAll(), req.query);
+    const parsedRequest = parseQuoteRequest(assetPolicyStore, req.query);
     if (!parsedRequest.ok) {
       observe("bad_request");
       return reply.code(400).send(badRequest(parsedRequest.message));
@@ -1013,7 +1001,7 @@ function registerColdStartQuoteRoute(context: ServerContext): void {
       return reply.code(401).send(unauthorized());
     }
 
-    const parsedRequest = parseColdStartQuoteRequest(assetPolicyStore.getAll(), req.query);
+    const parsedRequest = parseColdStartQuoteRequest(assetPolicyStore, req.query);
     if (!parsedRequest.ok) {
       observe("bad_request");
       return reply.code(400).send(badRequest(parsedRequest.message));

--- a/services/attestation/test/asset-policy-store.test.ts
+++ b/services/attestation/test/asset-policy-store.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import { LmdbAssetPolicyStore } from "../src/asset-policy-store.js";
 import type { Config } from "../src/config.js";
 
@@ -58,6 +58,27 @@ function makeConfig(statePath: string): Config {
 }
 
 describe("asset policy store", () => {
+  it("looks up a single asset by address", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "asset-policy-store-test-"));
+    const dbPath = path.join(dir, "assets-db");
+
+    try {
+      const config = makeConfig(dbPath);
+      const store = new LmdbAssetPolicyStore(config);
+
+      const seededAddress = "0x0000000000000000000000000000000000000000000000000000000000000002";
+      assert.equal(store.get(seededAddress)?.name, "humanUSDC");
+      assert.equal(
+        store.get("0x0000000000000000000000000000000000000000000000000000000000000099"),
+        undefined,
+      );
+
+      await store.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("persists admin-managed supported asset state", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "asset-policy-store-test-"));
     const dbPath = path.join(dir, "assets-db");

--- a/services/attestation/test/config.test.ts
+++ b/services/attestation/test/config.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import { loadConfig } from "../src/config.js";
 
 const VALID_SECRET = "0x0000000000000000000000000000000000000000000000000000000000000001";

--- a/services/attestation/test/fpc-immutables.test.ts
+++ b/services/attestation/test/fpc-immutables.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import type { AztecNode } from "@aztec/aztec.js/node";
+import { describe, it } from "#test";
 import {
   computeExpectedFpcInitializationHash,
   FpcImmutableVerificationError,

--- a/services/attestation/test/server.test.ts
+++ b/services/attestation/test/server.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { rmSync } from "node:fs";
-import { afterEach, describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { afterEach, describe, it } from "#test";
 import type { Config } from "../src/config.js";
 import type { OperatorTreasuryPort } from "../src/operator-treasury.js";
 import { buildServer } from "../src/server.js";

--- a/services/attestation/test/signer.test.ts
+++ b/services/attestation/test/signer.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import { computeInnerAuthWitHash } from "@aztec/stdlib/auth-witness";
+import { describe, it } from "#test";
 import {
   type ColdStartQuoteParams,
   computeColdStartQuoteHash,

--- a/services/topup/package.json
+++ b/services/topup/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "bun build src/index.ts --outdir=dist --target=${BUILD_TARGET:-bun} --external @aztec/bb.js --external @aztec/noir-noirc_abi --external @aztec/noir-acvm_js --external pino --external lmdb --external ordered-binary",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/*.test.ts",
+    "test": "vitest run",
     "fund:claimer:l2": "tsx src/fund-claimer-l2.ts",
     "start": "bun run dist/index.js",
     "dev": "tsx src/index.ts"
@@ -29,6 +29,12 @@
     "lmdb": "^3.2.0",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"
+  },
+  "imports": {
+    "#test": {
+      "bun": "bun:test",
+      "default": "vitest"
+    }
   },
   "engines": {
     "bun": "1.3.11"

--- a/services/topup/test/autoclaim.test.ts
+++ b/services/topup/test/autoclaim.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import {
   resolveAutoClaimSecretKeyFromEnv,
   resolveAutoClaimSponsoredFpcFromEnv,

--- a/services/topup/test/bridge.test.ts
+++ b/services/topup/test/bridge.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import type { AztecNode } from "@aztec/aztec.js/node";
 import type { createExtendedL1Client } from "@aztec/ethereum/client";
 import { createLogger } from "@aztec/foundation/log";
 import type { Chain } from "viem";
+import { describe, it } from "#test";
 import type { BridgeDeps } from "../src/bridge.js";
 import { bridgeFeeJuice, isNonceTooLowError, isRetryableNonceError } from "../src/bridge.js";
 
@@ -192,7 +192,7 @@ describe("bridge", () => {
       /already known/,
     );
     assert.equal(attempts, 3);
-  });
+  }, 15_000);
 
   it("classifies nonce errors correctly", () => {
     assert.equal(isNonceTooLowError(new Error("nonce too low")), true);

--- a/services/topup/test/checker.test.ts
+++ b/services/topup/test/checker.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import { createTopupChecker } from "../src/checker.js";
 
 const HASH = `0x${"ab".repeat(32)}` as `0x${string}`;

--- a/services/topup/test/config.test.ts
+++ b/services/topup/test/config.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import { loadConfig } from "../src/config.js";
 
 const VALID_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";

--- a/services/topup/test/confirm.test.ts
+++ b/services/topup/test/confirm.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import type { Fr } from "@aztec/aztec.js/fields";
 import type { AztecNode } from "@aztec/aztec.js/node";
+import { describe, it } from "#test";
 import { waitForFeeJuiceBridgeConfirmation } from "../src/confirm.js";
 
 const FPC = AztecAddress.fromString(

--- a/services/topup/test/l1.test.ts
+++ b/services/topup/test/l1.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import { assertL1RpcChainIdMatches } from "../src/l1.js";
 
 describe("l1", () => {

--- a/services/topup/test/monitor.test.ts
+++ b/services/topup/test/monitor.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import type { AztecNode } from "@aztec/aztec.js/node";
+import { describe, it } from "#test";
 import { createGetFeeJuiceBalance } from "../src/monitor.js";
 
 describe("monitor", () => {

--- a/services/topup/test/ops.test.ts
+++ b/services/topup/test/ops.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it } from "#test";
 import { createTopupOpsServer, TopupOpsState } from "../src/ops.js";
 
 describe("topup ops", () => {

--- a/services/topup/test/reconcile.test.ts
+++ b/services/topup/test/reconcile.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { describe, it } from "#test";
 import { reconcilePersistedBridgeState } from "../src/reconcile.js";
 import type { BridgeStateStore } from "../src/state.js";
 

--- a/services/topup/test/state.test.ts
+++ b/services/topup/test/state.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { describe, it } from "#test";
 import { reconcilePersistedBridgeState } from "../src/reconcile.js";
 import {
   acquireProcessLock,


### PR DESCRIPTION
Test runner migration (#318): Replace tsx --test with vitest run in attestation and topup service test scripts. Migrate all test imports from node:test to the #test subpath alias (resolves to vitest on Node.js, bun:test on Bun), completing the ARM64-compatible test runner setup from #338.
Direct asset lookup (#322): Add get(address) to the AssetPolicyStore interface for O(1) LMDB lookup. Replace getAll() + linear scan in quote, cold-start-quote, and admin sweep request parsing with direct get() calls.