### PR TITLE
refactor: reduce unknown types and use static imports

### DIFF
--- a/profiling/benchmarks/cold-start.benchmark.ts
+++ b/profiling/benchmarks/cold-start.benchmark.ts
@@ -25,6 +25,8 @@ const pinoLogger = pino({
  *   L1_RPC_URL      — L1 (anvil) endpoint (default http://127.0.0.1:8545)
  */
 
+import { FeeJuiceArtifact } from '@aztec/protocol-contracts/fee-juice';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { createAztecNodeClient } from '@aztec/aztec.js/node';
 import { Contract } from '@aztec/aztec.js/contracts';
 import { L1FeeJuicePortalManager, L1ToL2TokenPortalManager } from '@aztec/aztec.js/ethereum';
@@ -203,6 +205,7 @@ interface ColdStartBenchmarkContext {
   userAddress: any;
   operatorAddress: any;
   fpcAddress: any;
+  _coldStartAction?: ColdStartAction;
 }
 
 export default class ColdStartBenchmark {
@@ -504,7 +507,7 @@ export default class ColdStartBenchmark {
   }
 
   getMethods(context: ColdStartBenchmarkContext) {
-    const action = (context as any)._coldStartAction;
+    const action = context._coldStartAction;
     if (!action) {
       throw new Error('ColdStartAction not found in context — was setup() called?');
     }
@@ -694,13 +697,7 @@ async function fundFpcWithFeeJuice(
 
   await mineL1Blocks(l1Client, 5);
 
-  const { FeeJuiceArtifact } = await import('@aztec/protocol-contracts/fee-juice');
-  const { ProtocolContractAddress } = await import('@aztec/protocol-contracts');
-  const feeJuice = Contract.at(
-    ProtocolContractAddress.FeeJuice,
-    FeeJuiceArtifact,
-    wallet,
-  );
+  const feeJuice = Contract.at(ProtocolContractAddress.FeeJuice, FeeJuiceArtifact, wallet);
   const MAX_ATTEMPTS = 30;
 
   function isRetryable(msg: string) {

--- a/scripts/contract/devnet-postdeploy-smoke.ts
+++ b/scripts/contract/devnet-postdeploy-smoke.ts
@@ -1,13 +1,35 @@
 import { existsSync, readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
+import { Contract } from "@aztec/aztec.js/contracts";
+import { Fr } from "@aztec/aztec.js/fields";
+import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { FeeJuiceContract, ProtocolContractAddress } from "@aztec/aztec.js/protocol";
+import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
+import { createExtendedL1Client } from "@aztec/ethereum/client";
+import { Schnorr } from "@aztec/foundation/crypto/schnorr";
+import {
+  type ContractArtifact,
+  loadContractArtifact,
+  loadContractArtifactForPublic,
+} from "@aztec/stdlib/abi";
+import { GasSettings } from "@aztec/stdlib/gas";
+import { computeSecretHash } from "@aztec/stdlib/hash";
+import { deriveSigningKey } from "@aztec/stdlib/keys";
+import type { NoirCompiledContract } from "@aztec/stdlib/noir";
+import { ExecutionPayload } from "@aztec/stdlib/tx";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import {
   type DeployManifest,
   readDeployManifest,
 } from "@aztec-fpc/contract-deployment/src/manifest.ts";
 import { readTestTokenManifest } from "@aztec-fpc/contract-deployment/src/test-token-manifest.ts";
 import pino from "pino";
+import { type Chain, createPublicClient, decodeEventLog, extractChain, http, parseAbi } from "viem";
+import * as viemChains from "viem/chains";
 
 const pinoLogger = pino();
 
@@ -35,116 +57,6 @@ type CliParseResult =
       kind: "args";
       args: CliArgs;
     };
-
-type AztecAddressLike = {
-  toString: () => string;
-  toField: () => unknown;
-};
-
-type ContractMethodLike = {
-  send: (opts: unknown) => Promise<{ transactionFee: bigint }>;
-  simulate: (opts: unknown) => Promise<unknown>;
-  getFunctionCall: () => Promise<unknown>;
-};
-
-type ContractLike = {
-  address: AztecAddressLike;
-  methods: Record<string, (...args: unknown[]) => ContractMethodLike>;
-};
-
-type WalletLike = {
-  createSchnorrAccount: (
-    secret: unknown,
-    salt: unknown,
-    signingKey: unknown,
-  ) => Promise<{ address: AztecAddressLike }>;
-  createAuthWit: (authorizer: AztecAddressLike, intent: unknown) => Promise<unknown>;
-  registerContract: (instance: unknown, artifact?: unknown) => Promise<unknown>;
-};
-
-type NodeLike = {
-  getNodeInfo: () => Promise<{ l1ContractAddresses: Record<string, unknown> }>;
-  getCurrentMinFees: () => Promise<{
-    feePerDaGas: bigint;
-    feePerL2Gas: bigint;
-  }>;
-  getBlock: (blockTag: string) => Promise<{ timestamp: bigint } | null>;
-  getContract: (address: AztecAddressLike) => Promise<unknown | undefined>;
-};
-
-type L1PublicClientLike = {
-  getChainId: () => Promise<number>;
-  waitForTransactionReceipt: (args: { hash: string }) => Promise<{
-    logs: ReadonlyArray<{ address: string; data: string; topics: string[] }>;
-  }>;
-};
-
-type L1WalletClientLike = {
-  writeContract: (args: unknown) => Promise<string>;
-};
-
-type SchnorrLike = {
-  computePublicKey: (signingKey: unknown) => Promise<{
-    x: { toString: () => string };
-    y: { toString: () => string };
-  }>;
-  constructSignature: (
-    payload: Uint8Array,
-    signingKey: unknown,
-  ) => Promise<{ toBuffer: () => Uint8Array }>;
-};
-
-type FrLike = {
-  toString: () => string;
-  toBuffer: () => Buffer;
-};
-
-type FrFactory = {
-  new (value: unknown): FrLike;
-  ZERO: FrLike;
-  random: () => FrLike;
-  fromHexString: (value: string) => FrLike;
-};
-
-type AztecDeps = {
-  createAztecNodeClient: (url: string) => NodeLike;
-  waitForNode: (node: NodeLike) => Promise<void>;
-  waitForL1ToL2MessageReady: (
-    node: NodeLike,
-    messageHash: unknown,
-    opts: { timeoutSeconds: number },
-  ) => Promise<void>;
-  AztecAddress: { fromString: (value: string) => AztecAddressLike };
-  Contract: {
-    at: (address: AztecAddressLike, artifact: unknown, wallet: WalletLike) => ContractLike;
-  };
-  Fr: FrFactory;
-  computeInnerAuthWitHash: (values: unknown[]) => Promise<FrLike>;
-  FeeJuiceContract: { at: (wallet: WalletLike) => ContractLike };
-  ProtocolContractAddress: { FeeJuice: unknown };
-  getFeeJuiceBalance: (address: AztecAddressLike, node: NodeLike) => Promise<bigint>;
-  Schnorr: new () => SchnorrLike;
-  loadContractArtifact: (compiled: unknown) => unknown;
-  loadContractArtifactForPublic: (compiled: unknown) => unknown;
-  computeSecretHash: (secret: FrLike) => Promise<FrLike>;
-  deriveSigningKey: (secret: FrLike) => unknown;
-  ExecutionPayload: new (...args: unknown[]) => unknown;
-  EmbeddedWallet: { create: (node: NodeLike) => Promise<WalletLike> };
-  createPublicClient: (config: { transport: unknown }) => L1PublicClientLike;
-  createExtendedL1Client: (
-    rpcUrls: string[],
-    account: unknown,
-    chain?: unknown,
-  ) => L1WalletClientLike & L1PublicClientLike;
-  decodeEventLog: (config: { abi: unknown; data: string; topics: string[] }) => {
-    eventName: string;
-    args: Record<string, unknown>;
-  };
-  http: (url: string) => unknown;
-  parseAbi: (abi: string[]) => unknown;
-  extractChain: (args: { chains: unknown[]; id: number }) => unknown;
-  viemChains: unknown[];
-};
 
 class CliError extends Error {
   constructor(message: string) {
@@ -442,137 +354,17 @@ function parseManifestFromDisk(manifestPath: string): DeployManifest {
   }
 }
 
-async function importWithWorkspaceFallback(moduleId: string): Promise<Record<string, unknown>> {
-  const errors: string[] = [];
-  try {
-    return (await import(moduleId)) as Record<string, unknown>;
-  } catch (error) {
-    errors.push(`direct import failed: ${String(error)}`);
-  }
-
-  const fallbackPackageJsons = [
-    path.join(REPO_ROOT, "services", "attestation", "package.json"),
-    path.join(REPO_ROOT, "services", "topup", "package.json"),
-  ];
-
-  for (const packageJsonPath of fallbackPackageJsons) {
-    try {
-      const requireFromWorkspace = createRequire(packageJsonPath);
-      const resolved = requireFromWorkspace.resolve(moduleId);
-      return (await import(pathToFileURL(resolved).href)) as Record<string, unknown>;
-    } catch (error) {
-      errors.push(`workspace import failed via ${packageJsonPath}: ${String(error)}`);
-    }
-  }
-
-  throw new CliError(`Failed to load ${moduleId}.\n${errors.join("\n")}`);
-}
-
-async function loadDeps(): Promise<AztecDeps> {
-  const [
-    nodeApi,
-    messagingApi,
-    addressApi,
-    contractsApi,
-    fieldsApi,
-    authorizationApi,
-    protocolApi,
-    utilsApi,
-    schnorrApi,
-    abiApi,
-    hashApi,
-    keysApi,
-    txApi,
-    embeddedApi,
-    ethereumClientApi,
-    viemApi,
-    viemChainsApi,
-  ] = await Promise.all([
-    importWithWorkspaceFallback("@aztec/aztec.js/node"),
-    importWithWorkspaceFallback("@aztec/aztec.js/messaging"),
-    importWithWorkspaceFallback("@aztec/aztec.js/addresses"),
-    importWithWorkspaceFallback("@aztec/aztec.js/contracts"),
-    importWithWorkspaceFallback("@aztec/aztec.js/fields"),
-    importWithWorkspaceFallback("@aztec/aztec.js/authorization"),
-    importWithWorkspaceFallback("@aztec/aztec.js/protocol"),
-    importWithWorkspaceFallback("@aztec/aztec.js/utils"),
-    importWithWorkspaceFallback("@aztec/foundation/crypto/schnorr"),
-    importWithWorkspaceFallback("@aztec/stdlib/abi"),
-    importWithWorkspaceFallback("@aztec/stdlib/hash"),
-    importWithWorkspaceFallback("@aztec/stdlib/keys"),
-    importWithWorkspaceFallback("@aztec/stdlib/tx"),
-    importWithWorkspaceFallback("@aztec/wallets/embedded"),
-    importWithWorkspaceFallback("@aztec/ethereum/client"),
-    importWithWorkspaceFallback("viem"),
-    importWithWorkspaceFallback("viem/chains"),
-  ]);
-
-  const deps: AztecDeps = {
-    createAztecNodeClient: nodeApi.createAztecNodeClient as AztecDeps["createAztecNodeClient"],
-    waitForNode: nodeApi.waitForNode as AztecDeps["waitForNode"],
-    waitForL1ToL2MessageReady:
-      messagingApi.waitForL1ToL2MessageReady as AztecDeps["waitForL1ToL2MessageReady"],
-    AztecAddress: addressApi.AztecAddress as AztecDeps["AztecAddress"],
-    Contract: contractsApi.Contract as AztecDeps["Contract"],
-    Fr: fieldsApi.Fr as AztecDeps["Fr"],
-    computeInnerAuthWitHash:
-      authorizationApi.computeInnerAuthWitHash as AztecDeps["computeInnerAuthWitHash"],
-    FeeJuiceContract: protocolApi.FeeJuiceContract as AztecDeps["FeeJuiceContract"],
-    ProtocolContractAddress:
-      protocolApi.ProtocolContractAddress as AztecDeps["ProtocolContractAddress"],
-    getFeeJuiceBalance: utilsApi.getFeeJuiceBalance as AztecDeps["getFeeJuiceBalance"],
-    Schnorr: schnorrApi.Schnorr as AztecDeps["Schnorr"],
-    loadContractArtifact: abiApi.loadContractArtifact as AztecDeps["loadContractArtifact"],
-    loadContractArtifactForPublic:
-      abiApi.loadContractArtifactForPublic as AztecDeps["loadContractArtifactForPublic"],
-    computeSecretHash: hashApi.computeSecretHash as AztecDeps["computeSecretHash"],
-    deriveSigningKey: keysApi.deriveSigningKey as AztecDeps["deriveSigningKey"],
-    ExecutionPayload: txApi.ExecutionPayload as AztecDeps["ExecutionPayload"],
-    EmbeddedWallet: embeddedApi.EmbeddedWallet as AztecDeps["EmbeddedWallet"],
-    createPublicClient: viemApi.createPublicClient as AztecDeps["createPublicClient"],
-    createExtendedL1Client:
-      ethereumClientApi.createExtendedL1Client as AztecDeps["createExtendedL1Client"],
-    decodeEventLog: viemApi.decodeEventLog as AztecDeps["decodeEventLog"],
-    http: viemApi.http as AztecDeps["http"],
-    parseAbi: viemApi.parseAbi as AztecDeps["parseAbi"],
-    extractChain: viemApi.extractChain as AztecDeps["extractChain"],
-    viemChains: Object.values(viemChainsApi),
-  };
-
-  const requiredFunctions: Array<[string, unknown]> = [
-    ["createAztecNodeClient", deps.createAztecNodeClient],
-    ["waitForNode", deps.waitForNode],
-    ["waitForL1ToL2MessageReady", deps.waitForL1ToL2MessageReady],
-    ["computeInnerAuthWitHash", deps.computeInnerAuthWitHash],
-    ["getFeeJuiceBalance", deps.getFeeJuiceBalance],
-    ["computeSecretHash", deps.computeSecretHash],
-    ["deriveSigningKey", deps.deriveSigningKey],
-    ["createPublicClient", deps.createPublicClient],
-    ["createExtendedL1Client", deps.createExtendedL1Client],
-    ["decodeEventLog", deps.decodeEventLog],
-    ["http", deps.http],
-    ["parseAbi", deps.parseAbi],
-  ];
-  for (const [name, value] of requiredFunctions) {
-    if (typeof value !== "function") {
-      throw new CliError(`Loaded dependency missing function ${name}`);
-    }
-  }
-
-  return deps;
-}
-
-function loadArtifact(deps: AztecDeps, artifactPath: string): unknown {
+function loadArtifact(artifactPath: string): ContractArtifact {
   const raw = readFileSync(artifactPath, "utf8");
-  const parsed = JSON.parse(raw) as unknown;
+  const parsed = JSON.parse(raw) as NoirCompiledContract;
   try {
-    return deps.loadContractArtifact(parsed);
+    return loadContractArtifact(parsed);
   } catch (error) {
     if (
       error instanceof Error &&
       error.message.includes("Contract's public bytecode has not been transpiled")
     ) {
-      return deps.loadContractArtifactForPublic(parsed);
+      return loadContractArtifactForPublic(parsed);
     }
     throw error;
   }
@@ -621,9 +413,8 @@ function normalizeEthAddress(value: unknown, fieldName: string): string {
 }
 
 async function waitForFeeJuiceBalanceAtLeast(
-  deps: AztecDeps,
-  node: NodeLike,
-  feePayerAddress: AztecAddressLike,
+  node: ReturnType<typeof createAztecNodeClient>,
+  feePayerAddress: AztecAddress,
   minimum: bigint,
   timeoutMs: number,
   pollMs: number,
@@ -631,7 +422,7 @@ async function waitForFeeJuiceBalanceAtLeast(
   const deadline = Date.now() + timeoutMs;
   let latest = 0n;
   while (Date.now() <= deadline) {
-    const balance = await deps.getFeeJuiceBalance(feePayerAddress, node);
+    const balance = await getFeeJuiceBalance(feePayerAddress, node);
     latest = balance;
     if (balance >= minimum) {
       return balance;
@@ -644,19 +435,17 @@ async function waitForFeeJuiceBalanceAtLeast(
 }
 
 async function topUpFeePayer(params: {
-  deps: AztecDeps;
   args: CliArgs;
-  node: NodeLike;
-  wallet: WalletLike;
-  operatorAddress: AztecAddressLike;
-  l1PublicClient: L1PublicClientLike;
-  l1WalletClient: L1WalletClientLike;
-  feePayerAddress: AztecAddressLike;
+  node: ReturnType<typeof createAztecNodeClient>;
+  wallet: Awaited<ReturnType<typeof EmbeddedWallet.create>>;
+  operatorAddress: AztecAddress;
+  l1PublicClient: ReturnType<typeof createPublicClient>;
+  l1WalletClient: ReturnType<typeof createExtendedL1Client>;
+  feePayerAddress: AztecAddress;
   amount: bigint;
   label: string;
 }): Promise<bigint> {
   const {
-    deps,
     args,
     node,
     wallet,
@@ -668,10 +457,8 @@ async function topUpFeePayer(params: {
     label,
   } = params;
 
-  const ERC20_ABI = deps.parseAbi([
-    "function approve(address spender, uint256 amount) returns (bool)",
-  ]);
-  const FEE_JUICE_PORTAL_ABI = deps.parseAbi([
+  const ERC20_ABI = parseAbi(["function approve(address spender, uint256 amount) returns (bool)"]);
+  const FEE_JUICE_PORTAL_ABI = parseAbi([
     "function depositToAztecPublic(bytes32 to, uint256 amount, bytes32 secretHash) returns (bytes32, uint256)",
     "event DepositToAztecPublic(bytes32 indexed to, uint256 amount, bytes32 secretHash, bytes32 key, uint256 index)",
   ]);
@@ -692,16 +479,16 @@ async function topUpFeePayer(params: {
     "feeJuicePortalAddress",
   );
 
-  const initialBalance = await deps.getFeeJuiceBalance(feePayerAddress, node);
-  const claimSecret = deps.Fr.random();
-  const claimSecretHash = await deps.computeSecretHash(claimSecret);
+  const initialBalance = await getFeeJuiceBalance(feePayerAddress, node);
+  const claimSecret = Fr.random();
+  const claimSecretHash = await computeSecretHash(claimSecret);
 
   try {
     const approveTxHash = await l1WalletClient.writeContract({
-      address: feeJuiceAddress,
+      address: feeJuiceAddress as `0x${string}`,
       abi: ERC20_ABI,
       functionName: "approve",
-      args: [feeJuicePortalAddress, amount],
+      args: [feeJuicePortalAddress as `0x${string}`, amount],
     });
     await l1PublicClient.waitForTransactionReceipt({ hash: approveTxHash });
     pinoLogger.info(
@@ -710,10 +497,14 @@ async function topUpFeePayer(params: {
 
     const recipientBytes32 = `0x${feePayerAddress.toString().replace("0x", "").padStart(64, "0")}`;
     const bridgeTxHash = await l1WalletClient.writeContract({
-      address: feeJuicePortalAddress,
+      address: feeJuicePortalAddress as `0x${string}`,
       abi: FEE_JUICE_PORTAL_ABI,
       functionName: "depositToAztecPublic",
-      args: [recipientBytes32, amount, claimSecretHash.toString()],
+      args: [
+        recipientBytes32 as `0x${string}`,
+        amount,
+        claimSecretHash.toString() as `0x${string}`,
+      ],
     });
     const bridgeReceipt = await l1PublicClient.waitForTransactionReceipt({
       hash: bridgeTxHash,
@@ -721,13 +512,13 @@ async function topUpFeePayer(params: {
     pinoLogger.info(`[devnet-postdeploy-smoke] ${label} bridge_tx=${bridgeTxHash}`);
 
     let messageLeafIndex: bigint | undefined;
-    let l1ToL2MessageHash: unknown | undefined;
+    let l1ToL2MessageHash: Fr | undefined;
     for (const log of bridgeReceipt.logs) {
       if (log.address.toLowerCase() !== feeJuicePortalAddress.toLowerCase()) {
         continue;
       }
       try {
-        const decoded = deps.decodeEventLog({
+        const decoded = decodeEventLog({
           abi: FEE_JUICE_PORTAL_ABI,
           data: log.data,
           topics: log.topics,
@@ -735,8 +526,8 @@ async function topUpFeePayer(params: {
         if (decoded.eventName !== "DepositToAztecPublic") {
           continue;
         }
-        messageLeafIndex = decoded.args.index as bigint;
-        l1ToL2MessageHash = deps.Fr.fromHexString(decoded.args.key as string);
+        messageLeafIndex = decoded.args.index;
+        l1ToL2MessageHash = Fr.fromHexString(decoded.args.key as string);
         break;
       } catch {
         // Ignore non-matching logs.
@@ -748,17 +539,16 @@ async function topUpFeePayer(params: {
       );
     }
 
-    await deps.waitForL1ToL2MessageReady(node, l1ToL2MessageHash, {
+    await waitForL1ToL2MessageReady(node, l1ToL2MessageHash, {
       timeoutSeconds: Math.max(1, Math.floor(args.bridgeWaitTimeoutMs / 1000)),
     });
 
-    const feeJuice = deps.FeeJuiceContract.at(wallet);
+    const feeJuice = FeeJuiceContract.at(wallet);
     await feeJuice.methods
-      .claim(feePayerAddress, amount, claimSecret, new deps.Fr(messageLeafIndex))
+      .claim(feePayerAddress, amount, claimSecret, new Fr(messageLeafIndex))
       .send({ from: operatorAddress, wait: { timeout: 180 } });
 
     return waitForFeeJuiceBalanceAtLeast(
-      deps,
       node,
       feePayerAddress,
       initialBalance + amount,
@@ -774,7 +564,6 @@ async function topUpFeePayer(params: {
 }
 
 async function runSmoke(args: CliArgs): Promise<void> {
-  const deps = await loadDeps();
   const manifest = parseManifestFromDisk(args.manifestPath);
   const testTokenManifest = readTestTokenManifest(args.testTokenManifestPath);
 
@@ -784,10 +573,10 @@ async function runSmoke(args: CliArgs): Promise<void> {
 
   const operatorSecretKeyHex = resolveOperatorSecretKey(args);
   const l1OperatorPrivateKeyHex = resolveL1OperatorPrivateKey(args);
-  const operatorSecret = deps.Fr.fromHexString(operatorSecretKeyHex);
-  const operatorSigningKey = deps.deriveSigningKey(operatorSecret);
+  const operatorSecret = Fr.fromHexString(operatorSecretKeyHex);
+  const operatorSigningKey = deriveSigningKey(operatorSecret);
 
-  const schnorr = new deps.Schnorr();
+  const schnorr = new Schnorr();
   const derivedPubkey = await schnorr.computePublicKey(operatorSigningKey);
   const derivedX = BigInt(derivedPubkey.x.toString());
   const derivedY = BigInt(derivedPubkey.y.toString());
@@ -800,9 +589,9 @@ async function runSmoke(args: CliArgs): Promise<void> {
     );
   }
 
-  const node = deps.createAztecNodeClient(manifest.network.node_url);
+  const node = createAztecNodeClient(manifest.network.node_url);
   await Promise.race([
-    deps.waitForNode(node),
+    waitForNode(node),
     new Promise((_, reject) =>
       setTimeout(
         () =>
@@ -815,13 +604,13 @@ async function runSmoke(args: CliArgs): Promise<void> {
       ),
     ),
   ]);
-  const wallet = await deps.EmbeddedWallet.create(node);
+  const wallet = await EmbeddedWallet.create(node);
   const operatorAccount = await wallet.createSchnorrAccount(
     operatorSecret,
-    deps.Fr.ZERO,
+    Fr.ZERO,
     operatorSigningKey,
   );
-  const operatorAddress = deps.AztecAddress.fromString(operatorAccount.address.toString());
+  const operatorAddress = AztecAddress.fromString(operatorAccount.address.toString());
   if (
     operatorAddress.toString().toLowerCase() !== manifest.operator.address.toString().toLowerCase()
   ) {
@@ -830,8 +619,8 @@ async function runSmoke(args: CliArgs): Promise<void> {
     );
   }
 
-  const l1PublicClient = deps.createPublicClient({
-    transport: deps.http(args.l1RpcUrl),
+  const l1PublicClient = createPublicClient({
+    transport: http(args.l1RpcUrl),
   });
   const l1ChainId = await l1PublicClient.getChainId();
   if (l1ChainId !== manifest.network.l1_chain_id) {
@@ -840,18 +629,14 @@ async function runSmoke(args: CliArgs): Promise<void> {
     );
   }
 
-  const l1Chain = deps.extractChain({ chains: deps.viemChains, id: l1ChainId });
-  const l1WalletClient = deps.createExtendedL1Client(
-    [args.l1RpcUrl],
-    l1OperatorPrivateKeyHex,
-    l1Chain,
-  );
+  const l1Chain = extractChain({
+    chains: Object.values(viemChains) as unknown as readonly [Chain, ...Chain[]],
+    id: l1ChainId,
+  });
+  const l1WalletClient = createExtendedL1Client([args.l1RpcUrl], l1OperatorPrivateKeyHex, l1Chain);
 
-  const tokenArtifact = loadArtifact(
-    deps,
-    path.join(REPO_ROOT, "target", "token_contract-Token.json"),
-  );
-  const selectedFpcArtifact = loadArtifact(deps, FPC_ARTIFACT_PATH);
+  const tokenArtifact = loadArtifact(path.join(REPO_ROOT, "target", "token_contract-Token.json"));
+  const selectedFpcArtifact = loadArtifact(FPC_ARTIFACT_PATH);
 
   const tokenAddress = testTokenManifest.contracts.token;
   const fpcAddress = manifest.contracts.fpc;
@@ -870,18 +655,18 @@ async function runSmoke(args: CliArgs): Promise<void> {
   }
   await wallet.registerContract(fpcInstance, selectedFpcArtifact);
 
-  const token = deps.Contract.at(tokenAddress, tokenArtifact, wallet);
-  const fpc = deps.Contract.at(fpcAddress, selectedFpcArtifact, wallet);
+  const token = Contract.at(tokenAddress, tokenArtifact, wallet);
+  const fpc = Contract.at(fpcAddress, selectedFpcArtifact, wallet);
 
   // Register faucet contract for dripping tokens (bridge is the minter, not operator)
   const faucetAddress = testTokenManifest.contracts.faucet;
-  const faucetArtifact = loadArtifact(deps, path.join(REPO_ROOT, "target", "faucet-Faucet.json"));
+  const faucetArtifact = loadArtifact(path.join(REPO_ROOT, "target", "faucet-Faucet.json"));
   const faucetInstance = await node.getContract(faucetAddress);
   if (!faucetInstance) {
     throw new CliError(`Faucet contract not found on node at ${faucetAddress}`);
   }
   await wallet.registerContract(faucetInstance, faucetArtifact);
-  const faucet = deps.Contract.at(faucetAddress, faucetArtifact, wallet);
+  const faucet = Contract.at(faucetAddress, faucetArtifact, wallet);
 
   const minFees = await node.getCurrentMinFees();
   const feePerDaGas = minFees.feePerDaGas as bigint;
@@ -904,7 +689,6 @@ async function runSmoke(args: CliArgs): Promise<void> {
   pinoLogger.info(`[devnet-postdeploy-smoke] topup target fpc=${fpcTopupAmount}`);
 
   const fpcFeeJuiceBalance = await topUpFeePayer({
-    deps,
     args,
     node,
     wallet,
@@ -917,7 +701,7 @@ async function runSmoke(args: CliArgs): Promise<void> {
   });
   pinoLogger.info(`[devnet-postdeploy-smoke] fpc_fee_juice_balance=${fpcFeeJuiceBalance}`);
 
-  const QUOTE_DOMAIN_SEPARATOR = deps.Fr.fromHexString("0x465043");
+  const QUOTE_DOMAIN_SEPARATOR = Fr.fromHexString("0x465043");
   const fpcExpectedCharge = ceilDiv(maxGasCostNoTeardown * args.fpcRateNum, args.fpcRateDen);
   const fpcFjAmount = maxGasCostNoTeardown;
   const fpcAaAmount = fpcExpectedCharge;
@@ -938,18 +722,18 @@ async function runSmoke(args: CliArgs): Promise<void> {
     throw new Error("Could not read latest block while creating FPC quote");
   }
   const fpcValidUntil = latestBlock.timestamp + args.quoteTtlSeconds;
-  const fpcQuoteHash = await deps.computeInnerAuthWitHash([
+  const fpcQuoteHash = await computeInnerAuthWitHash([
     QUOTE_DOMAIN_SEPARATOR,
     fpc.address.toField(),
     token.address.toField(),
-    new deps.Fr(fpcFjAmount),
-    new deps.Fr(fpcAaAmount),
-    new deps.Fr(fpcValidUntil),
+    new Fr(fpcFjAmount),
+    new Fr(fpcAaAmount),
+    new Fr(fpcValidUntil),
     operatorAddress.toField(),
   ]);
   const fpcQuoteSig = await schnorr.constructSignature(fpcQuoteHash.toBuffer(), operatorSigningKey);
   const fpcQuoteSigBytes = Array.from(fpcQuoteSig.toBuffer());
-  const fpcAuthwitNonce = deps.Fr.random();
+  const fpcAuthwitNonce = Fr.random();
   const fpcTransferCall = token.methods.transfer_private_to_private(
     operatorAddress,
     operatorAddress,
@@ -958,7 +742,7 @@ async function runSmoke(args: CliArgs): Promise<void> {
   );
   const fpcTransferAuthwit = await wallet.createAuthWit(operatorAddress, {
     caller: fpc.address,
-    action: fpcTransferCall,
+    call: await fpcTransferCall.getFunctionCall(),
   });
   const fpcFeeEntrypointCall = await fpc.methods
     .fee_entrypoint(
@@ -971,28 +755,29 @@ async function runSmoke(args: CliArgs): Promise<void> {
     )
     .getFunctionCall();
   const fpcPaymentMethod = {
-    getAsset: async () => deps.ProtocolContractAddress.FeeJuice,
+    getAsset: async () => ProtocolContractAddress.FeeJuice,
     getExecutionPayload: async () =>
-      new deps.ExecutionPayload([fpcFeeEntrypointCall], [fpcTransferAuthwit], [], [], fpc.address),
+      new ExecutionPayload([fpcFeeEntrypointCall], [fpcTransferAuthwit], [], [], fpc.address),
     getFeePayer: async () => fpc.address,
     getGasSettings: () => undefined,
   };
   const fpcReceipt = await token.methods
-    .transfer_public_to_public(operatorAddress, operatorAddress, 1n, deps.Fr.random())
+    .transfer_public_to_public(operatorAddress, operatorAddress, 1n, Fr.random())
     .send({
       from: operatorAddress,
       fee: {
         paymentMethod: fpcPaymentMethod,
-        gasSettings: {
+        gasSettings: GasSettings.from({
           gasLimits: { daGas: args.daGasLimit, l2Gas: args.l2GasLimit },
           teardownGasLimits: { daGas: 0, l2Gas: 0 },
           maxFeesPerGas: { feePerDaGas, feePerL2Gas },
-        },
+          maxPriorityFeesPerGas: { feePerDaGas: 0n, feePerL2Gas: 0n },
+        }),
       },
       wait: { timeout: 180 },
     });
   pinoLogger.info(
-    `[devnet-postdeploy-smoke] fpc_fee_path_tx_fee_juice=${fpcReceipt.transactionFee} expected_charge=${fpcExpectedCharge}`,
+    `[devnet-postdeploy-smoke] fpc_fee_path_tx_fee_juice=${fpcReceipt.receipt.transactionFee} expected_charge=${fpcExpectedCharge}`,
   );
   pinoLogger.info(`[devnet-postdeploy-smoke] PASS variant=${"FPCMultiAsset"} successful_txs=1`);
 }

--- a/scripts/contract/verify-fpc-devnet-deployment.ts
+++ b/scripts/contract/verify-fpc-devnet-deployment.ts
@@ -1,6 +1,6 @@
-import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { type AztecNode, createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import {
   type DeployManifest,
   readDeployManifest,
@@ -28,21 +28,6 @@ type CliParseResult =
       kind: "args";
       args: CliArgs;
     };
-
-type AztecDeps = {
-  createAztecNodeClient: (url: string) => {
-    getContract: (address: unknown) => Promise<unknown>;
-    getContractClass: (classId: unknown) => Promise<unknown>;
-  };
-  waitForNode: (node: unknown) => Promise<void>;
-  AztecAddress: {
-    fromString: (value: string) => unknown;
-  };
-  Fr: {
-    fromString: (value: string) => unknown;
-    fromHexString: (value: string) => unknown;
-  };
-};
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -159,78 +144,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function importWithWorkspaceFallback(moduleId: string): Promise<Record<string, unknown>> {
-  const errors: string[] = [];
-  try {
-    return (await import(moduleId)) as Record<string, unknown>;
-  } catch (error) {
-    errors.push(`direct import failed: ${String(error)}`);
-  }
-
-  const fallbackPackageJsons = [
-    path.join(REPO_ROOT, "services", "attestation", "package.json"),
-    path.join(REPO_ROOT, "services", "topup", "package.json"),
-  ];
-
-  for (const packageJsonPath of fallbackPackageJsons) {
-    try {
-      const requireFromWorkspace = createRequire(packageJsonPath);
-      const resolved = requireFromWorkspace.resolve(moduleId);
-      return (await import(pathToFileURL(resolved).href)) as Record<string, unknown>;
-    } catch (error) {
-      errors.push(`workspace import failed via ${packageJsonPath}: ${String(error)}`);
-    }
-  }
-
-  throw new CliError(`Failed to load ${moduleId}.\n${errors.join("\n")}`);
-}
-
-async function loadAztecDeps(): Promise<AztecDeps> {
-  const [nodeApi, addressApi, fieldsApi] = await Promise.all([
-    importWithWorkspaceFallback("@aztec/aztec.js/node"),
-    importWithWorkspaceFallback("@aztec/aztec.js/addresses"),
-    importWithWorkspaceFallback("@aztec/aztec.js/fields"),
-  ]);
-
-  const createAztecNodeClient = nodeApi.createAztecNodeClient;
-  const waitForNode = nodeApi.waitForNode;
-  const AztecAddress = addressApi.AztecAddress;
-  const Fr = fieldsApi.Fr;
-
-  if (typeof createAztecNodeClient !== "function") {
-    throw new CliError("Loaded @aztec/aztec.js/node, but createAztecNodeClient is unavailable");
-  }
-  if (typeof waitForNode !== "function") {
-    throw new CliError("Loaded @aztec/aztec.js/node, but waitForNode is unavailable");
-  }
-  if (
-    !AztecAddress ||
-    typeof AztecAddress !== "function" ||
-    typeof (AztecAddress as { fromString?: unknown }).fromString !== "function"
-  ) {
-    throw new CliError(
-      "Loaded @aztec/aztec.js/addresses, but AztecAddress.fromString is unavailable",
-    );
-  }
-  if (
-    !Fr ||
-    typeof Fr !== "function" ||
-    typeof (Fr as { fromString?: unknown }).fromString !== "function" ||
-    typeof (Fr as { fromHexString?: unknown }).fromHexString !== "function"
-  ) {
-    throw new CliError(
-      "Loaded @aztec/aztec.js/fields, but Fr.fromString/fromHexString are unavailable",
-    );
-  }
-
-  return {
-    createAztecNodeClient: createAztecNodeClient as AztecDeps["createAztecNodeClient"],
-    waitForNode: waitForNode as AztecDeps["waitForNode"],
-    AztecAddress: AztecAddress as unknown as AztecDeps["AztecAddress"],
-    Fr: Fr as unknown as AztecDeps["Fr"],
-  };
-}
-
 function formatCheckIssues(issues: string[]): string {
   if (issues.length === 0) {
     return "<none>";
@@ -288,11 +201,7 @@ function isZeroFieldLike(value: string): boolean {
 
 async function verifyAttempt(params: {
   manifest: DeployManifest;
-  deps: AztecDeps;
-  node: {
-    getContract: (address: unknown) => Promise<unknown>;
-    getContractClass: (classId: unknown) => Promise<unknown>;
-  };
+  node: AztecNode;
 }): Promise<string[]> {
   const { manifest, node } = params;
   const issues: string[] = [];
@@ -304,17 +213,8 @@ async function verifyAttempt(params: {
     },
   ] as const;
 
-  const parsedAddresses = new Map<string, unknown>();
   for (const contract of contracts) {
-    parsedAddresses.set(contract.key, contract.address);
-  }
-
-  for (const contract of contracts) {
-    const address = parsedAddresses.get(contract.key);
-    if (!address) {
-      issues.push(`address parsing failed for ${contract.key}`);
-      continue;
-    }
+    const address = contract.address;
 
     const deployed = await node.getContract(address);
     if (!deployed) {
@@ -346,18 +246,20 @@ async function verifyAttempt(params: {
       issues.push(`missing current contract class id for ${contract.key}`);
       continue;
     }
-    const classPayload = await node.getContractClass(classId);
+    const classPayload = await node.getContractClass(
+      classId as Parameters<AztecNode["getContractClass"]>[0],
+    );
     if (!classPayload) {
       issues.push(`contract class not publicly registered: ${contract.key}`);
     }
   }
 
   try {
-    await verifyFpcImmutablesOnStartup(node as never, {
-      fpcAddress: parsedAddresses.get("fpc") as never,
-      operatorAddress: manifest.operator.address as never,
-      operatorPubkeyX: manifest.operator.pubkey_x as never,
-      operatorPubkeyY: manifest.operator.pubkey_y as never,
+    await verifyFpcImmutablesOnStartup(node, {
+      fpcAddress: manifest.contracts.fpc,
+      operatorAddress: manifest.operator.address,
+      operatorPubkeyX: manifest.operator.pubkey_x,
+      operatorPubkeyY: manifest.operator.pubkey_y,
     });
   } catch (error) {
     if (error instanceof FpcImmutableVerificationError && error.reason === "IMMUTABLE_MISMATCH") {
@@ -386,11 +288,10 @@ async function main(): Promise<void> {
     `[verify-fpc-devnet] loaded manifest for node=${manifest.network.node_url} fpc=${manifest.contracts.fpc}`,
   );
 
-  const deps = await loadAztecDeps();
-  const node = deps.createAztecNodeClient(manifest.network.node_url);
+  const node = createAztecNodeClient(manifest.network.node_url);
 
   await Promise.race([
-    deps.waitForNode(node),
+    waitForNode(node),
     new Promise((_, reject) =>
       setTimeout(
         () =>
@@ -409,7 +310,6 @@ async function main(): Promise<void> {
     try {
       lastIssues = await verifyAttempt({
         manifest,
-        deps,
         node,
       });
     } catch (error) {

--- a/scripts/services/bootstrap-topup-autoclaim-account.ts
+++ b/scripts/services/bootstrap-topup-autoclaim-account.ts
@@ -1,8 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import pino from "pino";
 
 const pinoLogger = pino();
@@ -12,6 +10,7 @@ import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { SponsoredFPCContractArtifact } from "@aztec/noir-contracts.js/SponsoredFPC";
 import { deriveSigningKey } from "@aztec/stdlib/keys";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 
@@ -490,25 +489,6 @@ async function registerSponsoredFpcInEmbeddedWallet(
   sponsoredFpcAddress: string,
   wallet: EmbeddedWallet,
 ): Promise<AztecAddress> {
-  const moduleId = "@aztec/noir-contracts.js/SponsoredFPC";
-  let sponsoredFpcArtifact: unknown;
-  try {
-    const imported = (await import(moduleId)) as {
-      SponsoredFPCContractArtifact?: unknown;
-    };
-    sponsoredFpcArtifact = imported.SponsoredFPCContractArtifact;
-  } catch {
-    const requireFromTopup = createRequire(path.resolve("services/topup/package.json"));
-    const resolved = requireFromTopup.resolve(moduleId);
-    const imported = (await import(pathToFileURL(resolved).href)) as {
-      SponsoredFPCContractArtifact?: unknown;
-    };
-    sponsoredFpcArtifact = imported.SponsoredFPCContractArtifact;
-  }
-  if (!sponsoredFpcArtifact) {
-    throw new CliError("Failed to load SponsoredFPC artifact for embedded-wallet registration");
-  }
-
   const node = createAztecNodeClient(nodeUrl);
   await waitForNode(node);
   const sponsorAddress = AztecAddress.fromString(sponsoredFpcAddress);
@@ -518,10 +498,7 @@ async function registerSponsoredFpcInEmbeddedWallet(
       `Sponsored FPC contract ${sponsoredFpcAddress} is not available on node ${nodeUrl}`,
     );
   }
-  await wallet.registerContract(
-    sponsorInstance,
-    sponsoredFpcArtifact as Parameters<EmbeddedWallet["registerContract"]>[1],
-  );
+  await wallet.registerContract(sponsorInstance, SponsoredFPCContractArtifact);
   return sponsorAddress;
 }
 

--- a/sdk/test/payment-method.test.ts
+++ b/sdk/test/payment-method.test.ts
@@ -1,5 +1,7 @@
 import { AztecAddress } from "@aztec/aztec.js/addresses";
+import type { AztecNode } from "@aztec/aztec.js/node";
 import { ProtocolContractAddress } from "@aztec/aztec.js/protocol";
+import type { Wallet as AccountWallet } from "@aztec/aztec.js/wallet";
 import { Gas, GasFees, GasSettings } from "@aztec/stdlib/gas";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -91,7 +93,7 @@ function createClient(nodeOverride?: ReturnType<typeof createMockNode>) {
   return new FpcClient({
     fpcAddress: FPC_ADDRESS,
     operator: OPERATOR,
-    node: (nodeOverride ?? createMockNode()) as never,
+    node: (nodeOverride ?? createMockNode()) as unknown as AztecNode,
     attestationBaseUrl: "https://example.com/v2",
   });
 }
@@ -117,11 +119,11 @@ describe("FpcClient", () => {
 
   it("builds payment method with correct fee payer, asset, and gas settings", async () => {
     const wallet = createMockWallet();
-    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as unknown as typeof fetch;
 
     const client = createClient();
     const result = await client.createPaymentMethod({
-      wallet: wallet as never,
+      wallet: wallet as unknown as AccountWallet,
       user: USER,
       tokenAddress: TOKEN_ADDRESS,
       ...DEFAULT_GAS_INPUT,
@@ -142,11 +144,11 @@ describe("FpcClient", () => {
   it("computes fjAmount from node gas fees and gas limits", async () => {
     const wallet = createMockWallet();
     const node = createMockNode();
-    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as unknown as typeof fetch;
 
     const client = createClient(node);
     const result = await client.createPaymentMethod({
-      wallet: wallet as never,
+      wallet: wallet as unknown as AccountWallet,
       user: USER,
       tokenAddress: TOKEN_ADDRESS,
       ...DEFAULT_GAS_INPUT,
@@ -159,11 +161,11 @@ describe("FpcClient", () => {
   it("constructs correct quote URL", async () => {
     const wallet = createMockWallet();
     const mockFetch = mockFetchOk(QUOTE_RESPONSE);
-    globalThis.fetch = mockFetch as never;
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
 
     const client = createClient();
     await client.createPaymentMethod({
-      wallet: wallet as never,
+      wallet: wallet as unknown as AccountWallet,
       user: USER,
       tokenAddress: TOKEN_ADDRESS,
       ...DEFAULT_GAS_INPUT,
@@ -179,11 +181,11 @@ describe("FpcClient", () => {
 
   it("returns full quote response", async () => {
     const wallet = createMockWallet();
-    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as unknown as typeof fetch;
 
     const client = createClient();
     const result = await client.createPaymentMethod({
-      wallet: wallet as never,
+      wallet: wallet as unknown as AccountWallet,
       user: USER,
       tokenAddress: TOKEN_ADDRESS,
       ...DEFAULT_GAS_INPUT,
@@ -194,11 +196,11 @@ describe("FpcClient", () => {
 
   it("calls wallet.createAuthWit with correct args", async () => {
     const wallet = createMockWallet();
-    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as unknown as typeof fetch;
 
     const client = createClient();
     await client.createPaymentMethod({
-      wallet: wallet as never,
+      wallet: wallet as unknown as AccountWallet,
       user: USER,
       tokenAddress: TOKEN_ADDRESS,
       ...DEFAULT_GAS_INPUT,
@@ -213,11 +215,11 @@ describe("FpcClient", () => {
 
   it("registers contracts with wallet before use", async () => {
     const wallet = createMockWallet();
-    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as unknown as typeof fetch;
 
     const client = createClient();
     await client.createPaymentMethod({
-      wallet: wallet as never,
+      wallet: wallet as unknown as AccountWallet,
       user: USER,
       tokenAddress: TOKEN_ADDRESS,
       ...DEFAULT_GAS_INPUT,
@@ -232,12 +234,12 @@ describe("FpcClient", () => {
       ok: false,
       status: 500,
       text: async () => "Internal Server Error",
-    })) as never;
+    })) as unknown as typeof fetch;
 
     const client = createClient();
     await expect(
       client.createPaymentMethod({
-        wallet: wallet as never,
+        wallet: wallet as unknown as AccountWallet,
         user: USER,
         tokenAddress: TOKEN_ADDRESS,
         ...DEFAULT_GAS_INPUT,
@@ -247,7 +249,7 @@ describe("FpcClient", () => {
 
   it("throws when contract not found on node", async () => {
     const wallet = createMockWallet();
-    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as never;
+    globalThis.fetch = mockFetchOk(QUOTE_RESPONSE) as unknown as typeof fetch;
 
     const node = createMockNode();
     node.getContract.mockResolvedValue(null);
@@ -255,7 +257,7 @@ describe("FpcClient", () => {
     const client = createClient(node);
     await expect(
       client.createPaymentMethod({
-        wallet: wallet as never,
+        wallet: wallet as unknown as AccountWallet,
         user: USER,
         tokenAddress: TOKEN_ADDRESS,
         ...DEFAULT_GAS_INPUT,

--- a/services/topup/src/bridge.ts
+++ b/services/topup/src/bridge.ts
@@ -25,7 +25,7 @@ export interface BridgeResult {
 
 type ExtendedWalletClient = Parameters<typeof L1FeeJuicePortalManager.new>[1];
 
-interface FeeJuicePortalManagerLike {
+export interface FeeJuicePortalManagerLike {
   bridgeTokensPublic(to: AztecAddress, amount: bigint): Promise<L2AmountClaim>;
 }
 

--- a/services/topup/src/fund-claimer-l2.ts
+++ b/services/topup/src/fund-claimer-l2.ts
@@ -451,7 +451,7 @@ async function setupBridgePortal(
 
   const l1Wallet = createL1WalletClient(l1RpcUrl, l1ChainId, l1PrivateKey);
   const bridgeLogger = createLogger("fund-claimer-l2:bridge");
-  const portalManager = await L1FeeJuicePortalManager.new(node, l1Wallet as never, bridgeLogger);
+  const portalManager = await L1FeeJuicePortalManager.new(node, l1Wallet, bridgeLogger);
   return { node, portalManager };
 }
 

--- a/services/topup/test/bridge.test.ts
+++ b/services/topup/test/bridge.test.ts
@@ -2,11 +2,10 @@ import assert from "node:assert/strict";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import type { AztecNode } from "@aztec/aztec.js/node";
-import type { createExtendedL1Client } from "@aztec/ethereum/client";
 import { createLogger } from "@aztec/foundation/log";
 import type { Chain } from "viem";
 import { describe, it } from "#test";
-import type { BridgeDeps } from "../src/bridge.js";
+import type { BridgeDeps, FeeJuicePortalManagerLike } from "../src/bridge.js";
 import { bridgeFeeJuice, isNonceTooLowError, isRetryableNonceError } from "../src/bridge.js";
 
 const MESSAGE_HASH = `0x${"ab".repeat(32)}` as `0x${string}`;
@@ -19,20 +18,23 @@ function makeNode(): AztecNode {
   return {} as AztecNode;
 }
 
+function stubL1Client(): BridgeDeps["createExtendedL1Client"] {
+  return (() => ({})) as unknown as BridgeDeps["createExtendedL1Client"];
+}
+
 function makeDeps(overrides: Partial<BridgeDeps> = {}): BridgeDeps {
   return {
-    createExtendedL1Client: (() => ({})) as never as typeof createExtendedL1Client,
-    createPortalManager: async () =>
-      ({
-        bridgeTokensPublic: (_to: AztecAddress, amount: bigint) =>
-          Promise.resolve({
-            claimAmount: amount,
-            claimSecret: new Fr(1n),
-            claimSecretHash: new Fr(2n),
-            messageHash: MESSAGE_HASH,
-            messageLeafIndex: 7n,
-          }),
-      }) as never,
+    createExtendedL1Client: stubL1Client(),
+    createPortalManager: async (): Promise<FeeJuicePortalManagerLike> => ({
+      bridgeTokensPublic: (_to: AztecAddress, amount: bigint) =>
+        Promise.resolve({
+          claimAmount: amount,
+          claimSecret: new Fr(1n),
+          claimSecretHash: new Fr(2n),
+          messageHash: MESSAGE_HASH,
+          messageLeafIndex: 7n,
+        }),
+    }),
     createLogger: () => createLogger("topup:test"),
     chains: [
       {
@@ -59,21 +61,20 @@ describe("bridge", () => {
       createExtendedL1Client: ((_rpcUrls: string[], _account: unknown, chain?: { id: number }) => {
         capturedChainId = chain?.id;
         return {};
-      }) as never,
-      createPortalManager: async () =>
-        ({
-          bridgeTokensPublic: (to: AztecAddress, amount: bigint) => {
-            capturedTo = to;
-            capturedAmount = amount;
-            return Promise.resolve({
-              claimAmount: amount,
-              claimSecret: new Fr(1n),
-              claimSecretHash: new Fr(2n),
-              messageHash: MESSAGE_HASH,
-              messageLeafIndex: 7n,
-            });
-          },
-        }) as never,
+      }) as unknown as BridgeDeps["createExtendedL1Client"],
+      createPortalManager: async (): Promise<FeeJuicePortalManagerLike> => ({
+        bridgeTokensPublic: (to: AztecAddress, amount: bigint) => {
+          capturedTo = to;
+          capturedAmount = amount;
+          return Promise.resolve({
+            claimAmount: amount,
+            claimSecret: new Fr(1n),
+            claimSecretHash: new Fr(2n),
+            messageHash: MESSAGE_HASH,
+            messageLeafIndex: 7n,
+          });
+        },
+      }),
     });
 
     const result = await bridgeFeeJuice(
@@ -123,22 +124,21 @@ describe("bridge", () => {
   it("retries bridge submission on retryable nonce conflicts", async () => {
     let attempts = 0;
     const deps = makeDeps({
-      createPortalManager: async () =>
-        ({
-          bridgeTokensPublic: (_to: AztecAddress, amount: bigint) => {
-            attempts += 1;
-            if (attempts === 1) {
-              return Promise.reject(new Error("already known"));
-            }
-            return Promise.resolve({
-              claimAmount: amount,
-              claimSecret: new Fr(11n),
-              claimSecretHash: new Fr(22n),
-              messageHash: MESSAGE_HASH,
-              messageLeafIndex: 99n,
-            });
-          },
-        }) as never,
+      createPortalManager: async (): Promise<FeeJuicePortalManagerLike> => ({
+        bridgeTokensPublic: (_to: AztecAddress, amount: bigint) => {
+          attempts += 1;
+          if (attempts === 1) {
+            return Promise.reject(new Error("already known"));
+          }
+          return Promise.resolve({
+            claimAmount: amount,
+            claimSecret: new Fr(11n),
+            claimSecretHash: new Fr(22n),
+            messageHash: MESSAGE_HASH,
+            messageLeafIndex: 99n,
+          });
+        },
+      }),
     });
 
     const result = await bridgeFeeJuice(
@@ -159,13 +159,12 @@ describe("bridge", () => {
   it("fails immediately on nonce-too-low without retry", async () => {
     let attempts = 0;
     const deps = makeDeps({
-      createPortalManager: async () =>
-        ({
-          bridgeTokensPublic: () => {
-            attempts += 1;
-            return Promise.reject(new Error("nonce too low"));
-          },
-        }) as never,
+      createPortalManager: async (): Promise<FeeJuicePortalManagerLike> => ({
+        bridgeTokensPublic: () => {
+          attempts += 1;
+          return Promise.reject(new Error("nonce too low"));
+        },
+      }),
     });
 
     await assert.rejects(
@@ -178,13 +177,12 @@ describe("bridge", () => {
   it("fails after exhausting retryable nonce conflict retries", async () => {
     let attempts = 0;
     const deps = makeDeps({
-      createPortalManager: async () =>
-        ({
-          bridgeTokensPublic: () => {
-            attempts += 1;
-            return Promise.reject(new Error("already known"));
-          },
-        }) as never,
+      createPortalManager: async (): Promise<FeeJuicePortalManagerLike> => ({
+        bridgeTokensPublic: () => {
+          attempts += 1;
+          return Promise.reject(new Error("already known"));
+        },
+      }),
     });
 
     await assert.rejects(

--- a/services/topup/test/l1.test.ts
+++ b/services/topup/test/l1.test.ts
@@ -1,30 +1,27 @@
 import assert from "node:assert/strict";
 import { describe, it } from "#test";
+import type { L1ChainDeps } from "../src/l1.js";
 import { assertL1RpcChainIdMatches } from "../src/l1.js";
+
+function makeDeps(chainId: number): L1ChainDeps {
+  return {
+    createPublicClient: (() => ({
+      getChainId: async () => chainId,
+    })) as unknown as L1ChainDeps["createPublicClient"],
+    http: (() => ({})) as unknown as L1ChainDeps["http"],
+  };
+}
 
 describe("l1", () => {
   it("passes when rpc chain id matches expected", async () => {
     await assert.doesNotReject(() =>
-      assertL1RpcChainIdMatches("http://localhost:8545", 31337, {
-        createPublicClient: (() =>
-          ({
-            getChainId: async () => 31337,
-          }) as never) as never,
-        http: ((_url) => ({})) as never,
-      }),
+      assertL1RpcChainIdMatches("http://localhost:8545", 31337, makeDeps(31337)),
     );
   });
 
   it("throws when rpc chain id mismatches expected", async () => {
     await assert.rejects(
-      () =>
-        assertL1RpcChainIdMatches("http://localhost:8545", 31337, {
-          createPublicClient: (() =>
-            ({
-              getChainId: async () => 1,
-            }) as never) as never,
-          http: ((_url) => ({})) as never,
-        }),
+      () => assertL1RpcChainIdMatches("http://localhost:8545", 31337, makeDeps(1)),
       /L1 chain mismatch/,
     );
   });

--- a/services/topup/test/reconcile.test.ts
+++ b/services/topup/test/reconcile.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { describe, it } from "#test";
-import { reconcilePersistedBridgeState } from "../src/reconcile.js";
+import {
+  type ReconcileBridgeStateOptions,
+  reconcilePersistedBridgeState,
+} from "../src/reconcile.js";
 import type { BridgeStateStore } from "../src/state.js";
+
+function stubNode(): ReconcileBridgeStateOptions["node"] {
+  return {} as ReconcileBridgeStateOptions["node"];
+}
 
 const FPC = AztecAddress.fromString(
   "0x27e0f62fe6edf34f850dd7c1cc7cd638f7ec38ed3eb5ae4bd8c0c941c78e67ac",
@@ -30,7 +37,7 @@ describe("reconcile", () => {
       {
         stateStore: store,
         getBalance: async () => 0n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -59,7 +66,7 @@ describe("reconcile", () => {
       {
         stateStore: store,
         getBalance: async () => 10n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -101,7 +108,7 @@ describe("reconcile", () => {
       {
         stateStore: store,
         getBalance: async () => 10n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -143,7 +150,7 @@ describe("reconcile", () => {
       {
         stateStore: store,
         getBalance: async () => 0n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -173,7 +180,7 @@ describe("reconcile", () => {
       {
         stateStore: store,
         getBalance: async () => 11n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -215,7 +222,7 @@ describe("reconcile", () => {
       {
         stateStore: store,
         getBalance: async () => 10n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,

--- a/services/topup/test/state.test.ts
+++ b/services/topup/test/state.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { describe, it } from "#test";
-import { reconcilePersistedBridgeState } from "../src/reconcile.js";
+import {
+  type ReconcileBridgeStateOptions,
+  reconcilePersistedBridgeState,
+} from "../src/reconcile.js";
 import {
   acquireProcessLock,
   createLmdbBridgeStateStore,
@@ -16,6 +19,10 @@ const HASH = `0x${"ab".repeat(32)}` as `0x${string}`;
 const FPC = AztecAddress.fromString(
   "0x27e0f62fe6edf34f850dd7c1cc7cd638f7ec38ed3eb5ae4bd8c0c941c78e67ac",
 );
+
+function stubNode(): ReconcileBridgeStateOptions["node"] {
+  return {} as ReconcileBridgeStateOptions["node"];
+}
 
 function makeTempDir() {
   const dir = mkdtempSync(path.join(tmpdir(), "topup-state-test-"));
@@ -216,7 +223,7 @@ describe("crash recovery", () => {
       {
         stateStore: store2,
         getBalance: async () => 105n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -271,7 +278,7 @@ describe("crash recovery", () => {
       {
         stateStore: store2,
         getBalance: async () => 100n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,
@@ -323,7 +330,7 @@ describe("crash recovery", () => {
       {
         stateStore: store,
         getBalance: async () => 0n,
-        node: {} as never,
+        node: stubNode(),
         fpcAddress: FPC,
         timeoutMs: 1,
         initialPollMs: 1,


### PR DESCRIPTION
## Summary

Replaces all `await import()` / `importWithWorkspaceFallback` patterns with static imports and eliminates loose types (`as any`, `as never`). Closes #325, closes #324.

## What changed

| Before | After |
|--------|-------|
| `importWithWorkspaceFallback()` + `createRequire` | Static `import` statements |
| `AztecDeps` bag + `Record<string, unknown>` SDK symbols | Real types from `@aztec/aztec.js`, `@aztec/stdlib`, `viem` |
| `as never` / `as any` casts in source + tests | Typed mock factories + `as unknown as <Type>` |

**Scripts** - Removed dynamic imports, `AztecDeps` type layer, and `*Like` wrapper types from `devnet-postdeploy-smoke.ts`, `verify-fpc-devnet-deployment.ts`, and `bootstrap-topup-autoclaim-account.ts`. Fixed latent API mismatches previously hidden by `unknown` typing.

**SDK & services** - Replaced `as any` in `payment-method.ts` with typed cast, removed unnecessary `as never` in `fund-claimer-l2.ts`, exported `FeeJuicePortalManagerLike` from `bridge.ts` for test use.

**Profiling** = Converted 2 dynamic imports to static, typed `_coldStartAction` on context interface.

**Tests** - Introduced typed mock factories (`stubNode()`, `stubL1Client()`, `makeDeps()`) across 5 test files; eliminated all 35 `as never` casts.