### PR TITLE
fix: stabilize CI cold-start and ARM64 integration tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,16 @@ services:
       DEPLOY_AZTEC_CONTRACTS_SALT: 1
       L1_CHAIN_ID: 31337
       ETHEREUM_HOSTS: "http://anvil:8545"
+      # Effectively disable epoch pruning for local/CI test runs.
+      # The default AZTEC_PROOF_SUBMISSION_EPOCHS is 1, which combined
+      # with a small AZTEC_EPOCH_DURATION gives only a few slots before
+      # unproven blocks are pruned — too tight for slow CI (ARM64).
+      # No real proving happens here, so a larger value is safe.
+      # Aztec's own e2e tests use a similar approach.
+      AZTEC_PROOF_SUBMISSION_EPOCHS: 100
+      # Concurrent tests with many simultaneous deployments can exceed the
+      # default RPC_MAX_BODY_SIZE of 1mb.
+      RPC_MAX_BODY_SIZE: "5mb"
     depends_on:
       anvil:
         condition: service_healthy

--- a/scripts/common/setup-helpers.ts
+++ b/scripts/common/setup-helpers.ts
@@ -92,6 +92,38 @@ export async function connectAndCreateWallet(nodeUrl: string, proverEnabled: boo
   });
   return { node, wallet };
 }
+
+/**
+ * Wait until a new L2 block is produced after the current tip.
+ *
+ * `waitForL1ToL2MessageReady` only checks the *node/archiver* - the PXE's
+ * anchor block may still lag by one block.  Waiting for one additional block
+ * gives the PXE's `BlockSynchronizer` time to process the `blocks-added`
+ * event that includes the message tree update, avoiding "Message not in
+ * state" simulation failures.
+ *
+ * Call this after `waitForL1ToL2MessageReady` and before submitting a tx
+ * that consumes the message.
+ */
+export async function waitForNextBlock(node: AztecNode, timeoutSeconds = 30): Promise<void> {
+  const currentBlock = await node.getBlock("latest");
+  if (!currentBlock) return;
+  const currentBlockNumber = currentBlock.header.getBlockNumber();
+
+  const POLL_MS = 500;
+  const deadline = Date.now() + timeoutSeconds * 1_000;
+  while (Date.now() < deadline) {
+    const latest = await node.getBlock("latest");
+    if (latest && latest.header.getBlockNumber() > currentBlockNumber) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+  pinoLogger.warn(
+    `No new block produced after block ${currentBlockNumber} within ${timeoutSeconds}s — proceeding anyway`,
+  );
+}
+
 export type CoreContracts = {
   token: Contract;
   fpc: Contract;

--- a/scripts/tests/cold-start.ts
+++ b/scripts/tests/cold-start.ts
@@ -30,6 +30,7 @@ import {
   type L1Infra,
   mintL1Erc20WithRetry,
   setupL1Infrastructure,
+  waitForNextBlock,
 } from "../common/setup-helpers.ts";
 
 const HEX_32_BYTE_PATTERN = /^0x[0-9a-fA-F]{64}$/;
@@ -223,6 +224,11 @@ describe("cold-start smoke", () => {
       timeoutSeconds: config.messageTimeoutSeconds,
     });
 
+    // waitForL1ToL2MessageReady only checks the node/archiver — the PXE's
+    // anchor block may not yet include the message tree update.  Wait for
+    // one more block so the BlockSynchronizer processes the blocks-added event.
+    await waitForNextBlock(node);
+
     // Execute cold-start via SDK
     const coldStartResult = await fpcClient.executeColdStart({
       wallet,
@@ -409,6 +415,7 @@ describe("cold-start smoke", () => {
     await waitForL1ToL2MessageReady(node, tinyMsgHash, {
       timeoutSeconds: config.messageTimeoutSeconds,
     });
+    await waitForNextBlock(node);
 
     // Attempt cold-start — should fail at quote stage
     await expect(


### PR DESCRIPTION
## Summary
- Add `waitForNextBlock` helper that polls until a new L2 block is produced after the current tip
- Call it in cold-start tests after `waitForL1ToL2MessageReady` before consuming bridged messages
- Set `AZTEC_PROOF_SUBMISSION_EPOCHS: 100` on the local aztec-node to prevent premature epoch pruning during slow CI runs
-  Increase `RPC_MAX_BODY_SIZE` to 5mb on the local aztec-node to prevent  "request entity too large" errors during concurrent deployment tests  (default is 1mb, exceeded by 20 simultaneous account deployments)

## Root cause

### amd64: cold-start "Message not in state" flake
`waitForL1ToL2MessageReady` checks the node/archiver, but private tx simulation uses the PXE's anchor block header which is updated asynchronously via `BlockSynchronizer`. Waiting for one more block gives the PXE time to process the `blocks-added` event containing the message tree update.

Normal fee_entrypoint tests are unaffected because they use L2 faucet drip — no L1→L2 message consumption involved.

### ARM64: chain prune to block 8
The default `AZTEC_PROOF_SUBMISSION_EPOCHS` is 1, which combined with a small `AZTEC_EPOCH_DURATION` gives only a few slots before unproven blocks become prunable. On slow ARM64 hardware, the archiver's epoch boundary calculation triggers premature pruning, wiping out all test state. No real proving happens in local/CI test runs, so a larger value is safe. Aztec's own e2e tests use a similar approach.

