### PR TITLE
fix: docker ci failures

### DIFF
--- a/scripts/contract/Dockerfile.contract
+++ b/scripts/contract/Dockerfile.contract
@@ -19,4 +19,12 @@ COPY contracts/ contracts/
 COPY mock/counter/ mock/counter/
 COPY vendor/ vendor/
 
-RUN aztec compile --workspace --force
+# bb segfaults under QEMU arm64 emulation during VK generation.
+# Skip compilation on arm64 — artifacts are platform-independent JSON
+# and are cross-copied from the amd64 variant by Dockerfile.deploy.
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      aztec compile --workspace --force; \
+    else \
+      mkdir -p /app/target; \
+    fi

--- a/scripts/contract/Dockerfile.deploy
+++ b/scripts/contract/Dockerfile.deploy
@@ -1,3 +1,8 @@
+# Always use the amd64 contract image for artifacts — the arm64 variant
+# skips compilation (bb segfaults under QEMU) and has an empty target dir.
+# Artifacts are platform-independent JSON, so cross-copy is safe.
+FROM --platform=linux/amd64 contract AS contract-amd64
+
 FROM common
 
 # Start as root so the entrypoint can fix bind-mount ownership, then drop to app
@@ -6,8 +11,8 @@ USER root
 # yq for config generation
 COPY --from=mikefarah/yq:4.45.4 /usr/bin/yq /usr/local/bin/yq
 
-# Contract artifacts from compile stage
-COPY --from=contract /app/target/ target/
+# Contract artifacts from compile stage (always amd64)
+COPY --from=contract-amd64 /app/target/ target/
 
 # Shell entrypoint + config generation script
 COPY scripts/contract/deploy-fpc.sh scripts/contract/

--- a/scripts/tests/cold-start.ts
+++ b/scripts/tests/cold-start.ts
@@ -17,6 +17,7 @@ import { waitForL1ToL2MessageReady } from "@aztec/aztec.js/messaging";
 import type { AztecNode } from "@aztec/aztec.js/node";
 import type { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { FpcClient } from "@nethermindeth/aztec-fpc-sdk";
+import pino from "pino";
 import type { Hex } from "viem";
 import { beforeAll, describe, expect, it } from "#test";
 import { PrivateBalanceTracker } from "../common/balance-tracker.ts";
@@ -33,6 +34,7 @@ import {
   waitForNextBlock,
 } from "../common/setup-helpers.ts";
 
+const logger = pino();
 const HEX_32_BYTE_PATTERN = /^0x[0-9a-fA-F]{64}$/;
 const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
 const DECIMAL_UINT_PATTERN = /^(0|[1-9][0-9]*)$/;
@@ -229,14 +231,35 @@ describe("cold-start smoke", () => {
     // one more block so the BlockSynchronizer processes the blocks-added event.
     await waitForNextBlock(node);
 
-    // Execute cold-start via SDK
-    const coldStartResult = await fpcClient.executeColdStart({
-      wallet,
-      userAddress: user,
-      tokenAddress,
-      bridgeAddress,
-      bridgeClaim,
-    });
+    // Execute cold-start via SDK.  Retry on "Message not in state" —
+    // the PXE syncs inside proveTx via L2BlockStream, but that stream's
+    // work() swallows errors silently.  On slow runners (arm64) the sync
+    // can fail, leaving the anchor block stale.  Each retry triggers a
+    // fresh sync attempt.
+    const MAX_COLD_START_ATTEMPTS = 3;
+    let coldStartResult!: Awaited<ReturnType<typeof fpcClient.executeColdStart>>;
+    for (let attempt = 1; attempt <= MAX_COLD_START_ATTEMPTS; attempt++) {
+      try {
+        coldStartResult = await fpcClient.executeColdStart({
+          wallet,
+          userAddress: user,
+          tokenAddress,
+          bridgeAddress,
+          bridgeClaim,
+        });
+        break;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("Message not in state") && attempt < MAX_COLD_START_ATTEMPTS) {
+          logger.warn(
+            `Cold-start attempt ${attempt}/${MAX_COLD_START_ATTEMPTS} failed with "Message not in state", retrying after next block`,
+          );
+          await waitForNextBlock(node);
+          continue;
+        }
+        throw err;
+      }
+    }
 
     // Verify balances after cold-start
     await userBalance.change(config.claimAmount - coldStartResult.aaPaymentAmount);

--- a/services/ARM64_RUNTIME.md
+++ b/services/ARM64_RUNTIME.md
@@ -69,6 +69,26 @@ else
 fi
 ```
 
+## Contract compilation (amd64-only)
+
+The Barretenberg `bb` backend segfaults under QEMU arm64 emulation during
+verification key generation (`cycle_group: Point is not on curve` / signal 11).
+Contract artifacts are platform-independent JSON (ACIR bytecode + verification
+keys), so they only need to be compiled once on amd64.
+
+The `contract` bake target (`Dockerfile.contract`) builds for both platforms
+but skips `aztec compile` on arm64 via a `TARGETARCH` guard:
+
+- **amd64**: full compilation — Aztec CLI + compiled artifacts in `/app/target/`
+- **arm64**: Aztec CLI only — `/app/target/` is an empty directory
+
+The `block-producer` compose service uses this image for `aztec-wallet` on
+arm64 (CLI works fine on native arm64, the crash is only under QEMU emulation).
+
+`Dockerfile.deploy` uses `FROM --platform=linux/amd64 contract` to always
+cross-copy the compiled artifacts from the amd64 variant, since artifacts are
+platform-independent JSON.
+
 ## Removing this workaround
 
 If Bun fixes the ARM64 NAPI crash, revert to a single `oven/bun` runtime image:


### PR DESCRIPTION
- Skip aztec compile on arm64 in Dockerfile.contract via TARGETARCH guard - bb segfaults under QEMU emulation during VK generation. The arm64 image retains the Aztec CLI (used by block-producer), while Dockerfile.deploy cross-copies artifacts from the amd64 variant.
- Retry executeColdStart up to 3 times on "Message not in state" - the PXE's L2BlockStream silently swallows sync errors, leaving the anchor block stale on slow runners (arm64). Each retry triggers a fresh sync inside proveTx.